### PR TITLE
refactor: split trainer into two files and clean up gateway

### DIFF
--- a/server/kubernetes/distributed-lustre/05-trainer-worker.yaml
+++ b/server/kubernetes/distributed-lustre/05-trainer-worker.yaml
@@ -21,7 +21,7 @@ spec:
       - name: trainer-worker
         image: gcr.io/cdrollouts-sunilarora/open-rl-server:latest
         imagePullPolicy: Always
-        command: ["uv", "run", "python", "-m", "src.trainer"]
+        command: ["uv", "run", "python", "-m", "src.clock_cycle"]
         env:
         - name: ENABLE_GCP_TRACE
           value: "1"

--- a/server/kubernetes/distributed-shared/05-trainer-worker.yaml
+++ b/server/kubernetes/distributed-shared/05-trainer-worker.yaml
@@ -21,7 +21,7 @@ spec:
       - name: trainer-worker
         image: gcr.io/cdrollouts-sunilarora/open-rl-server:latest
         imagePullPolicy: Always
-        command: ["uv", "run", "python", "-m", "src.trainer"]
+        command: ["uv", "run", "python", "-m", "src.clock_cycle"]
         env:
         - name: ENABLE_GCP_TRACE
           value: "1"

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -47,6 +47,10 @@ conflicts = [
         { extra = "cpu" },
         { extra = "vllm" },
     ],
+    [
+        { extra = "gpu" },
+        { extra = "vllm" },
+    ],
 ]
 
 [[tool.uv.index]]

--- a/server/src/clock_cycle.py
+++ b/server/src/clock_cycle.py
@@ -1,9 +1,186 @@
 import asyncio
+import os
+import threading
+import traceback
 
-from .trainer import clock_cycle_loop, engine
+import uvicorn
+from fastapi import FastAPI, HTTPException
+from opentelemetry import context as otel_context
+from opentelemetry import propagate, trace
+
+from .store import get_store
+from .trainer import Datum, LoraConfig, TrainerEngine
+
+tracer = trace.get_tracer(__name__)
+
+engine = TrainerEngine()
+
+
+def _parse_datum(raw: dict) -> Datum:
+  """Convert wire-format datum (with chunks) to our flat Datum type."""
+  chunks = raw.get("model_input", {}).get("chunks", [])
+  tokens: list[int] = []
+  for chunk in chunks:
+    tokens.extend(chunk.get("tokens", []))
+
+  loss_inputs = raw.get("loss_fn_inputs", {})
+  return Datum(model_input=tokens, loss_fn_inputs=loss_inputs)
+
+
+async def clock_cycle_loop() -> None:
+  store = get_store()
+
+  print("[WORKER] Training worker started.")
+
+  while True:
+    try:
+      batch = await store.get_requests()
+      if not batch:
+        await asyncio.sleep(0.1)
+        continue
+
+      m_id = batch[0].get("model_id", "default")
+
+      with tracer.start_as_current_span("clock_cycle_batch") as batch_span:
+        batch_span.set_attribute("batch_size", len(batch))
+        batch_span.set_attribute("model_id", m_id)
+
+        print(f"\n[CLOCK CYCLE] Popped {len(batch)} requests for tenant: {m_id}")
+
+        SKIP_ADAPTER_SWITCH = {"create_model", "create_model_from_state"}
+        if not any(r.get("type") in SKIP_ADAPTER_SWITCH for r in batch):
+          try:
+            await asyncio.to_thread(engine.set_active_adapter, m_id)
+          except Exception as e:
+            print(f"Failed to set adapter {m_id}: {e}")
+            for r in batch:
+              await store.set_future(r["req_id"], {"type": "RequestFailedResponse", "error_message": str(e)})
+            continue
+
+        for r in batch:
+          req_id = r["req_id"]
+          req_type = r["type"]
+
+          carrier = r.get("trace_context", {})
+          ctx = propagate.extract(carrier) if carrier else None
+          token = otel_context.attach(ctx) if ctx else None
+
+          try:
+            match req_type:
+              case "create_model":
+                base_model = r["base_model"]
+                raw_config = r.get("lora_config") or {}
+                lora_config = LoraConfig(**{k: v for k, v in raw_config.items() if k in LoraConfig.model_fields})
+
+                await asyncio.to_thread(engine.load_base_model, base_model)
+                await asyncio.to_thread(engine.create_adapter, m_id, lora_config)
+
+                await store.set_future(req_id, {
+                  "model_id": m_id,
+                  "is_lora": True,
+                  "lora_rank": lora_config.rank,
+                  "type": "create_model",
+                })
+
+              case "forward_backward":
+                raw_data = r["data"]
+                loss_fn = r["loss_fn"]
+                loss_config = r.get("loss_config")
+
+                typed_data = [_parse_datum(item) for item in raw_data]
+
+                result = await asyncio.to_thread(engine.forward_backward, typed_data, loss_fn, loss_config, m_id)
+                result["type"] = "forward_backward"
+                await store.set_future(req_id, result)
+
+              case "optim_step":
+                adam_params = r["adam_params"]
+                result = await asyncio.to_thread(engine.optim_step, adam_params, m_id)
+                result["type"] = "optim_step"
+                await store.set_future(req_id, result)
+
+              case "sample":
+                prompt_tokens = r["prompt_tokens"]
+                max_tokens = r["max_tokens"]
+                num_samples = r["num_samples"]
+                temperature = r.get("temperature", 0.0)
+
+                result = await asyncio.to_thread(
+                  engine.generate, prompt_tokens, max_tokens, num_samples, temperature, m_id,
+                )
+                result["type"] = "sample"
+                await store.set_future(req_id, result)
+
+              case "save_state":
+                state_path = r["state_path"]
+                include_optimizer = bool(r.get("include_optimizer", False))
+                kind = r.get("kind", "state")
+
+                result = await asyncio.to_thread(engine.save_state, m_id, state_path, include_optimizer, kind)
+                result["type"] = "save_state"
+                await store.set_future(req_id, result)
+
+              case "save_weights_for_sampler" | "save_weights":
+                await asyncio.to_thread(engine.save_adapter, m_id)
+                await store.set_future(req_id, {"status": "ok", "type": req_type})
+
+              case _:
+                print(f"Warning: Unhandled request type: {req_type}")
+                await store.set_future(req_id, {"type": "RequestFailedResponse", "error_message": f"Unknown request type: {req_type}"})
+
+          except Exception as e:
+            traceback.print_exc()
+            await store.set_future(req_id, {"type": "RequestFailedResponse", "error_message": str(e)})
+          finally:
+            if token:
+              otel_context.detach(token)
+
+    except asyncio.CancelledError:
+      break
+    except Exception as e:
+      print(f"Error in clock cycle loop: {e}")
+      traceback.print_exc()
+
+      import redis
+
+      if isinstance(e, redis.exceptions.ConnectionError):
+        print("[worker] Destroying StateStore singleton to force Redis reconnection...")
+        from . import store as store_mod
+
+        store_mod._store_instance = None
+        store = store_mod.get_store()
+
+      await asyncio.sleep(1)
 
 
 def main() -> None:
+  print("\n" + "=" * 50)
+  print("      Open-RL PyTorch Training Worker")
+  print("=" * 50)
+  cuda_devs = os.getenv("CUDA_VISIBLE_DEVICES", "ALL")
+  print(f"-> Hardware : CUDA_VISIBLE_DEVICES={cuda_devs}\n")
+
+  preload_target = os.getenv("OPEN_RL_BASE_MODEL") or os.getenv("VLLM_MODEL")
+  is_ready = False
+  if preload_target:
+    engine.load_base_model(preload_target)
+    is_ready = True
+  else:
+    print("[WARNING] OPEN_RL_BASE_MODEL / VLLM_MODEL not provided. Cold-start penalty will apply on first request.")
+    is_ready = True
+
+  probe_app = FastAPI()
+
+  @probe_app.get("/healthz")
+  def healthz():
+    if is_ready:
+      return {"status": "ready"}
+    raise HTTPException(status_code=503, detail="Model Loading")
+
+  def run_probe_server():
+    uvicorn.run(probe_app, host="0.0.0.0", port=8000, log_level="warning")
+
+  threading.Thread(target=run_probe_server, daemon=True).start()
   asyncio.run(clock_cycle_loop())
 
 

--- a/server/src/clock_cycle.py
+++ b/server/src/clock_cycle.py
@@ -1,0 +1,11 @@
+import asyncio
+
+from .trainer import clock_cycle_loop, engine
+
+
+def main() -> None:
+  asyncio.run(clock_cycle_loop())
+
+
+if __name__ == "__main__":
+  main()

--- a/server/src/clock_cycle.py
+++ b/server/src/clock_cycle.py
@@ -75,12 +75,15 @@ async def clock_cycle_loop() -> None:
                 await asyncio.to_thread(engine.load_base_model, base_model)
                 await asyncio.to_thread(engine.create_adapter, m_id, lora_config)
 
-                await store.set_future(req_id, {
-                  "model_id": m_id,
-                  "is_lora": True,
-                  "lora_rank": lora_config.rank,
-                  "type": "create_model",
-                })
+                await store.set_future(
+                  req_id,
+                  {
+                    "model_id": m_id,
+                    "is_lora": True,
+                    "lora_rank": lora_config.rank,
+                    "type": "create_model",
+                  },
+                )
 
               case "forward_backward":
                 raw_data = r["data"]
@@ -106,7 +109,12 @@ async def clock_cycle_loop() -> None:
                 temperature = r.get("temperature", 0.0)
 
                 result = await asyncio.to_thread(
-                  engine.generate, prompt_tokens, max_tokens, num_samples, temperature, m_id,
+                  engine.generate,
+                  prompt_tokens,
+                  max_tokens,
+                  num_samples,
+                  temperature,
+                  m_id,
                 )
                 result["type"] = "sample"
                 await store.set_future(req_id, result)

--- a/server/src/gateway.py
+++ b/server/src/gateway.py
@@ -72,10 +72,10 @@ def get_sampler_backend() -> str:
 
 def get_default_model_name() -> str | None:
   if is_single_process_mode():
-    from . import trainer as trainer_engine
+    from . import clock_cycle
 
-    if trainer_engine.engine.base_model_name:
-      return trainer_engine.engine.base_model_name
+    if clock_cycle.engine.base_model_name:
+      return clock_cycle.engine.base_model_name
   return os.getenv("OPEN_RL_BASE_MODEL") or os.getenv("VLLM_MODEL")
 
 
@@ -83,17 +83,17 @@ def get_default_model_name() -> str | None:
 async def lifespan(app: FastAPI):
   task = None
   if is_single_process_mode():
-    from . import trainer as trainer_engine
+    from . import clock_cycle
 
     base_model = os.getenv("OPEN_RL_BASE_MODEL")
     print("\n" + "=" * 50)
     print(" Open-RL Single-Process Mode")
     print("=" * 50)
     print(f"-> Base model: {base_model or 'unset'}")
-    print("-> Backend   : gateway + engine loop in one process\n")
+    print("-> Backend   : gateway + worker loop in one process\n")
     if base_model:
-      await asyncio.to_thread(trainer_engine.engine.preload_base_model, base_model)
-    task = asyncio.create_task(trainer_engine.clock_cycle_loop())
+      await asyncio.to_thread(clock_cycle.engine.preload_base_model, base_model)
+    task = asyncio.create_task(clock_cycle.clock_cycle_loop())
   try:
     yield
   finally:

--- a/server/src/gateway.py
+++ b/server/src/gateway.py
@@ -144,13 +144,15 @@ async def create_model(req: dict):
   if not base_model:
     return JSONResponse(status_code=400, content={"error": "base_model is required"})
   model_id = str(uuid.uuid4())
-  req_id = await _enqueue({
-    "req_id": model_id,
-    "model_id": model_id,
-    "type": "create_model",
-    "base_model": base_model,
-    "lora_config": req.get("lora_config") or {},
-  })
+  req_id = await _enqueue(
+    {
+      "req_id": model_id,
+      "model_id": model_id,
+      "type": "create_model",
+      "base_model": base_model,
+      "lora_config": req.get("lora_config") or {},
+    }
+  )
   return {"request_id": req_id}
 
 
@@ -190,24 +192,28 @@ async def retrieve_future(req: dict):
 async def forward_backward(req: dict):
   """TrainingClient.forward_backward_async()"""
   fwd_input = req.get("forward_backward_input", {})
-  req_id = await _enqueue({
-    "model_id": req.get("model_id"),
-    "type": "forward_backward",
-    "data": fwd_input.get("data", []),
-    "loss_fn": fwd_input.get("loss_fn", "cross_entropy"),
-    "loss_config": fwd_input.get("loss_fn_config", {}),
-  })
+  req_id = await _enqueue(
+    {
+      "model_id": req.get("model_id"),
+      "type": "forward_backward",
+      "data": fwd_input.get("data", []),
+      "loss_fn": fwd_input.get("loss_fn", "cross_entropy"),
+      "loss_config": fwd_input.get("loss_fn_config", {}),
+    }
+  )
   return {"request_id": req_id}
 
 
 @app.post("/api/v1/optim_step")
 async def optim_step(req: dict):
   """TrainingClient.optim_step_async()"""
-  req_id = await _enqueue({
-    "model_id": req.get("model_id"),
-    "type": "optim_step",
-    "adam_params": req.get("adam_params", {}),
-  })
+  req_id = await _enqueue(
+    {
+      "model_id": req.get("model_id"),
+      "type": "optim_step",
+      "adam_params": req.get("adam_params", {}),
+    }
+  )
   return {"request_id": req_id}
 
 
@@ -233,11 +239,14 @@ async def save_weights_for_sampler(req: dict):
     print(f"Failed to update alias metadata: {e}")
 
   session_id = f"{model_id}-samp-{seq_id}"
-  await store.set_future(req_id, {
-    "path": f"tinker://{session_id}" if alias else None,
-    "sampling_session_id": session_id,
-    "type": "save_weights_for_sampler",
-  })
+  await store.set_future(
+    req_id,
+    {
+      "path": f"tinker://{session_id}" if alias else None,
+      "sampling_session_id": session_id,
+      "type": "save_weights_for_sampler",
+    },
+  )
   return {"request_id": req_id}
 
 
@@ -263,11 +272,14 @@ async def save_weights(req: dict):
     print(f"Failed to update alias metadata: {e}")
 
   session_id = f"{model_id}-samp-{seq_id}"
-  await store.set_future(req_id, {
-    "path": f"tinker://{session_id}",
-    "sampling_session_id": session_id,
-    "type": "save_weights",
-  })
+  await store.set_future(
+    req_id,
+    {
+      "path": f"tinker://{session_id}",
+      "sampling_session_id": session_id,
+      "type": "save_weights",
+    },
+  )
   return {"request_id": req_id}
 
 
@@ -279,7 +291,7 @@ async def create_sampling_session(req: dict):
   model_id = req.get("model_id")
 
   if model_path and model_path.startswith("tinker://"):
-    sess_id = model_path[len("tinker://"):]
+    sess_id = model_path[len("tinker://") :]
   else:
     sess_id = model_id or "samp-session-live-123"
 
@@ -297,18 +309,20 @@ async def asample(req: dict):
 
   model_id = req.get("model_id") or req.get("sampling_session_id")
   if model_id and model_id.startswith("tinker://"):
-    model_id = model_id[len("tinker://"):]
+    model_id = model_id[len("tinker://") :]
   base_model_id = model_id.split("-samp-")[0] if model_id else None
 
   if get_sampler_backend() == "torch":
-    req_id = await _enqueue({
-      "model_id": base_model_id or model_id,
-      "type": "sample",
-      "prompt_tokens": prompt,
-      "max_tokens": max_tokens,
-      "temperature": temperature,
-      "num_samples": num_samples,
-    })
+    req_id = await _enqueue(
+      {
+        "model_id": base_model_id or model_id,
+        "type": "sample",
+        "prompt_tokens": prompt,
+        "max_tokens": max_tokens,
+        "temperature": temperature,
+        "num_samples": num_samples,
+      }
+    )
     return {"request_id": req_id}
 
   # vLLM backend

--- a/server/src/gateway.py
+++ b/server/src/gateway.py
@@ -1,31 +1,28 @@
 import asyncio
-import os
-import uuid
-from contextlib import asynccontextmanager
-
-from fastapi import FastAPI
-from fastapi.responses import JSONResponse
-
-# Removed direct PyTorch engine import to keep Gateway stateless
-from .store import get_store
-
-store = get_store()
-import json
 import logging
+import os
 import time
 import traceback
+import uuid
+from contextlib import asynccontextmanager
 from datetime import datetime
 
-from opentelemetry import trace
+import httpx
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from opentelemetry import propagate, trace
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
-# Initialize OpenTelemetry TracerProvider
+from .store import get_store
+
+store = get_store()
+
 provider = TracerProvider()
 trace.set_tracer_provider(provider)
 
-if os.environ.get("ENABLE_GCP_TRACE", "0") == "1":
+if os.getenv("ENABLE_GCP_TRACE", "0") == "1":
   try:
     from opentelemetry.exporter.cloud_trace import CloudTraceSpanExporter
 
@@ -38,22 +35,19 @@ else:
   print("OpenTelemetry: No exporter configured (ENABLE_GCP_TRACE=0)")
 
 
-async def enqueue_traced_request(store, payload: dict) -> None:
-  carrier = {}
-  from opentelemetry import propagate
-
-  propagate.inject(carrier)
-  payload["trace_context"] = carrier
-  await store.put_request(payload)
-
-
-class FilterNoisyEndpoints(logging.Filter):
+class _FilterNoisyEndpoints(logging.Filter):
   def filter(self, record: logging.LogRecord) -> bool:
     msg = record.getMessage()
     return "retrieve_future" not in msg and "session_heartbeat" not in msg
 
 
-logging.getLogger("uvicorn.access").addFilter(FilterNoisyEndpoints())
+logging.getLogger("uvicorn.access").addFilter(_FilterNoisyEndpoints())
+
+TMP_DIR = os.getenv("OPEN_RL_TMP_DIR", "/tmp/open-rl")
+VLLM_URL = os.getenv("VLLM_URL", "http://127.0.0.1:8001")
+
+
+# *** Helpers ***
 
 
 def is_single_process_mode() -> bool:
@@ -77,6 +71,18 @@ def get_default_model_name() -> str | None:
     if clock_cycle.engine.base_model_name:
       return clock_cycle.engine.base_model_name
   return os.getenv("OPEN_RL_BASE_MODEL") or os.getenv("VLLM_MODEL")
+
+
+async def _enqueue(payload: dict) -> str:
+  """Create a pending future, inject trace context, push to store. Returns req_id."""
+  req_id = payload.get("req_id") or str(uuid.uuid4())
+  payload["req_id"] = req_id
+  carrier: dict = {}
+  propagate.inject(carrier)
+  payload["trace_context"] = carrier
+  await store.set_future(req_id, {"status": "pending"})
+  await store.put_request(payload)
+  return req_id
 
 
 @asynccontextmanager
@@ -105,6 +111,7 @@ app = FastAPI(title="Open-RL Server MVP", lifespan=lifespan)
 FastAPIInstrumentor.instrument_app(app, excluded_urls="/api/v1/retrieve_future,/api/v1/session_heartbeat")
 
 
+# *** ServiceClient endpoints ***
 @app.get("/api/v1/healthz")
 async def health_check():
   return {"status": "ok"}
@@ -132,42 +139,30 @@ async def session_heartbeat(req: dict):
 
 @app.post("/api/v1/create_model")
 async def create_model(req: dict):
-  req_id = str(uuid.uuid4())
-  await store.set_future(req_id, {"status": "pending"})
-
+  """ServiceClient.create_lora_training_client_async()"""
   base_model = req.get("base_model")
   if not base_model:
     return JSONResponse(status_code=400, content={"error": "base_model is required"})
-
-  lora_config = req.get("lora_config") or {}
-
-  model_id = req_id
-
-  # Push the creation task globally to the Redis Queue for the decoupled Trainer Engine
-  # Note: We must route this specifically so the Engine instance can pick it up.
-  # Since it's a global operation (not tenant specific yet), we use "default" or model_id
-  await store.put_request(
-    {
-      "req_id": req_id,
-      "model_id": model_id,  # Tenant specific queue
-      "type": "create_model",
-      "base_model": base_model,
-      "lora_config": lora_config,
-    }
-  )
-
+  model_id = str(uuid.uuid4())
+  req_id = await _enqueue({
+    "req_id": model_id,
+    "model_id": model_id,
+    "type": "create_model",
+    "base_model": base_model,
+    "lora_config": req.get("lora_config") or {},
+  })
   return {"request_id": req_id}
 
 
 @app.post("/api/v1/get_info")
 async def get_info(req: dict):
+  """ServiceClient — model metadata for the training client."""
   model_name = get_default_model_name()
   if not model_name:
-    return JSONResponse(status_code=404, content={"error": "No base model is configured for the current server session"})
-
+    return JSONResponse(status_code=404, content={"error": "No base model is configured"})
   return {
     "model_data": {"arch": "unknown", "model_name": model_name, "tokenizer_id": model_name},
-    "model_id": req.get("model_id", "model-live-123"),  # Will be whatever client passed
+    "model_id": req.get("model_id", "model-live-123"),
     "is_lora": True,
     "lora_rank": 16,
     "model_name": model_name,
@@ -175,188 +170,116 @@ async def get_info(req: dict):
   }
 
 
-# Global set to hold strong references to background tasks to prevent GC
-background_tasks = set()
+@app.post("/api/v1/retrieve_future")
+async def retrieve_future(req: dict):
+  """ServiceClient — poll for async request results."""
+  request_id = req.get("request_id")
+  if not request_id:
+    return JSONResponse(status_code=400, content={"error": "request_id is required"})
+
+  result = await store.get_future(request_id, timeout=60.0)
+  if result is None:
+    return JSONResponse(status_code=400, content={"type": "RequestFailedResponse", "error_message": "Future not found"})
+  if isinstance(result, dict) and result.get("type") == "RequestFailedResponse":
+    return JSONResponse(status_code=400, content=result)
+  return result
 
 
+# *** TrainingClient endpoints ***
 @app.post("/api/v1/forward_backward")
 async def forward_backward(req: dict):
-  req_id = str(uuid.uuid4())
-  await store.set_future(req_id, {"status": "pending"})
-
+  """TrainingClient.forward_backward_async()"""
   fwd_input = req.get("forward_backward_input", {})
-  data = fwd_input.get("data", [])
-  loss_fn = fwd_input.get("loss_fn", "cross_entropy")
-  loss_config = fwd_input.get("loss_fn_config", {})
-  model_id = req.get("model_id")
-
-  await enqueue_traced_request(
-    store,
-    {
-      "req_id": req_id,
-      "model_id": model_id,
-      "type": "forward_backward",
-      "data": data,
-      "loss_fn": loss_fn,
-      "loss_config": loss_config,
-    },
-  )
-
+  req_id = await _enqueue({
+    "model_id": req.get("model_id"),
+    "type": "forward_backward",
+    "data": fwd_input.get("data", []),
+    "loss_fn": fwd_input.get("loss_fn", "cross_entropy"),
+    "loss_config": fwd_input.get("loss_fn_config", {}),
+  })
   return {"request_id": req_id}
 
 
 @app.post("/api/v1/optim_step")
 async def optim_step(req: dict):
-  req_id = str(uuid.uuid4())
-  await store.set_future(req_id, {"status": "pending"})
-
-  adam_params = req.get("adam_params", {})
-  model_id = req.get("model_id")
-
-  await enqueue_traced_request(
-    store,
-    {
-      "req_id": req_id,
-      "model_id": model_id,
-      "type": "optim_step",
-      "adam_params": adam_params,
-    },
-  )
-
+  """TrainingClient.optim_step_async()"""
+  req_id = await _enqueue({
+    "model_id": req.get("model_id"),
+    "type": "optim_step",
+    "adam_params": req.get("adam_params", {}),
+  })
   return {"request_id": req_id}
 
 
 @app.post("/api/v1/save_weights_for_sampler")
 async def save_weights_for_sampler(req: dict):
+  """TrainingClient.save_weights_for_sampler() — instant resolve, trainer auto-saves after optim_step."""
   req_id = str(uuid.uuid4())
-  await store.set_future(req_id, {"status": "pending"})
-  model_id = req.get("model_id")  # Client passes the TrainingClient's model_id
+  model_id = req.get("model_id")
   if not model_id:
     return JSONResponse(status_code=400, content={"error": "model_id is required"})
-  seq_id = req.get("sampling_session_seq_id", 0)
-  if not seq_id:
-    seq_id = int(time.time() * 1000)
-  # Tinker SDK might send 'name' or 'alias', or 'path' (if using save_weights_for_sampler)
+
+  seq_id = req.get("sampling_session_seq_id") or int(time.time() * 1000)
   alias = req.get("name") or req.get("alias") or req.get("path")
 
-  # 1. Update the metadata.json instantly
-  tmp_dir = os.environ.get("OPEN_RL_TMP_DIR", "/tmp/open-rl")
-  ram_path = os.path.join(tmp_dir, "peft", model_id)
+  ram_path = os.path.join(TMP_DIR, "peft", model_id)
   os.makedirs(ram_path, exist_ok=True)
-
-  metadata = {"model_id": model_id, "alias": alias, "created_at": datetime.now().isoformat(), "timestamp": time.time()}
   try:
+    import json
+
     with open(os.path.join(ram_path, "metadata.json"), "w") as f:
-      json.dump(metadata, f)
+      json.dump({"model_id": model_id, "alias": alias, "created_at": datetime.now().isoformat(), "timestamp": time.time()}, f)
   except Exception as e:
     print(f"Failed to update alias metadata: {e}")
 
   session_id = f"{model_id}-samp-{seq_id}"
-  result_path = f"tinker://{session_id}" if alias else None
-
-  result = {"path": result_path, "sampling_session_id": session_id, "type": "save_weights_for_sampler"}
-
-  # Instantly resolve the future, bypassing the Redis queue!
-  await store.set_future(req_id, result)
+  await store.set_future(req_id, {
+    "path": f"tinker://{session_id}" if alias else None,
+    "sampling_session_id": session_id,
+    "type": "save_weights_for_sampler",
+  })
   return {"request_id": req_id}
 
 
 @app.post("/api/v1/save_weights")
 async def save_weights(req: dict):
+  """TrainingClient.save_weights()"""
   req_id = str(uuid.uuid4())
-  await store.set_future(req_id, {"status": "pending"})
   model_id = req.get("model_id")
   if not model_id:
     return JSONResponse(status_code=400, content={"error": "model_id is required"})
-  seq_id = req.get("seq_id", 0)
-  if not seq_id:
-    seq_id = int(time.time() * 1000)
-  # in .save(path="..."), the path is the identifier
+
+  seq_id = req.get("seq_id") or int(time.time() * 1000)
   alias = req.get("path")
 
-  # 1. Update the metadata.json instantly
-  tmp_dir = os.environ.get("OPEN_RL_TMP_DIR", "/tmp/open-rl")
-  ram_path = os.path.join(tmp_dir, "peft", model_id)
+  ram_path = os.path.join(TMP_DIR, "peft", model_id)
   os.makedirs(ram_path, exist_ok=True)
-
-  metadata = {"model_id": model_id, "alias": alias, "created_at": datetime.now().isoformat(), "timestamp": time.time()}
   try:
+    import json
+
     with open(os.path.join(ram_path, "metadata.json"), "w") as f:
-      json.dump(metadata, f)
+      json.dump({"model_id": model_id, "alias": alias, "created_at": datetime.now().isoformat(), "timestamp": time.time()}, f)
   except Exception as e:
     print(f"Failed to update alias metadata: {e}")
 
   session_id = f"{model_id}-samp-{seq_id}"
-  result_path = f"tinker://{session_id}"
-
-  result = {"path": result_path, "sampling_session_id": session_id, "type": "save_weights"}
-
-  # Instantly resolve the future, bypassing the Redis queue!
-  await store.set_future(req_id, result)
+  await store.set_future(req_id, {
+    "path": f"tinker://{session_id}",
+    "sampling_session_id": session_id,
+    "type": "save_weights",
+  })
   return {"request_id": req_id}
 
 
-@app.get("/api/v1/list_adapters")
-async def list_adapters():
-  """
-  Scans the local temporary directory (used for RAM-disk sync) for available PEFT adapters.
-  Returns a list of adapters with metadata (creation time, alias) if available.
-  """
-  tmp_dir = os.environ.get("OPEN_RL_TMP_DIR", "/tmp/open-rl")
-  peft_dir = os.path.join(tmp_dir, "peft")
-
-  adapters = []
-
-  if os.path.exists(peft_dir):
-    # Scan all directories in peft_dir
-    with os.scandir(peft_dir) as entries:
-      for entry in entries:
-        if entry.is_dir():
-          model_id = entry.name
-          metadata_path = os.path.join(entry.path, "metadata.json")
-
-          adapter_info = {
-            "model_id": model_id,
-            "created_at": entry.stat().st_ctime,  # Fallback to filesystem time
-            "timestamp": entry.stat().st_ctime,
-            "alias": None,
-          }
-
-          # Try to read metadata.json
-          if os.path.exists(metadata_path):
-            try:
-              with open(metadata_path) as f:
-                meta = json.load(f)
-                adapter_info.update(meta)
-            except Exception:
-              pass
-
-          adapters.append(adapter_info)
-
-  # Sort by creation time descending (newest first)
-  # Prefer 'timestamp' (float) if available, otherwise 'created_at' if it's a number
-  def get_sort_key(x):
-    ts = x.get("timestamp")
-    if isinstance(ts, (int, float)):
-      return ts
-    ca = x.get("created_at")
-    if isinstance(ca, (int, float)):
-      return ca
-    return 0
-
-  adapters.sort(key=get_sort_key, reverse=True)
-
-  return {"adapters": adapters}
-
-
+# *** SamplingClient endpoints ***
 @app.post("/api/v1/create_sampling_session")
 async def create_sampling_session(req: dict):
-  # Support 'model_path' from SDK (e.g. "tinker://uuid-samp-seq")
+  """ServiceClient.create_sampling_client()"""
   model_path = req.get("model_path")
   model_id = req.get("model_id")
 
   if model_path and model_path.startswith("tinker://"):
-    sess_id = model_path[len("tinker://") :]
+    sess_id = model_path[len("tinker://"):]
   else:
     sess_id = model_id or "samp-session-live-123"
 
@@ -365,9 +288,7 @@ async def create_sampling_session(req: dict):
 
 @app.post("/api/v1/asample")
 async def asample(req: dict):
-  req_id = str(uuid.uuid4())
-  await store.set_future(req_id, {"status": "pending"})
-
+  """SamplingClient.sample_async()"""
   prompt = req.get("prompt", {}).get("chunks", [])[0].get("tokens", [])
   params = req.get("sampling_params", {})
   max_tokens = params.get("max_tokens", 20)
@@ -375,99 +296,85 @@ async def asample(req: dict):
   num_samples = req.get("num_samples", 1)
 
   model_id = req.get("model_id") or req.get("sampling_session_id")
-  # Strip potential tinker:// prefix explicitly
   if model_id and model_id.startswith("tinker://"):
-    model_id = model_id[len("tinker://") :]
+    model_id = model_id[len("tinker://"):]
+  base_model_id = model_id.split("-samp-")[0] if model_id else None
 
-  # vLLM caches adapters natively based on the `lora_id` key.
-  # To force vLLM to reload weights after PyTorch trains them, we pass a unique sequential `lora_id`.
-  lora_id = model_id
-  # Strip the sequence tag to find the base directory where PyTorch actually wrote the checkpoint
-  base_model_id = lora_id.split("-samp-")[0] if lora_id else None
-
-  sampler_backend = get_sampler_backend()
-  if sampler_backend == "torch":
-    await enqueue_traced_request(
-      store,
-      {
-        "req_id": req_id,
-        "model_id": base_model_id or model_id,
-        "type": "sample",
-        "prompt_tokens": prompt,
-        "max_tokens": max_tokens,
-        "temperature": temperature,
-        "num_samples": num_samples,
-      },
-    )
+  if get_sampler_backend() == "torch":
+    req_id = await _enqueue({
+      "model_id": base_model_id or model_id,
+      "type": "sample",
+      "prompt_tokens": prompt,
+      "max_tokens": max_tokens,
+      "temperature": temperature,
+      "num_samples": num_samples,
+    })
     return {"request_id": req_id}
 
-  # IPC Bridge: Route to vLLM worker on Port 8001 instead of PyTorch Queue
-  async def _route_to_vllm():
-    try:
-      import os
+  # vLLM backend
+  req_id = str(uuid.uuid4())
+  await store.set_future(req_id, {"status": "pending"})
 
-      tmp_dir = os.environ.get("OPEN_RL_TMP_DIR", "/tmp/open-rl")
-      # PEFT natively saves adapters into subdirectories named after their adapter ID
-      # Engine saves to: tmp_dir/peft/m_id (because adapter_name=m_id)
-      lora_path = os.path.join(tmp_dir, "peft", base_model_id, base_model_id) if base_model_id else None
+  lora_path = os.path.join(TMP_DIR, "peft", base_model_id, base_model_id) if base_model_id else None
+  headers: dict[str, str] = {"Content-Type": "application/json"}
+  propagate.inject(headers)
 
-      print(f"[Gateway DEBUG] Routing sample to vLLM. model_id_received={model_id} -> lora_id={lora_id}, lora_path={lora_path}")
-
-      payload = {
-        "request_id": req_id,
-        "prompt_token_ids": prompt,
-        "max_tokens": max_tokens,
-        "temperature": temperature,
-        "num_samples": num_samples,
-        "lora_id": lora_id,
-        "lora_path": lora_path,
-      }
-
-      # Use VLLM_URL env var instead of hardcoded 127.0.0.1:8001
-      vllm_url = os.environ.get("VLLM_URL", "http://127.0.0.1:8001")
-      vllm_generate_endpoint = f"{vllm_url.rstrip('/')}/generate"
-
-      headers = {"Content-Type": "application/json"}
-      from opentelemetry import propagate
-
-      propagate.inject(headers)
-
-      import httpx
-
-      # Use AsyncClient natively to prevent ThreadPool exhaustion from concurrent RL jobs!
-      # Increase timeout significantly since large RL batches will queue up in vLLM for > 60s
-      async with httpx.AsyncClient(timeout=60.0) as client:
-        resp = await client.post(vllm_generate_endpoint, json=payload, headers=headers)
-        resp.raise_for_status()
-        data = resp.json()
-      if data.get("type") != "RequestFailedResponse":
-        data["type"] = "sample"
-      await store.set_future(req_id, data)
-    except Exception as e:
-      traceback.print_exc()
-      await store.set_future(req_id, {"type": "RequestFailedResponse", "error_message": str(e), "category": "server_error"})
-
-  task = asyncio.create_task(_route_to_vllm())
-  background_tasks.add(task)
-  task.add_done_callback(background_tasks.discard)
+  try:
+    async with httpx.AsyncClient(timeout=60.0) as client:
+      resp = await client.post(
+        f"{VLLM_URL.rstrip('/')}/generate",
+        json={
+          "request_id": req_id,
+          "prompt_token_ids": prompt,
+          "max_tokens": max_tokens,
+          "temperature": temperature,
+          "num_samples": num_samples,
+          "lora_id": model_id,
+          "lora_path": lora_path,
+        },
+        headers=headers,
+      )
+      resp.raise_for_status()
+      data = resp.json()
+    if data.get("type") != "RequestFailedResponse":
+      data["type"] = "sample"
+    await store.set_future(req_id, data)
+  except Exception as e:
+    traceback.print_exc()
+    await store.set_future(req_id, {"type": "RequestFailedResponse", "error_message": str(e)})
 
   return {"request_id": req_id}
 
 
-@app.post("/api/v1/retrieve_future")
-async def retrieve_future(req: dict):
-  request_id = req.get("request_id")
-  if not request_id:
-    return JSONResponse(status_code=400, content={"error": "request_id is required"})
+# *** CLI endpoints ***
 
-  result = await store.get_future(request_id, timeout=60.0)
-  if result is None:
-    return JSONResponse(status_code=400, content={"type": "RequestFailedResponse", "error_message": "Future not found"})
 
-  if isinstance(result, dict) and result.get("type") == "RequestFailedResponse":
-    return JSONResponse(status_code=400, content=result)
+@app.get("/api/v1/list_adapters")
+async def list_adapters():
+  """CLI `list` — scan the peft directory for saved adapters."""
+  import json
 
-  return result
+  peft_dir = os.path.join(TMP_DIR, "peft")
+  adapters = []
+
+  if os.path.exists(peft_dir):
+    for entry in sorted(os.scandir(peft_dir), key=lambda e: e.stat().st_ctime, reverse=True):
+      if not entry.is_dir():
+        continue
+      info = {"model_id": entry.name, "created_at": entry.stat().st_ctime, "timestamp": entry.stat().st_ctime, "alias": None}
+      metadata_path = os.path.join(entry.path, "metadata.json")
+      if os.path.exists(metadata_path):
+        try:
+          with open(metadata_path) as f:
+            info.update(json.load(f))
+        except Exception:
+          pass
+      adapters.append(info)
+
+  return {"adapters": adapters}
+
+
+# *** Internal ***
 
 
 @app.post("/api/v1/telemetry")

--- a/server/src/gateway.py
+++ b/server/src/gateway.py
@@ -92,7 +92,7 @@ async def lifespan(app: FastAPI):
     print(f"-> Base model: {base_model or 'unset'}")
     print("-> Backend   : gateway + worker loop in one process\n")
     if base_model:
-      await asyncio.to_thread(clock_cycle.engine.preload_base_model, base_model)
+      await asyncio.to_thread(clock_cycle.engine.load_base_model, base_model)
     task = asyncio.create_task(clock_cycle.clock_cycle_loop())
   try:
     yield

--- a/server/src/trainer.py
+++ b/server/src/trainer.py
@@ -12,7 +12,6 @@ from peft import PeftModelForCausalLM, get_peft_model
 from pydantic import BaseModel
 from transformers import AutoModelForCausalLM, AutoTokenizer, PreTrainedModel, PreTrainedTokenizerBase
 
-# ── Wire types ────────────────────────────────────────
 
 class TensorData(BaseModel):
   data: list[int] | list[float]
@@ -30,6 +29,7 @@ class LoraConfig(BaseModel):
 class Datum(BaseModel):
   loss_fn_inputs: dict[str, TensorData]
   model_input: list[int]
+
 
 class TrainerEngine:
   def __init__(self):
@@ -144,11 +144,7 @@ class TrainerEngine:
       self.peft_model.save_pretrained(save_path, selected_adapters=[adapter_id])
 
       # Save minimal metadata
-      metadata = {
-        "model_id": adapter_id,
-        "created_at": datetime.now().isoformat(),
-        "timestamp": time.time()
-      }
+      metadata = {"model_id": adapter_id, "created_at": datetime.now().isoformat(), "timestamp": time.time()}
       with open(os.path.join(save_path, "metadata.json"), "w") as f:
         json.dump(metadata, f)
 
@@ -211,21 +207,12 @@ class TrainerEngine:
       logprobs_list = target_logprobs.detach().cpu().tolist()
       logprobs_list = [max(l, -9999.0) if not math.isinf(l) else (-9999.0 if l < 0 else 9999.0) for l in logprobs_list]
 
-      loss_fn_outputs.append({
-        "logprobs": {
-          "data": logprobs_list,
-          "dtype": "float32",
-          "shape": [len(logprobs_list)]
-        }
-      })
+      loss_fn_outputs.append({"logprobs": {"data": logprobs_list, "dtype": "float32", "shape": [len(logprobs_list)]}})
 
     mean_loss = total_loss / max(1, len(data))
 
     return {
-      "metrics": {
-        "loss:mean": self._sanitize_float(mean_loss),
-        "loss:sum": self._sanitize_float(total_loss)
-      },
+      "metrics": {"loss:mean": self._sanitize_float(mean_loss), "loss:sum": self._sanitize_float(total_loss)},
       "loss_fn_outputs": loss_fn_outputs,
       "loss_fn_output_type": "ArrayRecord",
     }
@@ -417,7 +404,7 @@ class TrainerEngine:
     sequences_out = []
     for seq_idx in range(num_samples):
       gen_sequences = outputs.sequences[seq_idx]
-      generated_tokens = gen_sequences[len(prompt_tokens):].cpu().tolist()
+      generated_tokens = gen_sequences[len(prompt_tokens) :].cpu().tolist()
 
       logprobs = []
       for token_step_idx in range(len(generated_tokens)):

--- a/server/src/trainer.py
+++ b/server/src/trainer.py
@@ -1,294 +1,322 @@
-import asyncio
 import json
+import math
 import os
-import threading
 import time
 import traceback
-from contextlib import asynccontextmanager
 from datetime import datetime
 from typing import Any
 
 import torch
-from fastapi import FastAPI
-from opentelemetry import trace
-from peft import LoraConfig, TaskType, get_peft_model
-from transformers import AutoModelForCausalLM, AutoTokenizer
+from peft import LoraConfig as PeftLoraConfig
+from peft import PeftModelForCausalLM, get_peft_model
+from pydantic import BaseModel
+from transformers import AutoModelForCausalLM, AutoTokenizer, PreTrainedModel, PreTrainedTokenizerBase
 
-tracer = trace.get_tracer(__name__)
+# ── Wire types ────────────────────────────────────────
 
-from .store import get_store
+class TensorData(BaseModel):
+  data: list[int] | list[float]
 
-store = get_store()
 
-import math
+class LoraConfig(BaseModel):
+  rank: int = 16
+  lora_alpha: int = 16
+  lora_dropout: float = 0.05
+  train_attn: bool = True
+  train_mlp: bool = True
+  train_unembed: bool = False
 
-ATTN_TARGET_SUFFIXES = ["q_proj", "k_proj", "v_proj", "o_proj"]
-MLP_TARGET_SUFFIXES = ["gate_proj", "up_proj", "down_proj"]
 
+class Datum(BaseModel):
+  loss_fn_inputs: dict[str, TensorData]
+  model_input: list[int]
 
 class TrainerEngine:
   def __init__(self):
-    self.model = None
-    self.tokenizer = None
+    # The raw pre-trained base model (e.g., Gemma, Qwen) loaded in VRAM
+    self.base_model: PreTrainedModel | None = None
 
-    # Store optimizers per model_id
+    # The model wrapped with PEFT/LoRA adapters that we actually train
+    self.peft_model: PeftModelForCausalLM | None = None
+
+    # The tokenizer associated with the base model
+    self.tokenizer: PreTrainedTokenizerBase | None = None
+
+    # String identifier of the currently loaded base model
+    self.base_model_name: str | None = None
+
+    # Store optimizers per model_id (adapter ID)
     self.optimizers: dict[str, torch.optim.Optimizer] = {}
-    self._init_lock = threading.Lock()
 
     # Decide device
     if torch.cuda.is_available():
-      self.device = "cuda"
+      self.device = torch.device("cuda")
     elif torch.backends.mps.is_available():
-      self.device = "mps"
+      self.device = torch.device("mps")
     else:
-      self.device = "cpu"
+      self.device = torch.device("cpu")
 
-    self.base_model_name = None
-
-  def preload_base_model(self, base_model: str):
+  def load_base_model(self, base_model_name: str) -> None:
     """Eagerly load the massive base model tensors into VRAM."""
-    with self._init_lock:
-      if self.model is None or self.base_model_name != base_model:
-        print(f"[EAGER INIT] Pre-loading heavy base model {base_model} to {self.device}...")
-        self.base_model_name = base_model
-        self.tokenizer = AutoTokenizer.from_pretrained(base_model)
-        dtype = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float32
+    if self.base_model is not None and self.base_model_name == base_model_name:
+      print(f"Base model {base_model_name} already loaded.")
+      return
 
-        # Load the raw base model graph (no adapters yet)
-        self.model_obj = AutoModelForCausalLM.from_pretrained(base_model, torch_dtype=dtype, device_map=self.device)
-        print(f"[EAGER INIT] {base_model} successfully seated in VRAM.")
+    print(f"Loading base model {base_model_name} to {self.device}...")
+    self.base_model_name = base_model_name
+    self.tokenizer = AutoTokenizer.from_pretrained(base_model_name)
+    dtype = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float32
 
-  def load_model(self, base_model: str, model_id: str, lora_config: dict[str, Any] | None = None):
-    with self._init_lock:
-      # If the user asks for a different base model than what's loaded, we have to swap it.
-      # But normally, eager init guarantees this matches.
-      if getattr(self, "model_obj", None) is None or self.base_model_name != base_model:
-        self.base_model_name = base_model
-        print(f"Loading base model {base_model} to {self.device}...")
+    self.base_model = AutoModelForCausalLM.from_pretrained(base_model_name, torch_dtype=dtype, device_map=self.device)
+    print("Successfully loaded.")
 
-        self.tokenizer = AutoTokenizer.from_pretrained(base_model)
-        dtype = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float32
-        self.model_obj = AutoModelForCausalLM.from_pretrained(base_model, torch_dtype=dtype, device_map=self.device)
-      config = lora_config or {}
-      rank = config.get("rank", 16)
-      train_attn = config.get("train_attn", True)
-      train_mlp = config.get("train_mlp", True)
-      train_unembed = config.get("train_unembed", True)
-      if not any([train_attn, train_mlp, train_unembed]):
-        raise ValueError("At least one LoRA training target must be enabled.")
+  def create_adapter(self, adapter_id: str, config: LoraConfig) -> None:
+    """Create a new LoRA adapter on top of the loaded base model."""
+    assert self.base_model is not None, "Base model is not loaded. Call load_base_model first."
 
-      # Tinker's LoRA config is intentionally coarse; PEFT still expects concrete target names here.
-      # Keep the historical broad behavior by default, but constrain Gemma4 to the language tower.
-      explicit_target_modules = os.getenv("OPEN_RL_TARGET_MODULES")
-      use_text_tower_lora = getattr(self.model_obj.config, "model_type", None) == "gemma4"
-      target_modules: str | list[str]
-      layers_to_transform = None
-      layers_pattern = None
-      target_suffixes: list[str] = []
-      if train_attn:
-        target_suffixes.extend(ATTN_TARGET_SUFFIXES)
-      if train_mlp:
-        target_suffixes.extend(MLP_TARGET_SUFFIXES)
-      if explicit_target_modules == "all-linear":
-        target_modules = "all-linear"
-        print("[engine] Forcing PEFT target_modules=all-linear via OPEN_RL_TARGET_MODULES")
-      elif use_text_tower_lora:
-        if target_suffixes:
-          target_modules = target_suffixes
-          model_config = getattr(self.model_obj.config, "text_config", self.model_obj.config)
-          num_hidden_layers = model_config.num_hidden_layers
-          layers_to_transform = list(range(num_hidden_layers))
-          layers_pattern = "language_model.layers"
-        else:
-          target_modules = []
-      elif train_attn and train_mlp and train_unembed:
-        target_modules = "all-linear"
-      else:
+    if adapter_id in self.optimizers:
+      del self.optimizers[adapter_id]
+
+    if not any([config.train_attn, config.train_mlp, config.train_unembed]):
+      raise ValueError("At least one LoRA training target must be enabled.")
+
+    print(f"Creating LoRA adapter '{adapter_id}'...")
+
+    target_suffixes: list[str] = []
+    if config.train_attn:
+      target_suffixes.extend(["q_proj", "k_proj", "v_proj", "o_proj"])
+    if config.train_mlp:
+      target_suffixes.extend(["gate_proj", "up_proj", "down_proj"])
+
+    # Decide target_modules based on model type and config
+    explicit_target_modules = os.getenv("OPEN_RL_TARGET_MODULES")
+    use_text_tower_lora = getattr(self.base_model.config, "model_type", None) == "gemma4"
+    target_modules: str | list[str]
+    layers_to_transform = None
+    layers_pattern = None
+
+    if explicit_target_modules == "all-linear":
+      target_modules = "all-linear"
+      print("[trainer] Forcing PEFT target_modules=all-linear via OPEN_RL_TARGET_MODULES")
+    elif use_text_tower_lora:
+      if target_suffixes:
         target_modules = target_suffixes
-
-      peft_config = LoraConfig(
-        task_type=TaskType.CAUSAL_LM,
-        r=rank,
-        lora_alpha=config.get("lora_alpha", 16),
-        lora_dropout=config.get("lora_dropout", 0.05),
-        bias="none",
-        target_modules=target_modules,
-        layers_to_transform=layers_to_transform,
-        layers_pattern=layers_pattern,
-        modules_to_save=["lm_head", "embed_tokens"] if train_unembed else None,
-      )
-
-      if getattr(self, "model", None) is None:
-        # First time wrapping the base model with PEFT
-        self.model = get_peft_model(self.model_obj, peft_config, adapter_name=model_id)
-        self.model.train()
-        print(f"Base model wrapped with initial LoRA adapter '{model_id}'.")
+        model_config = getattr(self.base_model.config, "text_config", self.base_model.config)
+        layers_to_transform = list(range(model_config.num_hidden_layers))
+        layers_pattern = "language_model.layers"
       else:
-        print(f"Adding new LoRA adapter '{model_id}' to existing base model...")
-        self.model.add_adapter(model_id, peft_config)
-        self.model.train()
+        target_modules = []
+    elif config.train_attn and config.train_mlp and config.train_unembed:
+      target_modules = "all-linear"
+    else:
+      target_modules = target_suffixes
 
-    # Reset/initialize optimizer for this new adapter
-    if model_id in self.optimizers:
-      del self.optimizers[model_id]
+    peft_config = PeftLoraConfig(
+      task_type="CAUSAL_LM",
+      r=config.rank,
+      lora_alpha=config.lora_alpha,
+      lora_dropout=config.lora_dropout,
+      bias="none",
+      target_modules=target_modules,
+      layers_to_transform=layers_to_transform,
+      layers_pattern=layers_pattern,
+      modules_to_save=["lm_head", "embed_tokens"] if config.train_unembed else None,
+    )
 
-    self._auto_save_adapter(model_id)
+    if self.peft_model is None:
+      self.peft_model = get_peft_model(self.base_model, peft_config, adapter_name=adapter_id)
+    else:
+      self.peft_model.add_adapter(adapter_id, peft_config)
 
-  def _auto_save_adapter(self, model_id: str):
+    self.peft_model.train()
+    print(f"LoRA adapter '{adapter_id}' created and set to active.")
+
+    self.save_adapter(adapter_id)
+
+  def save_adapter(self, adapter_id: str) -> None:
+    """Save adapter weights to disk for reliability and sharing."""
     try:
-      tmp_dir = os.environ.get("OPEN_RL_TMP_DIR", "/tmp/open-rl")
-      ram_path = os.path.join(tmp_dir, "peft", model_id)
-      os.makedirs(ram_path, exist_ok=True)
+      tmp_dir = os.getenv("OPEN_RL_TMP_DIR", "/tmp/open-rl")
+      save_path = os.path.join(tmp_dir, "peft", adapter_id)
+      os.makedirs(save_path, exist_ok=True)
 
-      with tracer.start_as_current_span(f"auto_save_weights_{model_id}"):
-        self.model.save_pretrained(ram_path, selected_adapters=[model_id])
+      # Save the adapter weights
+      self.peft_model.save_pretrained(save_path, selected_adapters=[adapter_id])
 
-      metadata = {"model_id": model_id, "alias": None, "created_at": datetime.now().isoformat(), "timestamp": time.time()}
-      with open(os.path.join(ram_path, "metadata.json"), "w") as f:
+      # Save minimal metadata
+      metadata = {
+        "model_id": adapter_id,
+        "created_at": datetime.now().isoformat(),
+        "timestamp": time.time()
+      }
+      with open(os.path.join(save_path, "metadata.json"), "w") as f:
         json.dump(metadata, f)
+
+      print(f"Auto-saved adapter '{adapter_id}' to {save_path}")
     except Exception as e:
-      print(f"[ERROR] Failed to auto-save weights for {model_id}: {e}")
+      print(f"[ERROR] Failed to auto-save weights for {adapter_id}: {e}")
       traceback.print_exc()
 
-  def set_active_adapter(self, model_id: str):
-    with self._init_lock:
-      if self.model is not None:
-        self.model.set_adapter(model_id)
+  def save_state(self, model_id: str, state_path: str, include_optimizer: bool = False, kind: str = "state") -> dict[str, Any]:
+    """Save adapter weights (and optionally optimizer state) to a specific path."""
+    assert self.peft_model is not None, "Model must be loaded first."
 
-  def forward_backward(self, data: list[dict[str, Any]], loss_fn: str, loss_fn_config: dict = None, model_id: str = None) -> dict[str, Any]:
-    with tracer.start_as_current_span("forward_backward") as span, self._init_lock:
-      span.set_attribute("model_id", model_id or "unknown")
-      span.set_attribute("batch_size", len(data))
-      span.set_attribute("loss_fn", loss_fn)
-      return self._forward_backward_internal(data, loss_fn, loss_fn_config, model_id)
+    self.peft_model.set_adapter(model_id)
+    os.makedirs(state_path, exist_ok=True)
+    self.peft_model.save_pretrained(state_path, selected_adapters=[model_id])
 
-  def _forward_backward_internal(self, data: list[dict[str, Any]], loss_fn: str, loss_fn_config: dict = None, model_id: str = None) -> dict[str, Any]:
-    """
-    data: List of Datum objects
-    """
-    assert self.model is not None, "Model not loaded."
+    metadata = {
+      "base_model": self.base_model_name,
+      "created_at": datetime.now().isoformat(),
+      "kind": kind,
+      "model_id": model_id,
+      "timestamp": time.time(),
+    }
+    with open(os.path.join(state_path, "metadata.json"), "w") as f:
+      json.dump(metadata, f)
 
-    if model_id and model_id not in self.optimizers:
-      # Ensuring optimizer exists is good, but we don't zero_grad here anymore
-      pass
+    print(f"Saved state for '{model_id}' to {state_path}")
+    return {"path": state_path}
+
+  def forward_backward(self, data: list[Datum], loss_fn: str, loss_config: dict | None = None, model_id: str | None = None) -> dict[str, Any]:
+    """Core training step: forward pass, loss computation, and backward pass."""
+    assert self.peft_model is not None, "Model must be loaded first."
 
     total_loss = 0.0
     loss_fn_outputs = []
 
+    # Ensure model is in train mode
+    self.peft_model.train()
+
     for datum in data:
-      # Extract inputs
-      chunks = datum.get("model_input", {}).get("chunks", [])
-      input_tokens = []
-      for chunk in chunks:
-        input_tokens.extend(chunk.get("tokens", []))
+      # 1. Common Setup: Extract tokens and get logprobs
+      target_logprobs, targets_tensor, weights_tensor = self._get_logprobs(datum)
 
-      inputs_tensor = torch.tensor([input_tokens], dtype=torch.long, device=self.device)
+      # 2. Specialized Loss Calculation
+      match loss_fn:
+        case "cross_entropy":
+          loss = self._compute_cross_entropy_loss(target_logprobs, weights_tensor)
+        case "importance_sampling":
+          loss = self._compute_importance_sampling_loss(target_logprobs, weights_tensor, datum)
+        case "ppo":
+          loss = self._compute_ppo_loss(target_logprobs, targets_tensor, datum, loss_config)
+        case _:
+          raise NotImplementedError(f"Loss {loss_fn} not supported")
 
-      # Extract loss inputs
-      loss_inputs = datum.get("loss_fn_inputs", {})
-
-      weights_data = loss_inputs.get("weights", {}).get("data", [])
-      weights_tensor = torch.tensor(weights_data, dtype=torch.float32, device=self.device)
-
-      targets_data = loss_inputs.get("target_tokens", {}).get("data", [])
-      targets_tensor = torch.tensor(targets_data, dtype=torch.long, device=self.device)
-
-      outputs = self.model(inputs_tensor, use_cache=False)
-      logits = outputs.logits[0]  # Shape: (SeqLen, VocabSize)
-
-      # gather logprobs for the target tokens
-      # The client SDK already offsets inputs vs targets.
-      seq_len = min(logits.size(0), targets_tensor.size(0))
-
-      sliced_logits = logits[:seq_len]
-      sliced_targets = targets_tensor[:seq_len]
-
-      target_logprobs = torch.nn.functional.log_softmax(sliced_logits, dim=-1).gather(dim=-1, index=sliced_targets.unsqueeze(-1)).squeeze(-1)
-
-      # Clamp weights tensor if it exists, otherwise ones
-      if weights_tensor.numel() > 0:
-        weights_tensor = weights_tensor[:seq_len]
-      else:
-        weights_tensor = torch.ones_like(target_logprobs)
-
-      if loss_fn == "cross_entropy":
-        elementwise_loss = -target_logprobs * weights_tensor
-        loss = elementwise_loss.sum()
-      elif loss_fn == "importance_sampling":
-        ref_logprobs_raw = loss_inputs.get("logprobs")
-        advs_raw = loss_inputs.get("advantages")
-
-        ref_logprobs = ref_logprobs_raw.get("data") if isinstance(ref_logprobs_raw, dict) else ref_logprobs_raw
-        advs = advs_raw.get("data") if isinstance(advs_raw, dict) else advs_raw
-        if not ref_logprobs or not advs:
-          raise ValueError("importance_sampling requires 'logprobs' and 'advantages' in loss_fn_inputs")
-
-        ref_tensor = torch.tensor(ref_logprobs, dtype=target_logprobs.dtype, device=self.device)
-        advantages_tensor = torch.tensor(advs, dtype=target_logprobs.dtype, device=self.device)
-
-        # Align reference logits and advantages to the generated right-aligned targets
-        ref_tensor = ref_tensor[:seq_len]
-        advantages_tensor = advantages_tensor[:seq_len]
-
-        # Prevent overflow in exp() by explicitly clamping diff
-        diff = target_logprobs - ref_tensor
-        diff = torch.clamp(diff, min=-20.0, max=20.0)
-
-        ratio = torch.exp(diff)
-
-        elementwise_loss = -(ratio * advantages_tensor) * weights_tensor
-        # Add nan_to_num to be absolutely sure no trailing NaNs poison the gradients
-        elementwise_loss = torch.nan_to_num(elementwise_loss, nan=0.0, posinf=0.0, neginf=0.0)
-
-        loss = elementwise_loss.sum()
-      elif loss_fn == "ppo":
-        ref_logprobs_raw = loss_inputs.get("logprobs")
-        advs_raw = loss_inputs.get("advantages")
-
-        ref_logprobs = ref_logprobs_raw.get("data") if isinstance(ref_logprobs_raw, dict) else ref_logprobs_raw
-        advs = advs_raw.get("data") if isinstance(advs_raw, dict) else advs_raw
-        if not ref_logprobs or not advs:
-          raise ValueError("ppo requires 'logprobs' and 'advantages' in loss_fn_inputs")
-
-        ref_tensor = torch.tensor(ref_logprobs, dtype=target_logprobs.dtype, device=self.device)
-        advantages_tensor = torch.tensor(advs, dtype=target_logprobs.dtype, device=self.device)
-
-        ref_tensor = ref_tensor[:seq_len]
-        advantages_tensor = advantages_tensor[:seq_len]
-
-        # Prevent overflow in exp() by explicitly clamping diff
-        diff = target_logprobs - ref_tensor
-        diff = torch.clamp(diff, min=-20.0, max=20.0)
-        ratio = torch.exp(diff)
-
-        epsilon = loss_fn_config.get("clip_range", 0.2) if loss_fn_config else 0.2
-
-        surr1 = ratio * advantages_tensor
-        surr2 = torch.clamp(ratio, 1.0 - epsilon, 1.0 + epsilon) * advantages_tensor
-
-        # PPO Objective: maximize min(surr1, surr2)
-        # Loss: minimize -min(surr1, surr2)
-        elementwise_objective = torch.min(surr1, surr2)
-
-        loss = -elementwise_objective.sum()
-      else:
-        raise NotImplementedError(f"Loss {loss_fn} not implemented in MVP yet.")
-
+      # 3. Common Cleanup: Backward pass
       loss.backward()
       total_loss += loss.item()
 
+      # Save logprobs for return
       logprobs_list = target_logprobs.detach().cpu().tolist()
       logprobs_list = [max(l, -9999.0) if not math.isinf(l) else (-9999.0 if l < 0 else 9999.0) for l in logprobs_list]
 
-      # Construct loss_fn_output
-      loss_fn_outputs.append({"logprobs": {"data": logprobs_list, "dtype": "float32", "shape": [len(logprobs_list)]}})
+      loss_fn_outputs.append({
+        "logprobs": {
+          "data": logprobs_list,
+          "dtype": "float32",
+          "shape": [len(logprobs_list)]
+        }
+      })
+
     mean_loss = total_loss / max(1, len(data))
 
     return {
-      "metrics": {"loss:mean": self._sanitize_float(mean_loss), "loss:sum": self._sanitize_float(total_loss)},
+      "metrics": {
+        "loss:mean": self._sanitize_float(mean_loss),
+        "loss:sum": self._sanitize_float(total_loss)
+      },
       "loss_fn_outputs": loss_fn_outputs,
       "loss_fn_output_type": "ArrayRecord",
     }
+
+  def _get_logprobs(self, datum: Datum) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Returns (target_logprobs, targets_tensor, weights_tensor)."""
+    # model_input is now just a flat list of tokens!
+    inputs_tensor = torch.tensor([datum.model_input], dtype=torch.long, device=self.device)
+
+    # Extract targets
+    targets_data = datum.loss_fn_inputs["target_tokens"].data
+    targets_tensor = torch.tensor(targets_data, dtype=torch.long, device=self.device)
+
+    # Extract weights with default fallback to 1.0
+    if "weights" in datum.loss_fn_inputs:
+      weights_data = datum.loss_fn_inputs["weights"].data
+    else:
+      weights_data = [1.0] * len(targets_data)
+
+    weights_tensor = torch.tensor(weights_data, dtype=torch.float32, device=self.device)
+
+    outputs = self.peft_model(inputs_tensor, use_cache=False)
+    logits = outputs.logits[0]  # Shape: (SeqLen, VocabSize)
+
+    seq_len = min(logits.size(0), targets_tensor.size(0))
+    sliced_logits = logits[:seq_len]
+    sliced_targets = targets_tensor[:seq_len]
+
+    target_logprobs = torch.nn.functional.log_softmax(sliced_logits, dim=-1).gather(dim=-1, index=sliced_targets.unsqueeze(-1)).squeeze(-1)
+
+    if weights_tensor.numel() > 0:
+      weights_tensor = weights_tensor[:seq_len]
+
+    return target_logprobs, targets_tensor, weights_tensor
+
+  def _compute_cross_entropy_loss(self, target_logprobs: torch.Tensor, weights_tensor: torch.Tensor) -> torch.Tensor:
+    """Simple cross entropy loss."""
+    elementwise_loss = -target_logprobs * weights_tensor
+    return elementwise_loss.sum()
+
+  def _compute_importance_sampling_loss(self, target_logprobs: torch.Tensor, weights_tensor: torch.Tensor, datum: Datum) -> torch.Tensor:
+    """Importance sampling loss for RL."""
+    if "logprobs" not in datum.loss_fn_inputs or "advantages" not in datum.loss_fn_inputs:
+      raise ValueError("importance_sampling requires 'logprobs' and 'advantages' in loss_fn_inputs")
+
+    ref_logprobs = datum.loss_fn_inputs["logprobs"].data
+    advantages = datum.loss_fn_inputs["advantages"].data
+    ref_tensor = torch.tensor(ref_logprobs, dtype=target_logprobs.dtype, device=self.device)
+    advantages_tensor = torch.tensor(advantages, dtype=target_logprobs.dtype, device=self.device)
+
+    seq_len = min(target_logprobs.size(0), ref_tensor.size(0), advantages_tensor.size(0), weights_tensor.size(0))
+    target_logprobs = target_logprobs[:seq_len]
+    ref_tensor = ref_tensor[:seq_len]
+    advantages_tensor = advantages_tensor[:seq_len]
+    weights_tensor = weights_tensor[:seq_len]
+
+    diff = target_logprobs - ref_tensor
+    diff = torch.clamp(diff, min=-20.0, max=20.0)
+    ratio = torch.exp(diff)
+
+    elementwise_loss = -(ratio * advantages_tensor) * weights_tensor
+    elementwise_loss = torch.nan_to_num(elementwise_loss, nan=0.0, posinf=0.0, neginf=0.0)
+    return elementwise_loss.sum()
+
+  def _compute_ppo_loss(self, target_logprobs: torch.Tensor, targets_tensor: torch.Tensor, datum: Datum, loss_config: dict | None) -> torch.Tensor:
+    """PPO loss for RL."""
+    if "logprobs" not in datum.loss_fn_inputs or "advantages" not in datum.loss_fn_inputs:
+      raise ValueError("ppo requires 'logprobs' and 'advantages' in loss_fn_inputs")
+
+    ref_logprobs = datum.loss_fn_inputs["logprobs"].data
+    advantages = datum.loss_fn_inputs["advantages"].data
+
+    ref_tensor = torch.tensor(ref_logprobs, dtype=target_logprobs.dtype, device=self.device)
+    advantages_tensor = torch.tensor(advantages, dtype=target_logprobs.dtype, device=self.device)
+
+    seq_len = min(target_logprobs.size(0), ref_tensor.size(0), advantages_tensor.size(0))
+    target_logprobs = target_logprobs[:seq_len]
+    ref_tensor = ref_tensor[:seq_len]
+    advantages_tensor = advantages_tensor[:seq_len]
+
+    diff = target_logprobs - ref_tensor
+    diff = torch.clamp(diff, min=-20.0, max=20.0)
+    ratio = torch.exp(diff)
+
+    epsilon = loss_config.get("clip_range", 0.2) if loss_config else 0.2
+
+    surr1 = ratio * advantages_tensor
+    surr2 = torch.clamp(ratio, 1.0 - epsilon, 1.0 + epsilon) * advantages_tensor
+
+    elementwise_objective = torch.min(surr1, surr2)
+    return -elementwise_objective.sum()
 
   def _sanitize_float(self, val: float) -> float:
     if math.isinf(val):
@@ -297,12 +325,14 @@ class TrainerEngine:
       return 0.0
     return val
 
-  def optim_step(self, adam_params: dict[str, Any], model_id: str = None):
-    with tracer.start_as_current_span("optim_step") as span, self._init_lock:
-      span.set_attribute("model_id", model_id or "unknown")
-      return self._optim_step_internal(adam_params, model_id)
+  def set_active_adapter(self, adapter_id: str) -> None:
+    """Switch which LoRA adapter is active."""
+    if self.peft_model is not None:
+      self.peft_model.set_adapter(adapter_id)
 
-  def _optim_step_internal(self, adam_params: dict[str, Any], model_id: str = None):
+  def optim_step(self, adam_params: dict[str, Any], model_id: str) -> dict[str, Any]:
+    """Apply accumulated gradients and update model weights."""
+    assert self.peft_model is not None, "Model must be loaded first."
     if not model_id:
       raise ValueError("model_id is required for optim_step")
 
@@ -313,64 +343,81 @@ class TrainerEngine:
       eps = adam_params.get("eps", 1e-12)
       weight_decay = adam_params.get("weight_decay", 0.0)
 
-      # Ensure we only pass the parameters of the active adapter for this model_id
-      # peft's model.parameters() works, but it's better to filter requires_grad
-      params = [p for p in self.model.parameters() if p.requires_grad]
-
-      self.optimizers[model_id] = torch.optim.AdamW(params, lr=lr, betas=(beta1, beta2), eps=eps, weight_decay=weight_decay)
+      print(f"Initializing AdamW optimizer for '{model_id}' with lr={lr}")
+      params = [p for p in self.peft_model.parameters() if p.requires_grad]
+      self.optimizers[model_id] = torch.optim.AdamW(
+        params,
+        lr=lr,
+        betas=(beta1, beta2),
+        eps=eps,
+        weight_decay=weight_decay,
+      )
 
     optimizer = self.optimizers[model_id]
+    learning_rate = adam_params.get("learning_rate")
+    if learning_rate is not None:
+      for param_group in optimizer.param_groups:
+        param_group["lr"] = learning_rate
 
-    # Compute grad norm BEFORE stepping
     total_norm = 0.0
-    for p in self.model.parameters():
-      if p.grad is not None:
-        total_norm += p.grad.data.norm(2).item() ** 2
+    for param in self.peft_model.parameters():
+      if param.grad is not None:
+        total_norm += param.grad.data.norm(2).item() ** 2
     total_norm = total_norm**0.5
-    print(f"DEBUG: grad_norm={total_norm}")
 
-    # Apply gradient clipping if requested
     clip_norm = adam_params.get("grad_clip_norm", 0.0)
-    if clip_norm > 0.0:
-      torch.nn.utils.clip_grad_norm_(self.model.parameters(), clip_norm)
+    if clip_norm and clip_norm > 0.0:
+      torch.nn.utils.clip_grad_norm_(self.peft_model.parameters(), clip_norm)
 
     optimizer.step()
     optimizer.zero_grad()
 
-    # Auto-save for Hardware Pipeline bypass
-    self._auto_save_adapter(model_id)
+    self.save_adapter(model_id)
 
-    return {"metrics": {"grad_norm:mean": self._sanitize_float(total_norm)}}
+    return {
+      "metrics": {
+        "grad_norm:mean": self._sanitize_float(total_norm),
+      },
+    }
 
   def generate(
-    self, prompt_tokens: list[int], max_tokens: int, num_samples: int = 1, temperature: float = 0.0, model_id: str = None
+    self,
+    prompt_tokens: list[int],
+    max_tokens: int,
+    num_samples: int = 1,
+    temperature: float = 0.0,
+    model_id: str | None = None,
   ) -> dict[str, Any]:
-    with self._init_lock:
-      assert self.model is not None, "Model not loaded."
+    """Generate completions from the current model."""
+    assert self.peft_model is not None, "Model must be loaded first."
 
-      input_tensor = torch.tensor([prompt_tokens], dtype=torch.long, device=self.device)
-      do_sample = (num_samples > 1) or (temperature and temperature > 0.0)
+    if model_id:
+      self.peft_model.set_adapter(model_id)
+    self.peft_model.eval()
 
-      with torch.no_grad():
-        attention_mask = torch.ones_like(input_tensor)
-        outputs = self.model.generate(
-          input_tensor,
-          attention_mask=attention_mask,
-          max_new_tokens=max_tokens,
-          pad_token_id=self.tokenizer.pad_token_id or self.tokenizer.eos_token_id,
-          do_sample=do_sample,
-          temperature=temperature if do_sample else None,
-          top_p=None,
-          top_k=None,
-          num_return_sequences=num_samples,
-          output_scores=True,
-          return_dict_in_generate=True,
-        )
+    input_tensor = torch.tensor([prompt_tokens], dtype=torch.long, device=self.device)
+    do_sample = (num_samples > 1) or (temperature and temperature > 0.0)
+
+    with torch.no_grad():
+      attention_mask = torch.ones_like(input_tensor)
+      outputs = self.peft_model.generate(
+        input_tensor,
+        attention_mask=attention_mask,
+        max_new_tokens=max_tokens,
+        pad_token_id=self.tokenizer.pad_token_id or self.tokenizer.eos_token_id,
+        do_sample=do_sample,
+        temperature=temperature if do_sample else None,
+        top_p=None,
+        top_k=None,
+        num_return_sequences=num_samples,
+        output_scores=True,
+        return_dict_in_generate=True,
+      )
 
     sequences_out = []
     for seq_idx in range(num_samples):
       gen_sequences = outputs.sequences[seq_idx]
-      generated_tokens = gen_sequences[len(prompt_tokens) :].cpu().tolist()
+      generated_tokens = gen_sequences[len(prompt_tokens):].cpu().tolist()
 
       logprobs = []
       for token_step_idx in range(len(generated_tokens)):
@@ -378,188 +425,18 @@ class TrainerEngine:
         logprob_dist = torch.nn.functional.log_softmax(score_tensor[seq_idx], dim=-1)
         token_id = generated_tokens[token_step_idx]
         logprob = logprob_dist[token_id].item()
-        if logprob == float("-inf"):
-          logprob = -9999.0
-        elif logprob == float("inf"):
-          logprob = 9999.0
-        logprobs.append(logprob)
+        logprobs.append(self._sanitize_float(logprob))
 
       sequences_out.append({"tokens": generated_tokens, "logprobs": logprobs, "stop_reason": "stop"})
 
     return {"sequences": sequences_out}
 
 
-# Global singleton
-engine = TrainerEngine()
+def main() -> None:
+  from .clock_cycle import main as clock_cycle_main
 
-
-@asynccontextmanager
-async def lifespan(app: FastAPI):
-  print("\n" + "=" * 50)
-  print("      Open-RL PyTorch Training Gateway")
-  print("=" * 50)
-  cuda_devs = os.getenv("CUDA_VISIBLE_DEVICES", "ALL")
-  vllm_url = os.getenv("VLLM_URL", "http://127.0.0.1:8001")
-  print(f"-> Hardware : CUDA_VISIBLE_DEVICES={cuda_devs}")
-  print(f"-> Inference: Routing completions to VLLM_URL={vllm_url}\n")
-
-  # Start the clock cycle loop
-  task = asyncio.create_task(clock_cycle_loop())
-  yield
-
-  # Cleanup if needed
-  task.cancel()
-
-
-async def clock_cycle_loop():
-  global store
-  while True:
-    try:
-      # Block until requests are available and drain the queue
-      # With the new RR Queue logic, this batch is guaranteed to belong to ONE tenant
-      batch = await store.get_requests()
-      if not batch:
-        await asyncio.sleep(0.1)
-        continue
-
-      m_id = batch[0].get("model_id", "default")
-
-      with tracer.start_as_current_span("clock_cycle_batch") as batch_span:
-        batch_span.set_attribute("batch_size", len(batch))
-        batch_span.set_attribute("model_id", m_id)
-
-        print(f"\n[CLOCK CYCLE] Popped {len(batch)} requests for tenant: {m_id}")
-
-        with tracer.start_as_current_span("process_model_batch") as model_span:
-          model_span.set_attribute("model_id", m_id)
-          model_span.set_attribute("model_reqs", len(batch))
-          print(f"  -> [TENSOR CORE] Hot-swapping to LoRA adapter: {m_id}")
-
-          # Set active adapter, UNLESS the batch is trying to create it!
-          has_create_model = any(r.get("type") == "create_model" for r in batch)
-          if not has_create_model:
-            try:
-              with tracer.start_as_current_span("set_active_adapter"):
-                await asyncio.to_thread(engine.set_active_adapter, m_id)
-            except Exception as e:
-              print(f"Failed to set adapter {m_id}: {e}")
-              for r in batch:
-                await store.set_future(r["req_id"], {"type": "RequestFailedResponse", "error_message": str(e)})
-              continue
-
-          print(f"     Executing {len(batch)} operations for {m_id}...")
-
-          # Execute sequentially
-          for r in batch:
-            req_id = r["req_id"]
-            req_type = r["type"]
-
-            carrier = r.get("trace_context", {})
-            from opentelemetry import context as otel_context
-            from opentelemetry import propagate
-
-            ctx = propagate.extract(carrier) if carrier else None
-            token = otel_context.attach(ctx) if ctx else None
-
-            try:
-              if req_type == "forward_backward":
-                data = r["data"]
-                loss_fn = r["loss_fn"]
-                loss_config = r["loss_config"]
-                result = await asyncio.to_thread(engine.forward_backward, data, loss_fn, loss_config, m_id)
-                result["type"] = "forward_backward"
-                await store.set_future(req_id, result)
-              elif req_type == "optim_step":
-                adam_params = r["adam_params"]
-                result = await asyncio.to_thread(engine.optim_step, adam_params, m_id)
-                result["type"] = "optim_step"
-                await store.set_future(req_id, result)
-              elif req_type == "sample":
-                prompt_tokens = r["prompt_tokens"]
-                max_tokens = r["max_tokens"]
-                num_samples = r["num_samples"]
-                temperature = r.get("temperature", 0.0)
-                result = await asyncio.to_thread(engine.generate, prompt_tokens, max_tokens, num_samples, temperature, m_id)
-                result["type"] = "sample"
-                await store.set_future(req_id, result)
-              elif req_type == "create_model":
-                base_model = r["base_model"]
-                lora_config = r.get("lora_config") or {}
-                rank = lora_config.get("rank", 16)
-                await asyncio.to_thread(engine.load_model, base_model, m_id, lora_config)
-                await store.set_future(req_id, {"model_id": m_id, "is_lora": True, "lora_rank": rank, "type": "create_model"})
-            except Exception as e:
-              traceback.print_exc()
-              await store.set_future(req_id, {"type": "RequestFailedResponse", "error_message": str(e)})
-            finally:
-              if token:
-                otel_context.detach(token)
-
-    except asyncio.CancelledError:
-      break
-    except Exception as e:
-      print(f"Error in clock cycle loop: {e}")
-      traceback.print_exc()
-
-      # If the background Redis pod was restarted, the asyncio connection pool gets stuck.
-      # We forcefully destroy the singleton to create a fresh connection pool on the next loop.
-      import redis
-
-      if isinstance(e, redis.exceptions.ConnectionError):
-        print("[engine] Destroying RequestStore singleton to force Redis reconnection...")
-        from . import store as store_mod
-
-        store_mod._store_instance = None
-        store = store_mod.get_store()
-
-      await asyncio.sleep(1)
+  clock_cycle_main()
 
 
 if __name__ == "__main__":
-  import threading
-
-  import uvicorn
-  from fastapi import FastAPI
-
-  print("\n" + "=" * 50)
-  print("      Open-RL PyTorch Training Worker")
-  print("=" * 50)
-  cuda_devs = os.getenv("CUDA_VISIBLE_DEVICES", "ALL")
-  print(f"-> Hardware : CUDA_VISIBLE_DEVICES={cuda_devs}\n")
-
-  # 1. Eagerly load the base model to bypass cold-start penalties
-  preload_target = os.getenv("VLLM_MODEL")
-  is_ready = False
-  if preload_target:
-    engine.preload_base_model(preload_target)
-    is_ready = True
-  else:
-    print("[WARNING] VLLM_MODEL not provided. Cold-start penalty will apply on first request.")
-    is_ready = True  # Nothing to load, so we are "ready" to receive the first request
-
-  # 2. Stand up a lightweight ASGI app strictly for Kubernetes Readiness Probes
-  probe_app = FastAPI()
-
-  @probe_app.get("/healthz")
-  def healthz():
-    if is_ready:
-      return {"status": "ready"}
-    from fastapi import HTTPException
-
-    raise HTTPException(status_code=503, detail="Model Loading")
-
-  def run_probe_server():
-    # Run on port 8000 so the Kubernetes deployment health check works
-    uvicorn.run(probe_app, host="0.0.0.0", port=8000, log_level="warning")
-
-  threading.Thread(target=run_probe_server, daemon=True).start()
-
-  # 3. Start the infinite tensor crunching loop
-  async def main():
-    task = asyncio.create_task(clock_cycle_loop())
-    try:
-      await task
-    except asyncio.CancelledError:
-      pass
-
-  asyncio.run(main())
+  main()

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -2,9 +2,6 @@ version = 1
 revision = 3
 requires-python = "==3.12.*"
 resolution-markers = [
-    "sys_platform == 'win32' and extra != 'extra-6-server-cpu' and extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm'",
-    "sys_platform == 'emscripten' and extra != 'extra-6-server-cpu' and extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm'",
-    "sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-6-server-cpu' and extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm'",
     "sys_platform == 'win32' and extra != 'extra-6-server-cpu' and extra == 'extra-6-server-gpu' and extra != 'extra-6-server-vllm'",
     "sys_platform == 'emscripten' and extra != 'extra-6-server-cpu' and extra == 'extra-6-server-gpu' and extra != 'extra-6-server-vllm'",
     "sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-6-server-cpu' and extra == 'extra-6-server-gpu' and extra != 'extra-6-server-vllm'",
@@ -21,6 +18,9 @@ conflicts = [[
 ], [
     { package = "server", extra = "cpu" },
     { package = "server", extra = "vllm" },
+], [
+    { package = "server", extra = "gpu" },
+    { package = "server", extra = "vllm" },
 ]]
 
 [[package]]
@@ -28,16 +28,15 @@ name = "accelerate"
 version = "1.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "huggingface-hub" },
+    { name = "huggingface-hub", version = "1.9.2", source = { registry = "https://pypi.org/simple" } },
     { name = "numpy" },
     { name = "packaging" },
     { name = "psutil" },
     { name = "pyyaml" },
     { name = "safetensors" },
-    { name = "torch", version = "2.10.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-6-server-cpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "torch", version = "2.10.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform == 'emscripten' and extra == 'extra-6-server-gpu') or (sys_platform == 'win32' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "torch", version = "2.10.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-cpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "torch", version = "2.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+    { name = "torch", version = "2.10.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-6-server-cpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
+    { name = "torch", version = "2.10.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-cpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
+    { name = "torch", version = "2.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "extra == 'extra-6-server-gpu' or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4a/8e/ac2a9566747a93f8be36ee08532eb0160558b07630a081a6056a9f89bf1d/accelerate-1.12.0.tar.gz", hash = "sha256:70988c352feb481887077d2ab845125024b2a137a5090d6d7a32b57d03a45df6", size = 398399, upload-time = "2025-11-21T11:27:46.973Z" }
 wheels = [
@@ -123,14 +122,14 @@ name = "anthropic"
 version = "0.83.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "distro", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "docstring-parser", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "httpx", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "jiter", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "pydantic", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "sniffio", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "typing-extensions", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/db/e5/02cd2919ec327b24234abb73082e6ab84c451182cc3cc60681af700f4c63/anthropic-0.83.0.tar.gz", hash = "sha256:a8732c68b41869266c3034541a31a29d8be0f8cd0a714f9edce3128b351eceb4", size = 534058, upload-time = "2026-02-19T19:26:38.904Z" }
 wheels = [
@@ -155,7 +154,7 @@ name = "apache-tvm-ffi"
 version = "0.1.8.post2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e3/e9/a13952726228fa6282154ecf927092396bc759739e5e045019f6ab92f3ca/apache_tvm_ffi-0.1.8.post2.tar.gz", hash = "sha256:4513e38852894f290172ecfefcbc18d34e817fd29c16a0f1770e130c82b4067e", size = 2441111, upload-time = "2026-01-13T18:11:27.864Z" }
 wheels = [
@@ -253,7 +252,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy' or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy' or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -301,7 +300,7 @@ name = "click"
 version = "8.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
 wheels = [
@@ -328,17 +327,17 @@ wheels = [
 
 [[package]]
 name = "compressed-tensors"
-version = "0.13.0"
+version = "0.14.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "loguru", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "pydantic", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "torch", version = "2.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "transformers", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "loguru" },
+    { name = "pydantic" },
+    { name = "torch", version = "2.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" } },
+    { name = "transformers", version = "4.57.6", source = { registry = "https://pypi.org/simple" } },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/65/88dd1c58fb9d0ded51b5c86471b937a1525f91fad2211a6f051dc1ea822d/compressed_tensors-0.13.0.tar.gz", hash = "sha256:23893824d3498ea3f1a829f14a8fa85f9a5e76a34c711a038b8d7c619ca9a67c", size = 200995, upload-time = "2025-12-16T16:03:55.397Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/f1/4c9b01ceaf82ad58ad00919223e09b8e74d4073a2ba8e3ab2f97521ef65c/compressed_tensors-0.14.0.1.tar.gz", hash = "sha256:5ad3841184b6f5020e06059b2463191c5c57a144bb97cab9159978d8118839b1", size = 226393, upload-time = "2026-03-11T17:04:35.57Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/b5/61ac2563c62490922b603c09113a083fd74af3630ec3931e769484d6dcb5/compressed_tensors-0.13.0-py3-none-any.whl", hash = "sha256:3518799c9baf034eb642efb551db6b0537b8713d45a64fe4def26f7f8d6cabec", size = 192620, upload-time = "2025-12-16T16:03:53.041Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/26/16a13993ecf4fdc9c39d63b3a6daabafd32a452cf68b81aa9eb3b8170913/compressed_tensors-0.14.0.1-py3-none-any.whl", hash = "sha256:46c4940a3a779d3d97108c294bfcd9acf4bd0491f7c6737c320f0e815ec732e4", size = 196454, upload-time = "2026-03-11T17:04:33.2Z" },
 ]
 
 [[package]]
@@ -346,7 +345,7 @@ name = "cryptography"
 version = "46.0.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "platform_python_implementation != 'PyPy' or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy' or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a4/ba/04b1bd4218cbc58dc90ce967106d51582371b898690f3ae0402876cc4f34/cryptography-46.0.6.tar.gz", hash = "sha256:27550628a518c5c6c903d84f637fbecf287f6cb9ced3804838a1295dc1fd0759", size = 750542, upload-time = "2026-03-25T23:34:53.396Z" }
 wheels = [
@@ -385,7 +384,7 @@ name = "cuda-bindings"
 version = "12.9.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-gpu') or (sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-vllm') or (sys_platform == 'emscripten' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'win32' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
+    { name = "cuda-pathfinder", marker = "extra == 'extra-6-server-gpu' or extra == 'extra-6-server-vllm'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/c2/65bfd79292b8ff18be4dd7f7442cea37bcbc1a228c1886f1dea515c45b67/cuda_bindings-12.9.4-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:694ba35023846625ef471257e6b5a4bc8af690f961d197d77d34b1d1db393f56", size = 11760260, upload-time = "2025-10-21T14:51:40.79Z" },
@@ -406,24 +405,10 @@ name = "cuda-python"
 version = "12.9.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-bindings", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "cuda-bindings" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/af/f3/6b032a554019cfb3447e671798c1bd3e79b5f1af20d10253f56cea269ef2/cuda_python-12.9.4-py3-none-any.whl", hash = "sha256:d2cacea882a69863f1e7d27ee71d75f0684f4c76910aff839067e4f89c902279", size = 7594, upload-time = "2025-10-21T14:55:12.846Z" },
-]
-
-[[package]]
-name = "cupy-cuda12x"
-version = "14.0.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cuda-pathfinder", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "numpy", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/ca/b93ef9fca1471a65f136a73e10819634c0b83427362fc08fc9f29f935bf0/cupy_cuda12x-14.0.1-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:f244bc14fad6f1ef0c74abd98afa4b82d2534aecdba911197810ec0047f0d1f3", size = 145578614, upload-time = "2026-02-20T10:22:49.108Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/a6/944406223a190815d9df156a1d66f3b0352bd8827dc4a8c752196d616dbc/cupy_cuda12x-14.0.1-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:9f0c81c3509f77be3ae8444759d5b314201b2dfcbbf2ae0d0b5fb7a61f20893c", size = 134613763, upload-time = "2026-02-20T10:22:56.792Z" },
-    { url = "https://files.pythonhosted.org/packages/11/fd/62e6e3f3c0c9f785b2dbdc2bff01bc375f5c6669d52e5e151f7aeb577801/cupy_cuda12x-14.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:63dc8a3a88d2ffd0386796b915d27acc7f2332c2291efd1ff4f0021b96f02051", size = 96267167, upload-time = "2026-02-20T10:23:02.263Z" },
 ]
 
 [[package]]
@@ -435,7 +420,7 @@ dependencies = [
     { name = "filelock" },
     { name = "fsspec", version = "2025.10.0", source = { registry = "https://pypi.org/simple" }, extra = ["http"], marker = "extra == 'extra-6-server-cpu' or extra == 'extra-6-server-gpu'" },
     { name = "httpx" },
-    { name = "huggingface-hub" },
+    { name = "huggingface-hub", version = "1.9.2", source = { registry = "https://pypi.org/simple" } },
     { name = "multiprocess" },
     { name = "numpy" },
     { name = "packaging" },
@@ -456,8 +441,8 @@ name = "depyf"
 version = "0.20.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "astor", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "dill", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "astor" },
+    { name = "dill" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/88/35/83fb0178212279aa0af031031905804c6de5618435d229f41ed21bb9ad2c/depyf-0.20.0.tar.gz", hash = "sha256:fb7683bd72c44f67b56029df2c47721e9a02ffa4d7b19095f1c54c4ebf797a98", size = 6168761, upload-time = "2025-10-13T12:33:38.589Z" }
 wheels = [
@@ -523,8 +508,8 @@ name = "email-validator"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "dnspython", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "idna", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "dnspython" },
+    { name = "idna" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
 wheels = [
@@ -549,14 +534,14 @@ wheels = [
 
 [package.optional-dependencies]
 standard = [
-    { name = "email-validator", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "fastapi-cli", extra = ["standard"], marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-vllm') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "httpx", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "jinja2", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "pydantic-extra-types", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "pydantic-settings", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "python-multipart", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "uvicorn", extra = ["standard"], marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-vllm') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+    { name = "email-validator" },
+    { name = "fastapi-cli", extra = ["standard"], marker = "(extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra != 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+    { name = "httpx" },
+    { name = "jinja2" },
+    { name = "pydantic-extra-types" },
+    { name = "pydantic-settings" },
+    { name = "python-multipart" },
+    { name = "uvicorn", extra = ["standard"], marker = "(extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra != 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
 ]
 
 [[package]]
@@ -564,9 +549,9 @@ name = "fastapi-cli"
 version = "0.0.23"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "rich-toolkit", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "typer", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "uvicorn", extra = ["standard"], marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-vllm') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+    { name = "rich-toolkit" },
+    { name = "typer" },
+    { name = "uvicorn", extra = ["standard"], marker = "(extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra != 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/71/9f/cbd463e57de4e977b8ea0403f95347f9150441568b1d3fe3e4949ef80ef3/fastapi_cli-0.0.23.tar.gz", hash = "sha256:210ac280ea41e73aac5a57688781256beb23c2cba3a41266896fa43e6445c8e7", size = 19763, upload-time = "2026-02-16T19:45:53.358Z" }
 wheels = [
@@ -575,8 +560,8 @@ wheels = [
 
 [package.optional-dependencies]
 standard = [
-    { name = "fastapi-cloud-cli", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "uvicorn", extra = ["standard"], marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-vllm') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+    { name = "fastapi-cloud-cli" },
+    { name = "uvicorn", extra = ["standard"], marker = "(extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra != 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
 ]
 
 [[package]]
@@ -584,14 +569,14 @@ name = "fastapi-cloud-cli"
 version = "0.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "fastar", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "httpx", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "pydantic", extra = ["email"], marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-vllm') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "rich-toolkit", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "rignore", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "sentry-sdk", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "typer", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "uvicorn", extra = ["standard"], marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-vllm') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+    { name = "fastar" },
+    { name = "httpx" },
+    { name = "pydantic", extra = ["email"], marker = "(extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra != 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+    { name = "rich-toolkit" },
+    { name = "rignore" },
+    { name = "sentry-sdk" },
+    { name = "typer" },
+    { name = "uvicorn", extra = ["standard"], marker = "(extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra != 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/de/0b/f07f4976784978ef159fd2e8f5c16f1f9d610578fb1fd976ff1315c11ea6/fastapi_cloud_cli-0.13.0.tar.gz", hash = "sha256:4d8f42337e8021c648f6cb0672de7d5b31b0fc7387a83d7b12f974600ac3f2fd", size = 38436, upload-time = "2026-02-17T05:18:19.033Z" }
 wheels = [
@@ -631,27 +616,35 @@ wheels = [
 ]
 
 [[package]]
+name = "flashinfer-cubin"
+version = "0.6.6"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/e8/826f9452bc5f76b94d7eb025f03dcaf1b51b9ed7790386c0285191e69be4/flashinfer_cubin-0.6.6-py3-none-any.whl", hash = "sha256:36508dfc792eb5ecfb15d2c140a7702812e1fa1ab0fb03929b2ed55e3e8191f3", size = 267661457, upload-time = "2026-03-11T01:36:36.538Z" },
+]
+
+[[package]]
 name = "flashinfer-python"
-version = "0.6.4"
+version = "0.6.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "apache-tvm-ffi", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "click", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "einops", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "ninja", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "numpy", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "nvidia-cudnn-frontend", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "nvidia-cutlass-dsl", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "nvidia-ml-py", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "packaging", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "requests", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "tabulate", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "torch", version = "2.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "tqdm", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "apache-tvm-ffi" },
+    { name = "click" },
+    { name = "einops" },
+    { name = "ninja" },
+    { name = "numpy" },
+    { name = "nvidia-cudnn-frontend" },
+    { name = "nvidia-cutlass-dsl" },
+    { name = "nvidia-ml-py" },
+    { name = "packaging" },
+    { name = "requests" },
+    { name = "tabulate" },
+    { name = "torch", version = "2.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" } },
+    { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/77/45/15645d2a4ee81d08206f3e132a77323e48312f510462415d7cd1122eba43/flashinfer_python-0.6.4.tar.gz", hash = "sha256:e6ab798bd1030e5ff7a3bc6952f36386c406928f60b79cf964a6db7aa7ccde75", size = 5337134, upload-time = "2026-02-19T07:33:36.647Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/70/c5a235297351021f5d3d3233523a85f5a6468495587489ad2f257e8eafe2/flashinfer_python-0.6.6.tar.gz", hash = "sha256:0730ba7c7aad332961933bcebc5119762797161ede57d955f6fd199818ed1d92", size = 5344156, upload-time = "2026-03-11T01:36:21.434Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/9a/d2bab76d2bb15062c6a2329614653e4f8bec9c78eec9069856ef0c7c0a79/flashinfer_python-0.6.4-py3-none-any.whl", hash = "sha256:105596b505892ae330af84e250ee0eb6fc2c3a22e8dc42bd46de1b90d36004c8", size = 7819999, upload-time = "2026-02-19T07:33:34.82Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/61/385d06755f3ab66333018285657adf0daf8a90a129448231fd09e315bd2e/flashinfer_python-0.6.6-py3-none-any.whl", hash = "sha256:078f158636969eec1a0d3dea19c3ca90b426b66df89bbf7b7b8276ce2ec08148", size = 7817047, upload-time = "2026-03-11T01:36:19.198Z" },
 ]
 
 [[package]]
@@ -684,9 +677,6 @@ name = "fsspec"
 version = "2025.10.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "sys_platform == 'win32' and extra != 'extra-6-server-cpu' and extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm'",
-    "sys_platform == 'emscripten' and extra != 'extra-6-server-cpu' and extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm'",
-    "sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-6-server-cpu' and extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm'",
     "sys_platform == 'win32' and extra != 'extra-6-server-cpu' and extra == 'extra-6-server-gpu' and extra != 'extra-6-server-vllm'",
     "sys_platform == 'emscripten' and extra != 'extra-6-server-cpu' and extra == 'extra-6-server-gpu' and extra != 'extra-6-server-vllm'",
     "sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-6-server-cpu' and extra == 'extra-6-server-gpu' and extra != 'extra-6-server-vllm'",
@@ -719,9 +709,9 @@ name = "gguf"
 version = "0.17.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "pyyaml", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "tqdm", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "numpy" },
+    { name = "pyyaml" },
+    { name = "tqdm" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/08/08/7de1ca4b71e7bf33b547f82bb22505e221b5fa42f67d635e200e0ad22ad6/gguf-0.17.1.tar.gz", hash = "sha256:36ad71aad900a3e75fc94ebe96ea6029f03a4e44be7627ef7ad3d03e8c7bcb53", size = 89338, upload-time = "2025-06-19T14:00:33.705Z" }
 wheels = [
@@ -814,19 +804,6 @@ wheels = [
 ]
 
 [[package]]
-name = "grpcio-reflection"
-version = "1.78.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "grpcio", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "protobuf", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/4d/f1/389fbbff18e84fdde609114eae37e74d8ae23e3f48266769d1fe2486b754/grpcio_reflection-1.78.1.tar.gz", hash = "sha256:224c0d604207954923fd6f8dbec541e0976a64ab1be65d2ee40844ce16c762ab", size = 19116, upload-time = "2026-02-20T01:21:49.703Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/29/8f3ad00c7cfd97decd0a9b1c0e5422adf684736c639c7a9d840a1f9166e6/grpcio_reflection-1.78.1-py3-none-any.whl", hash = "sha256:222c4c3d1367fc4c6bf53d556229e3735f54ab4710b4aee541f7f741de069ba0", size = 22801, upload-time = "2026-02-20T01:21:34.143Z" },
-]
-
-[[package]]
 name = "grpcio-status"
 version = "1.78.0"
 source = { registry = "https://pypi.org/simple" }
@@ -851,17 +828,18 @@ wheels = [
 
 [[package]]
 name = "hf-xet"
-version = "1.2.0"
+version = "1.4.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5e/6e/0f11bacf08a67f7fb5ee09740f2ca54163863b07b70d579356e9222ce5d8/hf_xet-1.2.0.tar.gz", hash = "sha256:a8c27070ca547293b6890c4bf389f713f80e8c478631432962bb7f4bc0bd7d7f", size = 506020, upload-time = "2025-10-24T19:04:32.129Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/92/ec9ad04d0b5728dca387a45af7bc98fbb0d73b2118759f5f6038b61a57e8/hf_xet-1.4.3.tar.gz", hash = "sha256:8ddedb73c8c08928c793df2f3401ec26f95be7f7e516a7bee2fbb546f6676113", size = 670477, upload-time = "2026-03-31T22:40:07.874Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/2d/22338486473df5923a9ab7107d375dbef9173c338ebef5098ef593d2b560/hf_xet-1.2.0-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:46740d4ac024a7ca9b22bebf77460ff43332868b661186a8e46c227fdae01848", size = 2866099, upload-time = "2025-10-24T19:04:15.366Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/8c/c5becfa53234299bc2210ba314eaaae36c2875e0045809b82e40a9544f0c/hf_xet-1.2.0-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:27df617a076420d8845bea087f59303da8be17ed7ec0cd7ee3b9b9f579dff0e4", size = 2722178, upload-time = "2025-10-24T19:04:13.695Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/92/cf3ab0b652b082e66876d08da57fcc6fa2f0e6c70dfbbafbd470bb73eb47/hf_xet-1.2.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3651fd5bfe0281951b988c0facbe726aa5e347b103a675f49a3fa8144c7968fd", size = 3320214, upload-time = "2025-10-24T19:04:03.596Z" },
-    { url = "https://files.pythonhosted.org/packages/46/92/3f7ec4a1b6a65bf45b059b6d4a5d38988f63e193056de2f420137e3c3244/hf_xet-1.2.0-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d06fa97c8562fb3ee7a378dd9b51e343bc5bc8190254202c9771029152f5e08c", size = 3229054, upload-time = "2025-10-24T19:04:01.949Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/dd/7ac658d54b9fb7999a0ccb07ad863b413cbaf5cf172f48ebcd9497ec7263/hf_xet-1.2.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:4c1428c9ae73ec0939410ec73023c4f842927f39db09b063b9482dac5a3bb737", size = 3413812, upload-time = "2025-10-24T19:04:24.585Z" },
-    { url = "https://files.pythonhosted.org/packages/92/68/89ac4e5b12a9ff6286a12174c8538a5930e2ed662091dd2572bbe0a18c8a/hf_xet-1.2.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a55558084c16b09b5ed32ab9ed38421e2d87cf3f1f89815764d1177081b99865", size = 3508920, upload-time = "2025-10-24T19:04:26.927Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/44/870d44b30e1dcfb6a65932e3e1506c103a8a5aea9103c337e7a53180322c/hf_xet-1.2.0-cp37-abi3-win_amd64.whl", hash = "sha256:e6584a52253f72c9f52f9e549d5895ca7a471608495c4ecaa6cc73dba2b24d69", size = 2905735, upload-time = "2025-10-24T19:04:35.928Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/9f/9c23e4a447b8f83120798f9279d0297a4d1360bdbf59ef49ebec78fe2545/hf_xet-1.4.3-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:d0da85329eaf196e03e90b84c2d0aca53bd4573d097a75f99609e80775f98025", size = 3805048, upload-time = "2026-03-31T22:39:53.105Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/f8/7aacb8e5f4a7899d39c787b5984e912e6c18b11be136ef13947d7a66d265/hf_xet-1.4.3-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:e23717ce4186b265f69afa66e6f0069fe7efbf331546f5c313d00e123dc84583", size = 3562178, upload-time = "2026-03-31T22:39:51.295Z" },
+    { url = "https://files.pythonhosted.org/packages/df/9a/a24b26dc8a65f0ecc0fe5be981a19e61e7ca963b85e062c083f3a9100529/hf_xet-1.4.3-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc360b70c815bf340ed56c7b8c63aacf11762a4b099b2fe2c9bd6d6068668c08", size = 4212320, upload-time = "2026-03-31T22:39:42.922Z" },
+    { url = "https://files.pythonhosted.org/packages/53/60/46d493db155d2ee2801b71fb1b0fd67696359047fdd8caee2c914cc50c79/hf_xet-1.4.3-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:39f2d2e9654cd9b4319885733993807aab6de9dfbd34c42f0b78338d6617421f", size = 3991546, upload-time = "2026-03-31T22:39:41.335Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/f5/067363e1c96c6b17256910830d1b54099d06287e10f4ec6ec4e7e08371fc/hf_xet-1.4.3-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:49ad8a8cead2b56051aa84d7fce3e1335efe68df3cf6c058f22a65513885baac", size = 4193200, upload-time = "2026-03-31T22:40:01.936Z" },
+    { url = "https://files.pythonhosted.org/packages/42/4b/53951592882d9c23080c7644542fda34a3813104e9e11fa1a7d82d419cb8/hf_xet-1.4.3-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7716d62015477a70ea272d2d68cd7cad140f61c52ee452e133e139abfe2c17ba", size = 4429392, upload-time = "2026-03-31T22:40:03.492Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/21/75a6c175b4e79662ad8e62f46a40ce341d8d6b206b06b4320d07d55b188c/hf_xet-1.4.3-cp37-abi3-win_amd64.whl", hash = "sha256:6b591fcad34e272a5b02607485e4f2a1334aebf1bc6d16ce8eb1eb8978ac2021", size = 3677359, upload-time = "2026-03-31T22:40:13.619Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/7c/44314ecd0e89f8b2b51c9d9e5e7a60a9c1c82024ac471d415860557d3cd8/hf_xet-1.4.3-cp37-abi3-win_arm64.whl", hash = "sha256:7c2c7e20bcfcc946dc67187c203463f5e932e395845d098cc2a93f5b67ca0b47", size = 3533664, upload-time = "2026-03-31T22:40:12.152Z" },
 ]
 
 [[package]]
@@ -921,19 +899,47 @@ name = "huggingface-hub"
 version = "0.36.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "filelock" },
-    { name = "fsspec", version = "2025.10.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-6-server-cpu' or extra == 'extra-6-server-gpu'" },
-    { name = "fsspec", version = "2026.2.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
-    { name = "hf-xet", marker = "platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
-    { name = "packaging" },
-    { name = "pyyaml" },
-    { name = "requests" },
-    { name = "tqdm" },
-    { name = "typing-extensions" },
+    { name = "filelock", marker = "(extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra != 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+    { name = "fsspec", version = "2026.2.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra != 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+    { name = "hf-xet", marker = "(platform_machine == 'aarch64' and extra == 'extra-6-server-vllm') or (platform_machine == 'amd64' and extra == 'extra-6-server-vllm') or (platform_machine == 'arm64' and extra == 'extra-6-server-vllm') or (platform_machine == 'x86_64' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+    { name = "packaging", marker = "(extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra != 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+    { name = "pyyaml", marker = "(extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra != 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+    { name = "requests", marker = "(extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra != 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+    { name = "tqdm", marker = "(extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra != 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+    { name = "typing-extensions", marker = "(extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra != 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7c/b7/8cb61d2eece5fb05a83271da168186721c450eb74e3c31f7ef3169fa475b/huggingface_hub-0.36.2.tar.gz", hash = "sha256:1934304d2fb224f8afa3b87007d58501acfda9215b334eed53072dd5e815ff7a", size = 649782, upload-time = "2026-02-06T09:24:13.098Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a8/af/48ac8483240de756d2438c380746e7130d1c6f75802ef22f3c6d49982787/huggingface_hub-0.36.2-py3-none-any.whl", hash = "sha256:48f0c8eac16145dfce371e9d2d7772854a4f591bcb56c9cf548accf531d54270", size = 566395, upload-time = "2026-02-06T09:24:11.133Z" },
+]
+
+[[package]]
+name = "huggingface-hub"
+version = "1.9.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "sys_platform == 'win32' and extra != 'extra-6-server-cpu' and extra == 'extra-6-server-gpu' and extra != 'extra-6-server-vllm'",
+    "sys_platform == 'emscripten' and extra != 'extra-6-server-cpu' and extra == 'extra-6-server-gpu' and extra != 'extra-6-server-vllm'",
+    "sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-6-server-cpu' and extra == 'extra-6-server-gpu' and extra != 'extra-6-server-vllm'",
+    "sys_platform == 'win32' and extra == 'extra-6-server-cpu' and extra != 'extra-6-server-gpu' and extra != 'extra-6-server-vllm'",
+    "sys_platform == 'emscripten' and extra == 'extra-6-server-cpu' and extra != 'extra-6-server-gpu' and extra != 'extra-6-server-vllm'",
+    "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-cpu' and extra != 'extra-6-server-gpu' and extra != 'extra-6-server-vllm'",
+    "sys_platform == 'darwin' and extra == 'extra-6-server-cpu' and extra != 'extra-6-server-gpu' and extra != 'extra-6-server-vllm'",
+]
+dependencies = [
+    { name = "filelock", marker = "extra == 'extra-6-server-cpu' or extra == 'extra-6-server-gpu'" },
+    { name = "fsspec", version = "2025.10.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-6-server-cpu' or extra == 'extra-6-server-gpu'" },
+    { name = "hf-xet", marker = "(platform_machine == 'AMD64' and extra == 'extra-6-server-cpu') or (platform_machine == 'AMD64' and extra == 'extra-6-server-gpu') or (platform_machine == 'aarch64' and extra == 'extra-6-server-cpu') or (platform_machine == 'aarch64' and extra == 'extra-6-server-gpu') or (platform_machine == 'amd64' and extra == 'extra-6-server-cpu') or (platform_machine == 'amd64' and extra == 'extra-6-server-gpu') or (platform_machine == 'arm64' and extra == 'extra-6-server-cpu') or (platform_machine == 'arm64' and extra == 'extra-6-server-gpu') or (platform_machine == 'x86_64' and extra == 'extra-6-server-cpu') or (platform_machine == 'x86_64' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
+    { name = "httpx", marker = "extra == 'extra-6-server-cpu' or extra == 'extra-6-server-gpu'" },
+    { name = "packaging", marker = "extra == 'extra-6-server-cpu' or extra == 'extra-6-server-gpu'" },
+    { name = "pyyaml", marker = "extra == 'extra-6-server-cpu' or extra == 'extra-6-server-gpu'" },
+    { name = "tqdm", marker = "extra == 'extra-6-server-cpu' or extra == 'extra-6-server-gpu'" },
+    { name = "typer", marker = "extra == 'extra-6-server-cpu' or extra == 'extra-6-server-gpu'" },
+    { name = "typing-extensions", marker = "extra == 'extra-6-server-cpu' or extra == 'extra-6-server-gpu'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cf/65/fb800d327bf25bf31b798dd08935d326d064ecb9b359059fecd91b3a98e8/huggingface_hub-1.9.2.tar.gz", hash = "sha256:8d09d080a186bd950a361bfc04b862dfb04d6a2b41d48e9ba1b37507cfd3f1e1", size = 750284, upload-time = "2026-04-08T08:43:11.127Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/d4/e33bf0b362810a9b96c5923e38908950d58ecb512db42e3730320c7f4a3a/huggingface_hub-1.9.2-py3-none-any.whl", hash = "sha256:e1e62ce237d4fbeca9f970aeb15176fbd503e04c25577bfd22f44aa7aa2b5243", size = 637349, upload-time = "2026-04-08T08:43:09.114Z" },
 ]
 
 [[package]]
@@ -1036,10 +1042,10 @@ name = "jsonschema"
 version = "4.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "jsonschema-specifications", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "referencing", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "rpds-py", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
 wheels = [
@@ -1051,25 +1057,11 @@ name = "jsonschema-specifications"
 version = "2025.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "referencing", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "referencing" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
-]
-
-[[package]]
-name = "kaldi-native-fbank"
-version = "1.22.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3a/2c/84076b352107ce12d56f28c313f1aca1be332d953dd96aec7b84976e6d53/kaldi-native-fbank-1.22.3.tar.gz", hash = "sha256:387bf87225c6b83c93ae652eeaef1b4d531994b6e398e7a77189de340674f9af", size = 71013, upload-time = "2025-10-09T02:31:21.487Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/de/fbdbfcc75fad9d9a6f9a250bc986f1002902581eaa47a5948f53a7f11851/kaldi_native_fbank-1.22.3-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:7f636ccdea28bd187f93b06a1e4b9275e42e43af9405b0684fc739e829299c4b", size = 249003, upload-time = "2025-10-09T02:29:48.509Z" },
-    { url = "https://files.pythonhosted.org/packages/77/64/e57ce185dda028b7b9af72cdfb16825bfa52183653945681e7cb8e7c2dfa/kaldi_native_fbank-1.22.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:abd31a8bfe1db62a7ddb0beee84f3a5de9bb559fcdd2b96ca0fb729c551b9412", size = 228933, upload-time = "2025-10-09T02:31:35.8Z" },
-    { url = "https://files.pythonhosted.org/packages/43/28/6f4fd8953c0b3f30de4526fd024095032abcdc25b6736c77a891687c604e/kaldi_native_fbank-1.22.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5a44b4a83cf9bf13d3f77858928068b06d3ec2238c27ff2e39393fbf7749c9f", size = 298887, upload-time = "2025-10-09T02:30:53.739Z" },
-    { url = "https://files.pythonhosted.org/packages/84/90/01ef7331c52b1eaf9916f3f7a535155aac2e9e2ddad12a141613d92758c7/kaldi_native_fbank-1.22.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f16e74372fe9e20abb4183f98a8e2288d5ee4c48d04d94b6160311170e007661", size = 322002, upload-time = "2025-10-09T02:30:13.04Z" },
-    { url = "https://files.pythonhosted.org/packages/66/1c/fce142bd3aeadb1292360a90ceb91f923c8e12081c21576fe69917243c5f/kaldi_native_fbank-1.22.3-cp312-cp312-win32.whl", hash = "sha256:a90f51377569575fc0d1a66ef7e89a36102bfb6dcd1d15d6c4afb930ce726672", size = 273308, upload-time = "2025-10-09T02:29:59.931Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/8d/c0b0b6280edabad85d7e15093fad612c027e175fe4e0b960ce2f36485143/kaldi_native_fbank-1.22.3-cp312-cp312-win_amd64.whl", hash = "sha256:cbbeea19fe6d584c54e93fe6615a7185b10e0d78fdb6471f9e44596018437c38", size = 308023, upload-time = "2025-10-09T02:28:43.909Z" },
 ]
 
 [[package]]
@@ -1114,10 +1106,10 @@ name = "lm-format-enforcer"
 version = "0.11.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "interegular", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "packaging", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "pydantic", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "pyyaml", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "interegular" },
+    { name = "packaging" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/84/d5/41cd417ba7dfdbbcfe46cebf81fb3dfd7c591b89897560ad05bb410a465d/lm_format_enforcer-0.11.3.tar.gz", hash = "sha256:e68081c108719cce284a9bcc889709b26ffb085a1945b5eba3a12cfa96d528da", size = 40258, upload-time = "2025-08-24T19:37:47.527Z" }
 wheels = [
@@ -1129,8 +1121,8 @@ name = "loguru"
 version = "0.7.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32' and extra != 'extra-6-server-gpu'" },
-    { name = "win32-setctime", marker = "sys_platform == 'win32' and extra != 'extra-6-server-gpu'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "win32-setctime", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6", size = 63559, upload-time = "2024-12-06T11:20:56.608Z" }
 wheels = [
@@ -1142,7 +1134,7 @@ name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mdurl", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "mdurl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
 wheels = [
@@ -1173,20 +1165,20 @@ name = "mcp"
 version = "1.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "httpx", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "httpx-sse", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "jsonschema", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "pydantic", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "pydantic-settings", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "pyjwt", extra = ["crypto"], marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-vllm') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "python-multipart", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "pywin32", marker = "sys_platform == 'win32' and extra != 'extra-6-server-gpu'" },
-    { name = "sse-starlette", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "starlette", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "typing-extensions", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "typing-inspection", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "uvicorn", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"], marker = "(extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra != 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fc/6d/62e76bbb8144d6ed86e202b5edd8a4cb631e7c8130f3f4893c3f90262b10/mcp-1.26.0.tar.gz", hash = "sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66", size = 608005, upload-time = "2026-01-24T19:40:32.468Z" }
 wheels = [
@@ -1204,69 +1196,26 @@ wheels = [
 
 [[package]]
 name = "mistral-common"
-version = "1.9.1"
+version = "1.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jsonschema", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "numpy", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "pillow", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "pydantic", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "pydantic-extra-types", extra = ["pycountry"], marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-vllm') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "requests", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "tiktoken", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "typing-extensions", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "jsonschema" },
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "pydantic" },
+    { name = "pydantic-extra-types", extra = ["pycountry"], marker = "(extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra != 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+    { name = "requests" },
+    { name = "tiktoken" },
+    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/db/ce/685b8127a326478e05501cb4c9ca23d1cd9f37e16c465a1e832c75aea709/mistral_common-1.9.1.tar.gz", hash = "sha256:550583d70a395c3586cfb748ffab53bd1d7c3409507f0efc0118bff30ffb26e9", size = 6338922, upload-time = "2026-02-12T10:53:41.639Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/97/753c85b5c0a19f4331ac99e0300ac8da06d4b29b629c9cb03064b38561bd/mistral_common-1.11.0.tar.gz", hash = "sha256:439b7fa38f9c3f020154af51bdf30eb81def507643017d8ce9f798384ec47ec3", size = 6355512, upload-time = "2026-04-01T13:54:12.36Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ac/72/a38bb1fd9fd4d4ef990341c9dd1a7c8061f1951e10efa6d50c0a3f04eced/mistral_common-1.9.1-py3-none-any.whl", hash = "sha256:9e2b2520b6f67bac2e2bb06fcf985b7a1277b01938da2b7cda8cf0fdbfa92e91", size = 6518623, upload-time = "2026-02-12T10:53:39.457Z" },
+    { url = "https://files.pythonhosted.org/packages/60/e4/73ad3c27e3fb613c3ce0953c928202c46cddebac3989b87be1b6f305a9f6/mistral_common-1.11.0-py3-none-any.whl", hash = "sha256:1d3ecaf7c3aa7338cb37b596fd0fb294485753958ee8e7254a6cc23eb30b249b", size = 6531513, upload-time = "2026-04-01T13:54:16.536Z" },
 ]
 
 [package.optional-dependencies]
 image = [
-    { name = "opencv-python-headless", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-]
-
-[[package]]
-name = "mlx"
-version = "0.31.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mlx-metal", marker = "sys_platform == 'darwin'" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/29/71fe1f68756f515856e6930973c23245810d4aa3cd22fddd719d86a709dc/mlx-0.31.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:8a63b31a398c9519f2bb0c81cf3865d9baca4ff573ffc31ead465d18286184e8", size = 574308, upload-time = "2026-03-12T02:16:10.256Z" },
-    { url = "https://files.pythonhosted.org/packages/21/be/70654a2cee0d71fd10bd237a50a79d06ae51679a194db6a3b16c0c84e6a5/mlx-0.31.1-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:a7a9347df4dcc41f0d16ff70b65650820af4879f686534b233b16826a22afa00", size = 574309, upload-time = "2026-03-12T02:16:11.577Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/69/c7bc7b04f76b0cbd678f328011d1634bd0bcfc2da45aba06e084cb031127/mlx-0.31.1-cp312-cp312-macosx_26_0_arm64.whl", hash = "sha256:6cdb797ea31787d1ce9e5be77991c4bd5cbf129ab15f7253b78e09737f535fce", size = 574289, upload-time = "2026-03-12T02:16:13.146Z" },
-    { url = "https://files.pythonhosted.org/packages/55/f7/dcc129228faab4d406041d91413c5999250ab79da6fe5417ac84f1616ff1/mlx-0.31.1-cp312-cp312-manylinux_2_35_aarch64.whl", hash = "sha256:1ed1991c8e39f841d5756c0c543beb819763a2f80fba3f4b150bc6cad4d973de", size = 626439, upload-time = "2026-03-12T02:16:14.741Z" },
-    { url = "https://files.pythonhosted.org/packages/90/1d/8b32e46ea98ab5c1c15cf1b37ac97af651977f84e72e1800412a700c51d9/mlx-0.31.1-cp312-cp312-manylinux_2_35_x86_64.whl", hash = "sha256:195c5cb27328380287c0ffe9ef48f860ab75ec5d3dfce153d475dc2c99369708", size = 668679, upload-time = "2026-03-12T02:16:16.012Z" },
-]
-
-[[package]]
-name = "mlx-lm"
-version = "0.29.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "jinja2", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "mlx", marker = "sys_platform == 'darwin'" },
-    { name = "numpy", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "protobuf", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "pyyaml", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "sentencepiece", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "transformers", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e3/62/f46e1355256a114808517947f8e83ad6be310c7288c551db0fa678f47923/mlx_lm-0.29.1.tar.gz", hash = "sha256:b99180d8f33d33a077b814e550bfb2d8a59ae003d668fd1f4b3fff62a381d34b", size = 232302, upload-time = "2025-12-16T16:58:27.959Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/53/913099c91d384e115ea078325efd9a0bc1ea3eb3458c694b4596cbd267f2/mlx_lm-0.29.1-py3-none-any.whl", hash = "sha256:440941b3054c2a2216e97615de584cc90fa1ea874782e20699b9895721fad8dc", size = 324884, upload-time = "2025-12-16T16:58:26.36Z" },
-]
-
-[[package]]
-name = "mlx-metal"
-version = "0.31.1"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/66/2313497fdbc7fbadf8e026c09366e3f049f9114e65ca4edc23cdb8699186/mlx_metal-0.31.1-py3-none-macosx_14_0_arm64.whl", hash = "sha256:70741174131dbf7fdd479cb730e06e08c358eac3bf7905d9e884e7960cfdd5b8", size = 38624074, upload-time = "2026-03-12T02:15:48.036Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/34/4c3c6890ce6095b2ab2ba2f5f15c9a7ba17208d47f8cacb572885a2dc0eb/mlx_metal-0.31.1-py3-none-macosx_15_0_arm64.whl", hash = "sha256:6c56bd8cd27743e635f5a90a22535af7c31bd22b4b126d46b6da2da52d72e413", size = 38618950, upload-time = "2026-03-12T02:15:51.908Z" },
-    { url = "https://files.pythonhosted.org/packages/51/bc/987cb99e3aafb296aa11ce5133838a10eae8447edd53168d0804d4fb3a14/mlx_metal-0.31.1-py3-none-macosx_26_0_arm64.whl", hash = "sha256:e7324b7c56b519ae67c025d3ced07e5d35bc3a9f19d4c45fe4927f385148c59e", size = 49256543, upload-time = "2026-03-12T02:15:54.851Z" },
+    { name = "opencv-python-headless" },
 ]
 
 [[package]]
@@ -1274,13 +1223,13 @@ name = "model-hosting-container-standards"
 version = "0.1.13"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "fastapi", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "httpx", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "jmespath", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "pydantic", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "setuptools", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "starlette", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "supervisor", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "fastapi" },
+    { name = "httpx" },
+    { name = "jmespath" },
+    { name = "pydantic" },
+    { name = "setuptools" },
+    { name = "starlette" },
+    { name = "supervisor" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d7/b7/a6a31b4dfd30d14b1019dc358f09c9d88ca38e555ba7c976e7d3e6b593fe/model_hosting_container_standards-0.1.13.tar.gz", hash = "sha256:27a1333410dde2719286a300a2803e24fdde407baa91894eb845c0f268aa194d", size = 79116, upload-time = "2026-01-09T21:45:20.683Z" }
 wheels = [
@@ -1294,23 +1243,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
-]
-
-[[package]]
-name = "msgpack"
-version = "1.1.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4d/f2/bfb55a6236ed8725a96b0aa3acbd0ec17588e6a2c3b62a93eb513ed8783f/msgpack-1.1.2.tar.gz", hash = "sha256:3b60763c1373dd60f398488069bcdc703cd08a711477b5d480eecc9f9626f47e", size = 173581, upload-time = "2025-10-08T09:15:56.596Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ad/bd/8b0d01c756203fbab65d265859749860682ccd2a59594609aeec3a144efa/msgpack-1.1.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:70a0dff9d1f8da25179ffcf880e10cf1aad55fdb63cd59c9a49a1b82290062aa", size = 81939, upload-time = "2025-10-08T09:15:01.472Z" },
-    { url = "https://files.pythonhosted.org/packages/34/68/ba4f155f793a74c1483d4bdef136e1023f7bcba557f0db4ef3db3c665cf1/msgpack-1.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:446abdd8b94b55c800ac34b102dffd2f6aa0ce643c55dfc017ad89347db3dbdb", size = 85064, upload-time = "2025-10-08T09:15:03.764Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/60/a064b0345fc36c4c3d2c743c82d9100c40388d77f0b48b2f04d6041dbec1/msgpack-1.1.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c63eea553c69ab05b6747901b97d620bb2a690633c77f23feb0c6a947a8a7b8f", size = 417131, upload-time = "2025-10-08T09:15:05.136Z" },
-    { url = "https://files.pythonhosted.org/packages/65/92/a5100f7185a800a5d29f8d14041f61475b9de465ffcc0f3b9fba606e4505/msgpack-1.1.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:372839311ccf6bdaf39b00b61288e0557916c3729529b301c52c2d88842add42", size = 427556, upload-time = "2025-10-08T09:15:06.837Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/87/ffe21d1bf7d9991354ad93949286f643b2bb6ddbeab66373922b44c3b8cc/msgpack-1.1.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2929af52106ca73fcb28576218476ffbb531a036c2adbcf54a3664de124303e9", size = 404920, upload-time = "2025-10-08T09:15:08.179Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/41/8543ed2b8604f7c0d89ce066f42007faac1eaa7d79a81555f206a5cdb889/msgpack-1.1.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:be52a8fc79e45b0364210eef5234a7cf8d330836d0a64dfbb878efa903d84620", size = 415013, upload-time = "2025-10-08T09:15:09.83Z" },
-    { url = "https://files.pythonhosted.org/packages/41/0d/2ddfaa8b7e1cee6c490d46cb0a39742b19e2481600a7a0e96537e9c22f43/msgpack-1.1.2-cp312-cp312-win32.whl", hash = "sha256:1fff3d825d7859ac888b0fbda39a42d59193543920eda9d9bea44d958a878029", size = 65096, upload-time = "2025-10-08T09:15:11.11Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/ec/d431eb7941fb55a31dd6ca3404d41fbb52d99172df2e7707754488390910/msgpack-1.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:1de460f0403172cff81169a30b9a92b260cb809c4cb7e2fc79ae8d0510c78b6b", size = 72708, upload-time = "2025-10-08T09:15:12.554Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/31/5b1a1f70eb0e87d1678e9624908f86317787b536060641d6798e3cf70ace/msgpack-1.1.2-cp312-cp312-win_arm64.whl", hash = "sha256:be5980f3ee0e6bd44f3a9e9dea01054f175b50c3e6cdb692bc9424c0bbb8bf69", size = 64119, upload-time = "2025-10-08T09:15:13.589Z" },
 ]
 
 [[package]]
@@ -1412,8 +1344,8 @@ name = "numba"
 version = "0.61.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "llvmlite", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "numpy", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "llvmlite" },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/a0/e21f57604304aa03ebb8e098429222722ad99176a4f979d34af1d1ee80da/numba-0.61.2.tar.gz", hash = "sha256:8750ee147940a6637b80ecf7f95062185ad8726c8c28a2295b8ec1160a196f7d", size = 2820615, upload-time = "2025-04-09T02:58:07.659Z" }
 wheels = [
@@ -1487,7 +1419,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-gpu') or (sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-vllm') or (sys_platform == 'emscripten' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'win32' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
+    { name = "nvidia-cublas-cu12", marker = "extra == 'extra-6-server-gpu' or extra == 'extra-6-server-vllm'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/41/e79269ce215c857c935fd86bcfe91a451a584dfc27f1e068f568b9ad1ab7/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:c9132cc3f8958447b4910a1720036d9eff5928cc3179b0a51fb6d167c6cc87d8", size = 705026878, upload-time = "2025-06-06T21:52:51.348Z" },
@@ -1510,7 +1442,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-gpu') or (sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-vllm') or (sys_platform == 'emscripten' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'win32' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
+    { name = "nvidia-nvjitlink-cu12", marker = "extra == 'extra-6-server-gpu' or extra == 'extra-6-server-vllm'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/60/bc/7771846d3a0272026c416fbb7e5f4c1f146d6d80704534d0b187dd6f4800/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:848ef7224d6305cdb2a4df928759dca7b1201874787083b6e7550dd6765ce69a", size = 193109211, upload-time = "2025-03-07T01:44:56.873Z" },
@@ -1542,9 +1474,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-gpu') or (sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-vllm') or (sys_platform == 'emscripten' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'win32' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
-    { name = "nvidia-cusparse-cu12", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-gpu') or (sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-vllm') or (sys_platform == 'emscripten' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'win32' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
-    { name = "nvidia-nvjitlink-cu12", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-gpu') or (sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-vllm') or (sys_platform == 'emscripten' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'win32' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
+    { name = "nvidia-cublas-cu12", marker = "extra == 'extra-6-server-gpu' or extra == 'extra-6-server-vllm'" },
+    { name = "nvidia-cusparse-cu12", marker = "extra == 'extra-6-server-gpu' or extra == 'extra-6-server-vllm'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "extra == 'extra-6-server-gpu' or extra == 'extra-6-server-vllm'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/32/f7cd6ce8a7690544d084ea21c26e910a97e077c9b7f07bf5de623ee19981/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:db9ed69dbef9715071232caa9b69c52ac7de3a95773c2db65bdba85916e4e5c0", size = 267229841, upload-time = "2025-03-07T01:46:54.356Z" },
@@ -1557,7 +1489,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-gpu') or (sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-vllm') or (sys_platform == 'emscripten' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'win32' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
+    { name = "nvidia-nvjitlink-cu12", marker = "extra == 'extra-6-server-gpu' or extra == 'extra-6-server-vllm'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bc/f7/cd777c4109681367721b00a106f491e0d0d15cfa1fd59672ce580ce42a97/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9b6c161cb130be1a07a27ea6923df8141f3c295852f4b260c65f18f3e0a091dc", size = 288117129, upload-time = "2025-03-07T01:47:40.407Z" },
@@ -1580,7 +1512,7 @@ name = "nvidia-cutlass-dsl"
 version = "4.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cutlass-dsl-libs-base", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "nvidia-cutlass-dsl-libs-base" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/55/09/42fca58af350265131b6f8665ad5b62526c95e6692788460bd5306d3efe2/nvidia_cutlass_dsl-4.4.0-py3-none-any.whl", hash = "sha256:2d1f34333e4d774002d44b53262d71aaf738700fcf3858290629f9a7b374c61c", size = 10168, upload-time = "2026-02-14T03:38:54.267Z" },
@@ -1591,9 +1523,9 @@ name = "nvidia-cutlass-dsl-libs-base"
 version = "4.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-python", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "numpy", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "typing-extensions", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "cuda-python" },
+    { name = "numpy" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/34/63a1dce4d65cd6fd29b9d50286abbfcdd965c3ca2156cf423eda2ab1fc5d/nvidia_cutlass_dsl_libs_base-4.4.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:9cde72efb065d9bea29a92ca85835eaedec20bf89af22798d2d2a551ccd51731", size = 75458501, upload-time = "2026-02-14T03:45:15.866Z" },
@@ -1652,14 +1584,14 @@ name = "openai"
 version = "2.22.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "distro", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "httpx", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "jiter", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "pydantic", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "sniffio", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "tqdm", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "typing-extensions", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/73/ed/0a004a42fea6b6f3dd4ab33235183e994a4c7ade214fba10d9494577ec04/openai-2.22.0.tar.gz", hash = "sha256:fc2ea71c79951ac3faf178ff72c766bb4b09c3e9aab277184c5260ab3e94294f", size = 657093, upload-time = "2026-02-23T20:14:31.017Z" }
 wheels = [
@@ -1671,7 +1603,7 @@ name = "openai-harmony"
 version = "0.0.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "pydantic" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3e/92/2d038d096f29179c7c9571b431f9e739f87a487121901725e23fe338dd9d/openai_harmony-0.0.8.tar.gz", hash = "sha256:6e43f98e6c242fa2de6f8ea12eab24af63fa2ed3e89c06341fb9d92632c5cbdf", size = 284777, upload-time = "2025-11-05T19:07:06.727Z" }
 wheels = [
@@ -1694,7 +1626,7 @@ name = "opencv-python-headless"
 version = "4.13.0.92"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "numpy" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/42/2310883be3b8826ac58c3f2787b9358a2d46923d61f88fedf930bc59c60c/opencv_python_headless-4.13.0.92-cp37-abi3-macosx_13_0_arm64.whl", hash = "sha256:1a7d040ac656c11b8c38677cc8cccdc149f98535089dbe5b081e80a4e5903209", size = 46247192, upload-time = "2026-02-05T07:01:35.187Z" },
@@ -1740,8 +1672,8 @@ name = "opentelemetry-exporter-otlp"
 version = "1.40.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "opentelemetry-exporter-otlp-proto-grpc", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "opentelemetry-exporter-otlp-proto-http", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d0/37/b6708e0eff5c5fb9aba2e0ea09f7f3bcbfd12a592d2a780241b5f6014df7/opentelemetry_exporter_otlp-1.40.0.tar.gz", hash = "sha256:7caa0870b95e2fcb59d64e16e2b639ecffb07771b6cd0000b5d12e5e4fef765a", size = 6152, upload-time = "2026-03-04T14:17:23.235Z" }
 wheels = [
@@ -1753,7 +1685,7 @@ name = "opentelemetry-exporter-otlp-proto-common"
 version = "1.40.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "opentelemetry-proto", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "opentelemetry-proto" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/51/bc/1559d46557fe6eca0b46c88d4c2676285f1f3be2e8d06bb5d15fbffc814a/opentelemetry_exporter_otlp_proto_common-1.40.0.tar.gz", hash = "sha256:1cbee86a4064790b362a86601ee7934f368b81cd4cc2f2e163902a6e7818a0fa", size = 20416, upload-time = "2026-03-04T14:17:23.801Z" }
 wheels = [
@@ -1765,13 +1697,13 @@ name = "opentelemetry-exporter-otlp-proto-grpc"
 version = "1.40.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "googleapis-common-protos", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "grpcio", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "opentelemetry-api", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "opentelemetry-exporter-otlp-proto-common", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "opentelemetry-proto", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "opentelemetry-sdk", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "typing-extensions", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8f/7f/b9e60435cfcc7590fa87436edad6822240dddbc184643a2a005301cc31f4/opentelemetry_exporter_otlp_proto_grpc-1.40.0.tar.gz", hash = "sha256:bd4015183e40b635b3dab8da528b27161ba83bf4ef545776b196f0fb4ec47740", size = 25759, upload-time = "2026-03-04T14:17:24.4Z" }
 wheels = [
@@ -1783,13 +1715,13 @@ name = "opentelemetry-exporter-otlp-proto-http"
 version = "1.40.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "googleapis-common-protos", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "opentelemetry-api", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "opentelemetry-exporter-otlp-proto-common", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "opentelemetry-proto", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "opentelemetry-sdk", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "requests", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "typing-extensions", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2e/fa/73d50e2c15c56be4d000c98e24221d494674b0cc95524e2a8cb3856d95a4/opentelemetry_exporter_otlp_proto_http-1.40.0.tar.gz", hash = "sha256:db48f5e0f33217588bbc00274a31517ba830da576e59503507c839b38fa0869c", size = 17772, upload-time = "2026-03-04T14:17:25.324Z" }
 wheels = [
@@ -1848,7 +1780,7 @@ name = "opentelemetry-proto"
 version = "1.40.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "protobuf", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "protobuf" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4c/77/dd38991db037fdfce45849491cb61de5ab000f49824a00230afb112a4392/opentelemetry_proto-1.40.0.tar.gz", hash = "sha256:03f639ca129ba513f5819810f5b1f42bcb371391405d99c168fe6937c62febcd", size = 45667, upload-time = "2026-03-04T14:17:31.194Z" }
 wheels = [
@@ -1902,8 +1834,8 @@ name = "opentelemetry-semantic-conventions-ai"
 version = "0.4.15"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "opentelemetry-sdk", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "opentelemetry-semantic-conventions", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "opentelemetry-sdk" },
+    { name = "opentelemetry-semantic-conventions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e9/75/455c15f8360b475dd31101a87eab316420388486f7941bf019cbf4e63d5b/opentelemetry_semantic_conventions_ai-0.4.15.tar.gz", hash = "sha256:12de172d1e11d21c6e82bbf578c7e8a713589a7fda76af9ed785632564a28b81", size = 18595, upload-time = "2026-03-02T15:36:50.254Z" }
 wheels = [
@@ -1980,18 +1912,17 @@ version = "0.18.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "accelerate" },
-    { name = "huggingface-hub" },
+    { name = "huggingface-hub", version = "1.9.2", source = { registry = "https://pypi.org/simple" } },
     { name = "numpy" },
     { name = "packaging" },
     { name = "psutil" },
     { name = "pyyaml" },
     { name = "safetensors" },
-    { name = "torch", version = "2.10.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-6-server-cpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "torch", version = "2.10.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform == 'emscripten' and extra == 'extra-6-server-gpu') or (sys_platform == 'win32' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "torch", version = "2.10.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-cpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "torch", version = "2.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+    { name = "torch", version = "2.10.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-6-server-cpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
+    { name = "torch", version = "2.10.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-cpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
+    { name = "torch", version = "2.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "extra == 'extra-6-server-gpu' or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
     { name = "tqdm" },
-    { name = "transformers" },
+    { name = "transformers", version = "5.5.0", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d8/48/147b3ea999560b40a34fd78724c7777aa9d18409c2250bdcaf9c4f2db7fc/peft-0.18.1.tar.gz", hash = "sha256:2dd0d6bfce936d1850e48aaddbd250941c5c02fc8ef3237cd8fd5aac35e0bae2", size = 635030, upload-time = "2026-01-09T13:08:01.136Z" }
 wheels = [
@@ -2031,8 +1962,8 @@ name = "prometheus-fastapi-instrumentator"
 version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "prometheus-client", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "starlette", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "prometheus-client" },
+    { name = "starlette" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/69/6d/24d53033cf93826aa7857699a4450c1c67e5b9c710e925b1ed2b320c04df/prometheus_fastapi_instrumentator-7.1.0.tar.gz", hash = "sha256:be7cd61eeea4e5912aeccb4261c6631b3f227d8924542d79eaf5af3f439cbe5e", size = 20220, upload-time = "2025-03-19T19:35:05.351Z" }
 wheels = [
@@ -2218,7 +2149,7 @@ wheels = [
 
 [package.optional-dependencies]
 email = [
-    { name = "email-validator", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "email-validator" },
 ]
 
 [[package]]
@@ -2255,8 +2186,8 @@ name = "pydantic-extra-types"
 version = "2.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "typing-extensions", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "pydantic" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fd/35/2fee58b1316a73e025728583d3b1447218a97e621933fc776fb8c0f2ebdd/pydantic_extra_types-2.11.0.tar.gz", hash = "sha256:4e9991959d045b75feb775683437a97991d02c138e00b59176571db9ce634f0e", size = 157226, upload-time = "2025-12-31T16:18:27.944Z" }
 wheels = [
@@ -2265,7 +2196,7 @@ wheels = [
 
 [package.optional-dependencies]
 pycountry = [
-    { name = "pycountry", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "pycountry" },
 ]
 
 [[package]]
@@ -2273,9 +2204,9 @@ name = "pydantic-settings"
 version = "2.13.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "python-dotenv", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "typing-inspection", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/52/6d/fffca34caecc4a3f97bda81b2098da5e8ab7efc9a66e819074a11955d87e/pydantic_settings-2.13.1.tar.gz", hash = "sha256:b4c11847b15237fb0171e1462bf540e294affb9b86db4d9aa5c01730bdbe4025", size = 223826, upload-time = "2026-02-19T13:45:08.055Z" }
 wheels = [
@@ -2302,7 +2233,7 @@ wheels = [
 
 [package.optional-dependencies]
 crypto = [
-    { name = "cryptography", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "cryptography" },
 ]
 
 [[package]]
@@ -2377,7 +2308,7 @@ name = "pyzmq"
 version = "27.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "(implementation_name == 'pypy' and sys_platform != 'emscripten' and sys_platform != 'win32') or (implementation_name == 'pypy' and sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (implementation_name == 'pypy' and sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "cffi", marker = "implementation_name == 'pypy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/04/0b/3c9baedbdf613ecaa7aa07027780b8867f57b6293b6ee50de316c9f3222b/pyzmq-27.1.0.tar.gz", hash = "sha256:ac0765e3d44455adb6ddbf4417dcce460fc40a05978c08efdf2948072f6db540", size = 281750, upload-time = "2025-09-08T23:10:18.157Z" }
 wheels = [
@@ -2398,40 +2329,14 @@ name = "quack-kernels"
 version = "0.2.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "apache-tvm-ffi", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "nvidia-cutlass-dsl", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "torch", version = "2.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "torch-c-dlpack-ext", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "apache-tvm-ffi" },
+    { name = "nvidia-cutlass-dsl" },
+    { name = "torch", version = "2.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" } },
+    { name = "torch-c-dlpack-ext" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/23/28/231c862500fec531080cc733e5766b46518edaefe0a068d46b276c380a25/quack_kernels-0.2.10.tar.gz", hash = "sha256:df86e981ea76542467ae2cd9ac606d587658e8d648a51c34dc0f2913a3e26bf6", size = 161102, upload-time = "2026-02-18T22:20:50.17Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/ac/8f70ddd397aff1d606d7aa6fbe857a2bc58a817965099cd97d91264175a8/quack_kernels-0.2.10-py3-none-any.whl", hash = "sha256:a5b604c5cf28d9e601aae00488b6b603bb4060ccab8409a4443e72a649226f74", size = 165298, upload-time = "2026-02-18T22:20:48.978Z" },
-]
-
-[[package]]
-name = "ray"
-version = "2.54.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "filelock", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "jsonschema", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "msgpack", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "packaging", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "protobuf", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "pyyaml", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "requests", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/16/45eefb51eb1767342a6dbf41af0b432279e422e56160705fcd1098a7ec53/ray-2.54.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:cf5c33b4b13850ec24a5bd5f9d9e0a8161f8e586bfd297e52913d170dec447fe", size = 70084880, upload-time = "2026-02-18T04:05:22.007Z" },
-    { url = "https://files.pythonhosted.org/packages/60/ad/e07aca3637e9c3ec4857ec4366208099cf8488ece8061a9925ba29b66382/ray-2.54.0-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:795ae21d6b764245d3f521bc5833446d58569e7dfde9c5777417eb285d87450f", size = 72107346, upload-time = "2026-02-18T04:05:27.999Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/b9/cc5ea8460c3dc602e6b7198277a7c59ba2b8929374ab22efa8df9f3deac8/ray-2.54.0-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:a972afd5aa3dda99d0b2f369b5f62e5dd95865ab7d37bf2e0a0e0d2cfbd9b325", size = 72967230, upload-time = "2026-02-18T04:05:33.771Z" },
-    { url = "https://files.pythonhosted.org/packages/de/d7/744de3b1bb881701330ddcbb2f6efaccd65915d564ece899a3838f9fb105/ray-2.54.0-cp312-cp312-win_amd64.whl", hash = "sha256:2ee074ede491d0aacfa339c003f5d7a15826e1e2a72ce873234ccbc0446e19b3", size = 27427353, upload-time = "2026-02-18T04:05:38.853Z" },
-]
-
-[package.optional-dependencies]
-cgraph = [
-    { name = "cupy-cuda12x", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
 ]
 
 [[package]]
@@ -2448,9 +2353,9 @@ name = "referencing"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "rpds-py", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "typing-extensions", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
 wheels = [
@@ -2501,8 +2406,8 @@ name = "rich"
 version = "14.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "markdown-it-py", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "pygments", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "markdown-it-py" },
+    { name = "pygments" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b3/c6/f3b320c27991c46f43ee9d856302c70dc2d0fb2dba4842ff739d5f46b393/rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b", size = 230582, upload-time = "2026-02-19T17:23:12.474Z" }
 wheels = [
@@ -2514,9 +2419,9 @@ name = "rich-toolkit"
 version = "0.19.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "rich", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "typing-extensions", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "click" },
+    { name = "rich" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d0/c9/4bbf4bfee195ed1b7d7a6733cc523ca61dbfb4a3e3c12ea090aaffd97597/rich_toolkit-0.19.4.tar.gz", hash = "sha256:52e23d56f9dc30d1343eb3b3f6f18764c313fbfea24e52e6a1d6069bec9c18eb", size = 193951, upload-time = "2026-02-12T10:08:15.814Z" }
 wheels = [
@@ -2624,8 +2529,8 @@ name = "sentry-sdk"
 version = "2.53.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "certifi", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "urllib3", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "certifi" },
+    { name = "urllib3" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d3/06/66c8b705179bc54087845f28fd1b72f83751b6e9a195628e2e9af9926505/sentry_sdk-2.53.0.tar.gz", hash = "sha256:6520ef2c4acd823f28efc55e43eb6ce2e6d9f954a95a3aa96b6fd14871e92b77", size = 412369, upload-time = "2026-02-16T11:11:14.743Z" }
 wheels = [
@@ -2653,16 +2558,16 @@ cpu = [
     { name = "datasets" },
     { name = "numpy" },
     { name = "peft" },
-    { name = "torch", version = "2.10.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-6-server-cpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "torch", version = "2.10.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-cpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "transformers" },
+    { name = "torch", version = "2.10.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-6-server-cpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
+    { name = "torch", version = "2.10.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-cpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
+    { name = "transformers", version = "5.5.0", source = { registry = "https://pypi.org/simple" } },
 ]
 gpu = [
     { name = "datasets" },
     { name = "numpy" },
     { name = "peft" },
     { name = "torch", version = "2.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "sys_platform == 'linux'" },
-    { name = "transformers" },
+    { name = "transformers", version = "5.5.0", source = { registry = "https://pypi.org/simple" } },
 ]
 vllm = [
     { name = "torch", version = "2.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "sys_platform == 'linux'" },
@@ -2690,10 +2595,10 @@ requires-dist = [
     { name = "torch", marker = "sys_platform == 'linux' and extra == 'vllm'", index = "https://download.pytorch.org/whl/cu128", conflict = { package = "server", extra = "vllm" } },
     { name = "torch", marker = "extra == 'cpu'", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "server", extra = "cpu" } },
     { name = "torch-c-dlpack-ext", marker = "sys_platform == 'linux' and extra == 'vllm'" },
-    { name = "transformers", marker = "extra == 'cpu'" },
-    { name = "transformers", marker = "extra == 'gpu'" },
+    { name = "transformers", marker = "extra == 'cpu'", specifier = ">=5.5.0" },
+    { name = "transformers", marker = "extra == 'gpu'", specifier = ">=5.5.0" },
     { name = "uvicorn" },
-    { name = "vllm", marker = "sys_platform == 'linux' and extra == 'vllm'", specifier = ">=0.15.0" },
+    { name = "vllm", marker = "sys_platform == 'linux' and extra == 'vllm'", specifier = ">=0.18.0" },
 ]
 provides-extras = ["cpu", "gpu", "vllm"]
 
@@ -2756,8 +2661,8 @@ name = "sse-starlette"
 version = "3.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "starlette", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "anyio" },
+    { name = "starlette" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8b/8d/00d280c03ffd39aaee0e86ec81e2d3b9253036a0f93f51d10503adef0e65/sse_starlette-3.2.0.tar.gz", hash = "sha256:8127594edfb51abe44eac9c49e59b0b01f1039d0c7461c6fd91d4e03b70da422", size = 27253, upload-time = "2026-01-17T13:11:05.62Z" }
 wheels = [
@@ -2812,8 +2717,8 @@ name = "tiktoken"
 version = "0.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "regex", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "requests", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "regex" },
+    { name = "requests" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7d/ab/4d017d0f76ec3171d469d80fc03dfbb4e48a4bcaddaa831b31d526f05edc/tiktoken-0.12.0.tar.gz", hash = "sha256:b18ba7ee2b093863978fcb14f74b3707cdc8d4d4d3836853ce7ec60772139931", size = 37806, upload-time = "2025-10-06T20:22:45.419Z" }
 wheels = [
@@ -2831,7 +2736,8 @@ name = "tokenizers"
 version = "0.22.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "huggingface-hub" },
+    { name = "huggingface-hub", version = "0.36.2", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra != 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+    { name = "huggingface-hub", version = "1.9.2", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-6-server-cpu' or extra == 'extra-6-server-gpu'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/73/6f/f80cfef4a312e1fb34baf7d85c72d4411afde10978d4657f8cdd811d3ccc/tokenizers-0.22.2.tar.gz", hash = "sha256:473b83b915e547aa366d1eee11806deaf419e17be16310ac0a14077f1e28f917", size = 372115, upload-time = "2026-01-05T10:45:15.988Z" }
 wheels = [
@@ -2860,44 +2766,18 @@ resolution-markers = [
     "sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "filelock", marker = "(sys_platform == 'darwin' and extra == 'extra-6-server-cpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "fsspec", version = "2025.10.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform == 'darwin' and extra == 'extra-6-server-cpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "jinja2", marker = "(sys_platform == 'darwin' and extra == 'extra-6-server-cpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "networkx", marker = "(sys_platform == 'darwin' and extra == 'extra-6-server-cpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "setuptools", marker = "(sys_platform == 'darwin' and extra == 'extra-6-server-cpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "sympy", marker = "(sys_platform == 'darwin' and extra == 'extra-6-server-cpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "typing-extensions", marker = "(sys_platform == 'darwin' and extra == 'extra-6-server-cpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+    { name = "filelock", marker = "(sys_platform == 'darwin' and extra == 'extra-6-server-cpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
+    { name = "fsspec", version = "2025.10.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform == 'darwin' and extra == 'extra-6-server-cpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
+    { name = "jinja2", marker = "(sys_platform == 'darwin' and extra == 'extra-6-server-cpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
+    { name = "networkx", marker = "(sys_platform == 'darwin' and extra == 'extra-6-server-cpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
+    { name = "setuptools", marker = "(sys_platform == 'darwin' and extra == 'extra-6-server-cpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
+    { name = "sympy", marker = "(sys_platform == 'darwin' and extra == 'extra-6-server-cpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
+    { name = "typing-extensions", marker = "(sys_platform == 'darwin' and extra == 'extra-6-server-cpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0-1-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:7fbbf409143a4fe0812a40c0b46a436030a7e1d14fe8c5234dfbe44df47f617e" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0-2-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:358bd7125cbec6e692d60618a5eec7f55a51b29e3652a849fd42af021d818023" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:45a1c5057629444aeb1c452c18298fa7f30f2f7aeadd4dc41f9d340980294407" },
-]
-
-[[package]]
-name = "torch"
-version = "2.10.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "sys_platform == 'win32'",
-    "sys_platform == 'emscripten'",
-]
-dependencies = [
-    { name = "filelock", marker = "(sys_platform == 'emscripten' and extra == 'extra-6-server-gpu') or (sys_platform == 'win32' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "fsspec", version = "2025.10.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform == 'emscripten' and extra == 'extra-6-server-gpu') or (sys_platform == 'win32' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "jinja2", marker = "(sys_platform == 'emscripten' and extra == 'extra-6-server-gpu') or (sys_platform == 'win32' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "networkx", marker = "(sys_platform == 'emscripten' and extra == 'extra-6-server-gpu') or (sys_platform == 'win32' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "setuptools", marker = "(sys_platform == 'emscripten' and extra == 'extra-6-server-gpu') or (sys_platform == 'win32' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "sympy", marker = "(sys_platform == 'emscripten' and extra == 'extra-6-server-gpu') or (sys_platform == 'win32' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "typing-extensions", marker = "(sys_platform == 'emscripten' and extra == 'extra-6-server-gpu') or (sys_platform == 'win32' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d3/54/a2ba279afcca44bbd320d4e73675b282fcee3d81400ea1b53934efca6462/torch-2.10.0-2-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:13ec4add8c3faaed8d13e0574f5cd4a323c11655546f91fbe6afa77b57423574", size = 79498202, upload-time = "2026-02-10T21:44:52.603Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/7a/abada41517ce0011775f0f4eacc79659bc9bc6c361e6bfe6f7052a6b9363/torch-2.10.0-3-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:98c01b8bb5e3240426dcde1446eed6f40c778091c8544767ef1168fc663a05a6", size = 915622781, upload-time = "2026-03-11T14:17:11.354Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/af/758e242e9102e9988969b5e621d41f36b8f258bb4a099109b7a4b4b50ea4/torch-2.10.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:5fd4117d89ffd47e3dcc71e71a22efac24828ad781c7e46aaaf56bf7f2796acf", size = 145996088, upload-time = "2026-01-21T16:24:44.171Z" },
-    { url = "https://files.pythonhosted.org/packages/23/8e/3c74db5e53bff7ed9e34c8123e6a8bfef718b2450c35eefab85bb4a7e270/torch-2.10.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:787124e7db3b379d4f1ed54dd12ae7c741c16a4d29b49c0226a89bea50923ffb", size = 915711952, upload-time = "2026-01-21T16:23:53.503Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/01/624c4324ca01f66ae4c7cd1b74eb16fb52596dce66dbe51eff95ef9e7a4c/torch-2.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:2c66c61f44c5f903046cc696d088e21062644cbe541c7f1c4eaae88b2ad23547", size = 113757972, upload-time = "2026-01-21T16:24:39.516Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/5c/dee910b87c4d5c0fcb41b50839ae04df87c1cfc663cf1b5fca7ea565eeaa/torch-2.10.0-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:6d3707a61863d1c4d6ebba7be4ca320f42b869ee657e9b2c21c736bf17000294", size = 79498198, upload-time = "2026-01-21T16:24:34.704Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0-1-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:7fbbf409143a4fe0812a40c0b46a436030a7e1d14fe8c5234dfbe44df47f617e" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0-2-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:358bd7125cbec6e692d60618a5eec7f55a51b29e3652a849fd42af021d818023" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:45a1c5057629444aeb1c452c18298fa7f30f2f7aeadd4dc41f9d340980294407" },
 ]
 
 [[package]]
@@ -2910,21 +2790,21 @@ resolution-markers = [
     "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "filelock", marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-cpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "fsspec", version = "2025.10.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-cpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "jinja2", marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-cpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "networkx", marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-cpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "setuptools", marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-cpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "sympy", marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-cpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "typing-extensions", marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-cpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+    { name = "filelock", marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-cpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
+    { name = "fsspec", version = "2025.10.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-cpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
+    { name = "jinja2", marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-cpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
+    { name = "networkx", marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-cpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
+    { name = "setuptools", marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-cpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
+    { name = "sympy", marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-cpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
+    { name = "typing-extensions", marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-cpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp312-cp312-linux_aarch64.whl", hash = "sha256:8de5a36371b775e2d4881ed12cc7f2de400b1ad3d728aa74a281f649f87c9b8c" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp312-cp312-linux_s390x.whl", hash = "sha256:9accc30b56cb6756d4a9d04fcb8ebc0bb68c7d55c1ed31a8657397d316d31596" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:179451716487f8cb09b56459667fa1f5c4c0946c1e75fbeae77cfc40a5768d87" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:ee40b8a4b4b2cf0670c6fd4f35a7ef23871af956fecb238fbf5da15a72650b1d" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp312-cp312-win_amd64.whl", hash = "sha256:21cb5436978ef47c823b7a813ff0f8c2892e266cfe0f1d944879b5fba81bf4e1" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp312-cp312-win_arm64.whl", hash = "sha256:3eaa727e6a73affa61564d86b9d03191df45c8650d0666bd3d57c8597ef61e78" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp312-cp312-linux_aarch64.whl", hash = "sha256:8de5a36371b775e2d4881ed12cc7f2de400b1ad3d728aa74a281f649f87c9b8c" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp312-cp312-linux_s390x.whl", hash = "sha256:9accc30b56cb6756d4a9d04fcb8ebc0bb68c7d55c1ed31a8657397d316d31596" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:179451716487f8cb09b56459667fa1f5c4c0946c1e75fbeae77cfc40a5768d87" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:ee40b8a4b4b2cf0670c6fd4f35a7ef23871af956fecb238fbf5da15a72650b1d" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp312-cp312-win_amd64.whl", hash = "sha256:21cb5436978ef47c823b7a813ff0f8c2892e266cfe0f1d944879b5fba81bf4e1" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp312-cp312-win_arm64.whl", hash = "sha256:3eaa727e6a73affa61564d86b9d03191df45c8650d0666bd3d57c8597ef61e78" },
 ]
 
 [[package]]
@@ -2932,41 +2812,42 @@ name = "torch"
 version = "2.10.0+cu128"
 source = { registry = "https://download.pytorch.org/whl/cu128" }
 resolution-markers = [
-    "sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-6-server-cpu' and extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm'",
+    "sys_platform == 'win32' and extra != 'extra-6-server-cpu' and extra == 'extra-6-server-gpu' and extra != 'extra-6-server-vllm'",
+    "sys_platform == 'emscripten' and extra != 'extra-6-server-cpu' and extra == 'extra-6-server-gpu' and extra != 'extra-6-server-vllm'",
     "sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-6-server-cpu' and extra == 'extra-6-server-gpu' and extra != 'extra-6-server-vllm'",
     "extra != 'extra-6-server-cpu' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm'",
 ]
 dependencies = [
-    { name = "cuda-bindings", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "filelock", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-gpu') or (sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-vllm') or (sys_platform == 'emscripten' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'win32' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
-    { name = "fsspec", version = "2025.10.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "fsspec", version = "2026.2.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
-    { name = "jinja2", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-gpu') or (sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-vllm') or (sys_platform == 'emscripten' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'win32' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
-    { name = "networkx", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-gpu') or (sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-vllm') or (sys_platform == 'emscripten' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'win32' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
-    { name = "nvidia-cublas-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "nvidia-cuda-cupti-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "nvidia-cuda-nvrtc-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "nvidia-cuda-runtime-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "nvidia-cudnn-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "nvidia-cufft-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "nvidia-cufile-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "nvidia-curand-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "nvidia-cusolver-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "nvidia-cusparse-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "nvidia-cusparselt-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "nvidia-nccl-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "nvidia-nvjitlink-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "nvidia-nvshmem-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "nvidia-nvtx-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "setuptools", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-gpu') or (sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-vllm') or (sys_platform == 'emscripten' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'win32' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
-    { name = "sympy", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-gpu') or (sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-vllm') or (sys_platform == 'emscripten' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'win32' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
-    { name = "triton", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "typing-extensions", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-gpu') or (sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-vllm') or (sys_platform == 'emscripten' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'win32' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
+    { name = "cuda-bindings", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
+    { name = "filelock", marker = "extra == 'extra-6-server-gpu' or extra == 'extra-6-server-vllm'" },
+    { name = "fsspec", version = "2025.10.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-6-server-gpu' or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+    { name = "fsspec", version = "2026.2.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra != 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+    { name = "jinja2", marker = "extra == 'extra-6-server-gpu' or extra == 'extra-6-server-vllm'" },
+    { name = "networkx", marker = "extra == 'extra-6-server-gpu' or extra == 'extra-6-server-vllm'" },
+    { name = "nvidia-cublas-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
+    { name = "nvidia-cuda-cupti-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
+    { name = "nvidia-cuda-nvrtc-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
+    { name = "nvidia-cuda-runtime-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
+    { name = "nvidia-cudnn-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
+    { name = "nvidia-cufft-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
+    { name = "nvidia-cufile-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
+    { name = "nvidia-curand-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
+    { name = "nvidia-cusolver-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
+    { name = "nvidia-cusparse-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
+    { name = "nvidia-cusparselt-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
+    { name = "nvidia-nccl-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
+    { name = "nvidia-nvshmem-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
+    { name = "nvidia-nvtx-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
+    { name = "setuptools", marker = "extra == 'extra-6-server-gpu' or extra == 'extra-6-server-vllm'" },
+    { name = "sympy", marker = "extra == 'extra-6-server-gpu' or extra == 'extra-6-server-vllm'" },
+    { name = "triton", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
+    { name = "typing-extensions", marker = "extra == 'extra-6-server-gpu' or extra == 'extra-6-server-vllm'" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:6f09cdf2415516be028ae82e6b985bcfc3eac37bc52ab401142689f6224516ca" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:628e89bd5110ced7debee2a57c69959725b7fbc64eab81a39dd70e46c7e28ba5" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp312-cp312-win_amd64.whl", hash = "sha256:fbde8f6a9ec8c76979a0d14df21c10b9e5cab6f0d106a73ca73e2179bc597cae" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:6f09cdf2415516be028ae82e6b985bcfc3eac37bc52ab401142689f6224516ca" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:628e89bd5110ced7debee2a57c69959725b7fbc64eab81a39dd70e46c7e28ba5" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp312-cp312-win_amd64.whl", hash = "sha256:fbde8f6a9ec8c76979a0d14df21c10b9e5cab6f0d106a73ca73e2179bc597cae" },
 ]
 
 [[package]]
@@ -2974,7 +2855,7 @@ name = "torch-c-dlpack-ext"
 version = "0.1.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "torch", version = "2.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "torch", version = "2.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/37/de/921b6491efce5c389a5ef9bbed3d2d6660005840dae488124173180859ab/torch_c_dlpack_ext-0.1.5.tar.gz", hash = "sha256:d06f0357d575d22a168cc77acb9020fc4bae30968ceb6718a055dcbe92bacabe", size = 12913, upload-time = "2026-01-12T11:25:08.484Z" }
 wheels = [
@@ -2989,7 +2870,7 @@ name = "torchaudio"
 version = "2.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "torch", version = "2.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "torch", version = "2.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" } },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0f/36/28a6f3e857616cf7576bdbf8170e483b8c5d0a1f8d349ecb2b75921236aa/torchaudio-2.10.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:9d0fbdbfd2f621c51d28571050d6d0c7287791034e5c7303b31480af1258f33f", size = 737144, upload-time = "2026-01-21T16:28:44.189Z" },
@@ -3003,9 +2884,9 @@ name = "torchvision"
 version = "0.25.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "pillow", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "torch", version = "2.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "torch", version = "2.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" } },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/3a/6ea0d73f49a9bef38a1b3a92e8dd455cea58470985d25635beab93841748/torchvision-0.25.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c2abe430c90b1d5e552680037d68da4eb80a5852ebb1c811b2b89d299b10573b", size = 1874920, upload-time = "2026-01-21T16:27:45.348Z" },
@@ -3032,7 +2913,7 @@ version = "4.57.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
-    { name = "huggingface-hub" },
+    { name = "huggingface-hub", version = "0.36.2", source = { registry = "https://pypi.org/simple" } },
     { name = "numpy" },
     { name = "packaging" },
     { name = "pyyaml" },
@@ -3045,6 +2926,35 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c4/35/67252acc1b929dc88b6602e8c4a982e64f31e733b804c14bc24b47da35e6/transformers-4.57.6.tar.gz", hash = "sha256:55e44126ece9dc0a291521b7e5492b572e6ef2766338a610b9ab5afbb70689d3", size = 10134912, upload-time = "2026-01-16T10:38:39.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/03/b8/e484ef633af3887baeeb4b6ad12743363af7cce68ae51e938e00aaa0529d/transformers-4.57.6-py3-none-any.whl", hash = "sha256:4c9e9de11333ddfe5114bc872c9f370509198acf0b87a832a0ab9458e2bd0550", size = 11993498, upload-time = "2026-01-16T10:38:31.289Z" },
+]
+
+[[package]]
+name = "transformers"
+version = "5.5.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "sys_platform == 'win32' and extra != 'extra-6-server-cpu' and extra == 'extra-6-server-gpu' and extra != 'extra-6-server-vllm'",
+    "sys_platform == 'emscripten' and extra != 'extra-6-server-cpu' and extra == 'extra-6-server-gpu' and extra != 'extra-6-server-vllm'",
+    "sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-6-server-cpu' and extra == 'extra-6-server-gpu' and extra != 'extra-6-server-vllm'",
+    "sys_platform == 'win32' and extra == 'extra-6-server-cpu' and extra != 'extra-6-server-gpu' and extra != 'extra-6-server-vllm'",
+    "sys_platform == 'emscripten' and extra == 'extra-6-server-cpu' and extra != 'extra-6-server-gpu' and extra != 'extra-6-server-vllm'",
+    "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-cpu' and extra != 'extra-6-server-gpu' and extra != 'extra-6-server-vllm'",
+    "sys_platform == 'darwin' and extra == 'extra-6-server-cpu' and extra != 'extra-6-server-gpu' and extra != 'extra-6-server-vllm'",
+]
+dependencies = [
+    { name = "huggingface-hub", version = "1.9.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "regex" },
+    { name = "safetensors" },
+    { name = "tokenizers" },
+    { name = "tqdm" },
+    { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ff/9d/fb46e729b461985f41a5740167688b924a4019141e5c164bea77548d3d9e/transformers-5.5.0.tar.gz", hash = "sha256:c8db656cf51c600cd8c75f06b20ef85c72e8b8ff9abc880c5d3e8bc70e0ddcbd", size = 8237745, upload-time = "2026-04-02T16:13:08.113Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/28/35f7411ff80a3640c1f4fc907dcbb6a65061ebb82f66950e38bfc9f7f740/transformers-5.5.0-py3-none-any.whl", hash = "sha256:821a9ff0961abbb29eb1eb686d78df1c85929fdf213a3fe49dc6bd94f9efa944", size = 10245591, upload-time = "2026-04-02T16:13:03.462Z" },
 ]
 
 [[package]]
@@ -3061,10 +2971,10 @@ name = "typer"
 version = "0.24.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "annotated-doc", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "click", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "rich", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "shellingham", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "annotated-doc" },
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f5/24/cb09efec5cc954f7f9b930bf8279447d24618bb6758d4f6adf2574c41780/typer-0.24.1.tar.gz", hash = "sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45", size = 118613, upload-time = "2026-02-21T16:54:40.609Z" }
 wheels = [
@@ -3125,13 +3035,13 @@ wheels = [
 
 [package.optional-dependencies]
 standard = [
-    { name = "colorama", marker = "sys_platform == 'win32' and extra != 'extra-6-server-gpu'" },
-    { name = "httptools", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "python-dotenv", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "pyyaml", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "uvloop", marker = "(platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (platform_python_implementation != 'PyPy' and sys_platform == 'emscripten' and extra != 'extra-6-server-gpu')" },
-    { name = "watchfiles", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "websockets", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "httptools" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'" },
+    { name = "watchfiles" },
+    { name = "websockets" },
 ]
 
 [[package]]
@@ -3150,82 +3060,79 @@ wheels = [
 
 [[package]]
 name = "vllm"
-version = "0.17.1"
+version = "0.19.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiohttp", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "anthropic", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "blake3", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "cachetools", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "cbor2", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "cloudpickle", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "compressed-tensors", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "depyf", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "diskcache", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "einops", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "fastapi", extra = ["standard"], marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-vllm') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "filelock", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "flashinfer-python", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "gguf", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "grpcio", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "grpcio-reflection", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "ijson", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "kaldi-native-fbank", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "lark", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "llguidance", marker = "(platform_machine == 'aarch64' and sys_platform != 'emscripten' and sys_platform != 'win32') or (platform_machine == 'arm64' and sys_platform != 'emscripten' and sys_platform != 'win32') or (platform_machine == 'ppc64le' and sys_platform != 'emscripten' and sys_platform != 'win32') or (platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32') or (platform_machine == 'x86_64' and sys_platform != 'emscripten' and sys_platform != 'win32') or (platform_machine == 'aarch64' and sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (platform_machine == 'arm64' and sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (platform_machine == 'ppc64le' and sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (platform_machine == 's390x' and sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (platform_machine == 'x86_64' and sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (platform_machine == 'aarch64' and sys_platform == 'win32' and extra != 'extra-6-server-gpu') or (platform_machine == 'arm64' and sys_platform == 'win32' and extra != 'extra-6-server-gpu') or (platform_machine == 'ppc64le' and sys_platform == 'win32' and extra != 'extra-6-server-gpu') or (platform_machine == 's390x' and sys_platform == 'win32' and extra != 'extra-6-server-gpu') or (platform_machine == 'x86_64' and sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "lm-format-enforcer", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "mcp", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "mistral-common", extra = ["image"], marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-vllm') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "model-hosting-container-standards", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "msgspec", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "ninja", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "numba", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "numpy", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "nvidia-cudnn-frontend", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "nvidia-cutlass-dsl", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "openai", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "openai-harmony", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "opencv-python-headless", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "opentelemetry-api", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "opentelemetry-exporter-otlp", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "opentelemetry-sdk", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "opentelemetry-semantic-conventions-ai", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "outlines-core", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "partial-json-parser", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "pillow", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "prometheus-client", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "prometheus-fastapi-instrumentator", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "protobuf", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "psutil", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "py-cpuinfo", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "pybase64", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "pydantic", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "python-json-logger", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "pyyaml", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "pyzmq", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "quack-kernels", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "ray", extra = ["cgraph"], marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-vllm') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "regex", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "requests", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "sentencepiece", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "setproctitle", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "setuptools", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "six", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "tiktoken", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "tokenizers", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "torch", version = "2.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "torchaudio", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "torchvision", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "tqdm", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "transformers", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "typing-extensions", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "watchfiles", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "xgrammar", marker = "(platform_machine == 'aarch64' and sys_platform != 'emscripten' and sys_platform != 'win32') or (platform_machine == 'arm64' and sys_platform != 'emscripten' and sys_platform != 'win32') or (platform_machine == 'ppc64le' and sys_platform != 'emscripten' and sys_platform != 'win32') or (platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32') or (platform_machine == 'x86_64' and sys_platform != 'emscripten' and sys_platform != 'win32') or (platform_machine == 'aarch64' and sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (platform_machine == 'arm64' and sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (platform_machine == 'ppc64le' and sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (platform_machine == 's390x' and sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (platform_machine == 'x86_64' and sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (platform_machine == 'aarch64' and sys_platform == 'win32' and extra != 'extra-6-server-gpu') or (platform_machine == 'arm64' and sys_platform == 'win32' and extra != 'extra-6-server-gpu') or (platform_machine == 'ppc64le' and sys_platform == 'win32' and extra != 'extra-6-server-gpu') or (platform_machine == 's390x' and sys_platform == 'win32' and extra != 'extra-6-server-gpu') or (platform_machine == 'x86_64' and sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "aiohttp" },
+    { name = "anthropic" },
+    { name = "blake3" },
+    { name = "cachetools" },
+    { name = "cbor2" },
+    { name = "cloudpickle" },
+    { name = "compressed-tensors" },
+    { name = "depyf" },
+    { name = "diskcache" },
+    { name = "einops" },
+    { name = "fastapi", extra = ["standard"], marker = "(extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra != 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+    { name = "filelock" },
+    { name = "flashinfer-cubin" },
+    { name = "flashinfer-python" },
+    { name = "gguf" },
+    { name = "ijson" },
+    { name = "lark" },
+    { name = "llguidance", marker = "platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 'ppc64le' or platform_machine == 's390x' or platform_machine == 'x86_64'" },
+    { name = "lm-format-enforcer" },
+    { name = "mcp" },
+    { name = "mistral-common", extra = ["image"], marker = "(extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra != 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+    { name = "model-hosting-container-standards" },
+    { name = "msgspec" },
+    { name = "ninja" },
+    { name = "numba" },
+    { name = "numpy" },
+    { name = "nvidia-cudnn-frontend" },
+    { name = "nvidia-cutlass-dsl" },
+    { name = "openai" },
+    { name = "openai-harmony" },
+    { name = "opencv-python-headless" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp" },
+    { name = "opentelemetry-sdk" },
+    { name = "opentelemetry-semantic-conventions-ai" },
+    { name = "outlines-core" },
+    { name = "partial-json-parser" },
+    { name = "pillow" },
+    { name = "prometheus-client" },
+    { name = "prometheus-fastapi-instrumentator" },
+    { name = "protobuf" },
+    { name = "psutil" },
+    { name = "py-cpuinfo" },
+    { name = "pybase64" },
+    { name = "pydantic" },
+    { name = "python-json-logger" },
+    { name = "pyyaml" },
+    { name = "pyzmq" },
+    { name = "quack-kernels" },
+    { name = "regex" },
+    { name = "requests" },
+    { name = "sentencepiece" },
+    { name = "setproctitle" },
+    { name = "setuptools" },
+    { name = "six" },
+    { name = "tiktoken" },
+    { name = "tokenizers" },
+    { name = "torch", version = "2.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" } },
+    { name = "torchaudio" },
+    { name = "torchvision" },
+    { name = "tqdm" },
+    { name = "transformers", version = "4.57.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "typing-extensions" },
+    { name = "watchfiles" },
+    { name = "xgrammar", marker = "platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 'ppc64le' or platform_machine == 's390x' or platform_machine == 'x86_64'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4c/7c/79ef306c71f3de2e73beb3c03c3f2966f966df61b8dd1f01dbdc65184050/vllm-0.17.1.tar.gz", hash = "sha256:d26a95dcb92e2ff78ed4b48bff247d845b0c768edf6c0acf2401376a56c57b61", size = 30547577, upload-time = "2026-03-11T11:03:58.693Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/14/c330a72309051f762b357a2e41d5015bedbb106ad1e16a231bdfda2e2163/vllm-0.19.0.tar.gz", hash = "sha256:81e59cf87175e7a62eb8d9acf5989484bbd17089d5eface353f89067bda282d9", size = 31071745, upload-time = "2026-04-03T04:04:52.833Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f5/02/ff63919abb341b0819f33a400c83698d095e5fd461ae3e44f3ff91f6489f/vllm-0.17.1-cp38-abi3-manylinux_2_31_aarch64.whl", hash = "sha256:f04d63a94d0415b2323b0a0d3ab89a8d4d9bd346251ff60d47a7df679f7b3ff8", size = 385333057, upload-time = "2026-03-11T11:06:44.106Z" },
-    { url = "https://files.pythonhosted.org/packages/18/28/f85e67b390082481298e27a5c9f1da540d2d5abb1a06a594545cdc320818/vllm-0.17.1-cp38-abi3-manylinux_2_31_x86_64.whl", hash = "sha256:c52e892309532b4e51cb94d022c5e3c0087300cdb56e4645708601443299d871", size = 432931666, upload-time = "2026-03-11T11:06:00.955Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/51/467e7a8cb4838022daa731b7f8b34c228691e36f938e1803c3a702c7bd69/vllm-0.19.0-cp38-abi3-manylinux_2_31_aarch64.whl", hash = "sha256:6ab90ccca5d7ca3bd2c8f90133f0fac85e8f4af582a1c67c6cc3f63c615521e3", size = 384650557, upload-time = "2026-04-03T04:05:52.513Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/08/6a431731e4c163bc1fab85b63e269d84104aad0fba98dac1af34fdc5077f/vllm-0.19.0-cp38-abi3-manylinux_2_31_x86_64.whl", hash = "sha256:2d0e5fae45367bdbf111fcad68f4c0f8fdddd2f2fb643e52f0f2daebef7b41cf", size = 432281473, upload-time = "2026-04-03T04:05:22.07Z" },
 ]
 
 [[package]]
@@ -3233,7 +3140,7 @@ name = "watchfiles"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "anyio" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c2/c9/8869df9b2a2d6c59d79220a4db37679e74f807c559ffe5265e08b227a210/watchfiles-1.1.1.tar.gz", hash = "sha256:a173cb5c16c4f40ab19cecf48a534c409f7ea983ab8fed0741304a1c0a31b3f2", size = 94440, upload-time = "2025-10-14T15:06:21.08Z" }
 wheels = [
@@ -3300,24 +3207,23 @@ wheels = [
 
 [[package]]
 name = "xgrammar"
-version = "0.1.29"
+version = "0.1.33"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mlx-lm", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'" },
-    { name = "numpy", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "pydantic", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "torch", version = "2.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
-    { name = "transformers", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "numpy" },
+    { name = "pydantic" },
+    { name = "torch", version = "2.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" } },
+    { name = "transformers", version = "4.57.6", source = { registry = "https://pypi.org/simple" } },
     { name = "triton", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "typing-extensions", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/02/a3/70dbe3ffd331a1e7e1ad5a95690a4086e6c7cdb8089f5c7eda712219ccec/xgrammar-0.1.29.tar.gz", hash = "sha256:cf195afa81b489eebf35d4c6f37f27136d05420739ab4a6f7f065c938d7e4baa", size = 2321317, upload-time = "2025-12-19T08:23:54.53Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/43/e5dfddb1d2a4fccf3e3a88f103e88698cdefc3182f4e169a359ffe1c1794/xgrammar-0.1.33.tar.gz", hash = "sha256:8dbe5fc3d76651ab1fac7a68fc2a118b885fa0ec7189927fb6e0dce0081aea99", size = 2398956, upload-time = "2026-03-27T10:16:36.582Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/d8/fb282fc78be6e9bbefb5cb389f66b22e4efd6ae14f06234f599651620da5/xgrammar-0.1.29-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:d992a3cee7594bbdaa64ae59f90da5ce21c5fe654719df3816014289ada6f04d", size = 16007376, upload-time = "2025-12-19T08:23:23.634Z" },
-    { url = "https://files.pythonhosted.org/packages/82/a7/2c9767620ee50f2f40f1eb95e55a3a29e1a0670f087ee6dc1bc1c887b906/xgrammar-0.1.29-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1bbdf02e45cfa8614218ba01ca7952d375f8bc1c13884e3d04daa4b54180cbc2", size = 17913535, upload-time = "2025-12-19T08:23:26.02Z" },
-    { url = "https://files.pythonhosted.org/packages/57/94/18793c64bf0368075a34c06e196bf002f1e6ab0aee332268f44e8d356d5a/xgrammar-0.1.29-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6eb370a16b27a683e5f2b9e429ab41440c69977d4a504849ed61831b94cc704c", size = 34705239, upload-time = "2025-12-19T08:23:28.369Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/da/4c14e3e00be698009b52700f15326a23272b4b00475939b6acc86b151188/xgrammar-0.1.29-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:79e6e4f5cd33be77418cf91efc482f2b3d773d309891224383bc8a4948ad7b07", size = 34906135, upload-time = "2025-12-19T08:23:30.838Z" },
-    { url = "https://files.pythonhosted.org/packages/22/d8/34423997f48627cef3b74cc894d9dfcaacae02941c06237ac5f3196406a7/xgrammar-0.1.29-cp312-cp312-win_amd64.whl", hash = "sha256:39bdfadedbce34599835486164fa80ba00248c6c75ad91f3843db90ef37e037f", size = 5928381, upload-time = "2025-12-19T08:23:33.428Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/5f/9a1ebc9505392ff626b9ba8fca54d46bdba454af80551169676ee5cd27d4/xgrammar-0.1.33-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:16d05f8f9df9852f2055e112adf2ce22440062979bc3dc66869a0b7c2f93eb0a", size = 22765695, upload-time = "2026-03-27T10:15:09.38Z" },
+    { url = "https://files.pythonhosted.org/packages/82/82/7081feb505873238583a003f790b10ce84d66ab3a8e8e244e8c1c4729d70/xgrammar-0.1.33-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0bb9e0ed6748b8e82d4569be4ebc8c9e60694369295c4fed0ebaa4bab4aa4eb4", size = 22702262, upload-time = "2026-03-27T10:15:12.9Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/04/43d4baca876f5ae1b45897ec30a59801a2da37f16da1fcd85f9555e4c125/xgrammar-0.1.33-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c803e60d791854c5d1f271ece7e1f34d73c82dd4a8b2a06b7af5331482a78ac", size = 42133168, upload-time = "2026-03-27T10:15:16.994Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/a8/672833a3cff027253793aa999401d8364896ebf396967e475c7a878b895f/xgrammar-0.1.33-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:52b8eaa533282a0efb0835db6998ae72e7b3c7875d7a52e360ffebff9b78c30a", size = 42205803, upload-time = "2026-03-27T10:15:21.599Z" },
+    { url = "https://files.pythonhosted.org/packages/04/38/3fd9f21b101871b4b7f86ee2e15fe6d0cb61a3753f18b391bdee22c74810/xgrammar-0.1.33-cp312-cp312-win_amd64.whl", hash = "sha256:94fea66b41feb28be7e91f95f078986cbc850f42f7adb2d8987634eadf1fb94b", size = 7222161, upload-time = "2026-03-27T10:15:24.636Z" },
 ]
 
 [[package]]


### PR DESCRIPTION

This PR separates trainer worker orchestration from trainer engine logic and simplifies the gateway path around that split.

At a high level, it:
- moves the worker loop into `clock_cycle.py`
- restructures `TrainerEngine` into smaller internal helpers
- simplifies gateway request routing while preserving the existing training and sampling flows

This refactor creates a cleaner boundary between:
- worker orchestration
- trainer engine logic
- gateway request handling



