### PR TITLE
feat: simplify runtime config 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,11 +20,11 @@ server:
 	@-kill -9 $$(lsof -ti:$(PORT)) 2>/dev/null || true
 	cd server && SINGLE_PROCESS=1 BASE_MODEL="$(BASE_MODEL)" SAMPLER="$(SAMPLER)" \
 	  uv run --extra $(if $(filter vllm,$(SAMPLER)),gpu,cpu) \
-	  uvicorn src.gateway:app --host 127.0.0.1 --port $(PORT)
+	  python -m uvicorn src.gateway:app --host 127.0.0.1 --port $(PORT)
 
 vllm:
 	cd server && BASE_MODEL="$(BASE_MODEL)" \
-	  uv run --extra gpu --extra vllm python -m src.vllm_sampler
+	  uv run --extra vllm python -m src.vllm_sampler
 
 # ---------------------------------------------------------------------------
 # CLI

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ help:
 # ---------------------------------------------------------------------------
 server:
 	@-kill -9 $$(lsof -ti:$(PORT)) 2>/dev/null || true
-	cd server && OPEN_RL_SINGLE_PROCESS=1 BASE_MODEL="$(BASE_MODEL)" SAMPLER="$(SAMPLER)" \
+	cd server && SINGLE_PROCESS=1 BASE_MODEL="$(BASE_MODEL)" SAMPLER="$(SAMPLER)" \
 	  uv run --extra $(if $(filter vllm,$(SAMPLER)),gpu,cpu) \
 	  uvicorn src.gateway:app --host 127.0.0.1 --port $(PORT)
 

--- a/Makefile
+++ b/Makefile
@@ -1,71 +1,45 @@
-.PHONY: run-server run-server-engine-sampler run-function-gemma-server run-function-gemma-sft run-pig-latin-server run-pig-latin-sft run-text-to-sql-server run-text-to-sql-server-gpu run-text-to-sql-vllm run-text-to-sql-sft run-sft run-sft-parallel run-rlvr run-rlvr-parallel test lint fmt
+.PHONY: server vllm test lint fmt help
 
-# Default VLLM model for inference, can be overridden via `make run-vllm VLLM_MODEL=...`
-#VLLM_MODEL ?= Qwen/Qwen2.5-0.5B
-VLLM_MODEL ?= Qwen/Qwen3-4B-Instruct-2507
+# ---------------------------------------------------------------------------
+# Knobs (override on the command line: make server BASE_MODEL=... SAMPLER=...)
+# ---------------------------------------------------------------------------
+BASE_MODEL ?= Qwen/Qwen3-0.6B
+SAMPLER    ?= torch
+PORT       ?= 9003
 
-# Default GPU allocations for running isolated processes locally/on VMs
-TRAINER_GPU ?= 0
-VLLM_GPU ?= 1
+help:
+	@echo "make server                              # $(BASE_MODEL), SAMPLER=$(SAMPLER), port $(PORT)"
+	@echo "make server BASE_MODEL=google/gemma-4-e2b SAMPLER=vllm"
+	@echo "make vllm   BASE_MODEL=google/gemma-4-e2b  # standalone vLLM worker"
+	@echo "make test | lint | fmt"
 
-# Run the gateway-only server locally
-run-server:
-	@-kill -9 $$(lsof -ti:8000) 2>/dev/null || true
-	cd server && UV_INDEX_URL="https://pypi.org/simple" CUDA_VISIBLE_DEVICES="$(TRAINER_GPU)" uv run uvicorn src.gateway:app --host 127.0.0.1 --port 8000
+# ---------------------------------------------------------------------------
+# Server
+# ---------------------------------------------------------------------------
+server:
+	@-kill -9 $$(lsof -ti:$(PORT)) 2>/dev/null || true
+	cd server && OPEN_RL_SINGLE_PROCESS=1 BASE_MODEL="$(BASE_MODEL)" SAMPLER="$(SAMPLER)" \
+	  uv run --extra $(if $(filter vllm,$(SAMPLER)),gpu,cpu) \
+	  uvicorn src.gateway:app --host 127.0.0.1 --port $(PORT)
 
-# Kill any local process stuck listening on port 8000
-kill-server:
-	@-kill -9 $$(lsof -ti:8000) 2>/dev/null || echo "Port 8000 is free"
+vllm:
+	cd server && BASE_MODEL="$(BASE_MODEL)" \
+	  uv run --extra gpu --extra vllm python -m src.vllm_sampler
 
-# Run the standalone vLLM inference worker locally
-run-vllm:
-	cd server && UV_INDEX_URL="https://pypi.org/simple" CUDA_VISIBLE_DEVICES="$(VLLM_GPU)" VLLM_MODEL="$(VLLM_MODEL)" uv run --extra gpu --extra vllm python -m src.vllm_sampler
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+ifeq (cli,$(firstword $(MAKECMDGOALS)))
+  CLI_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+  $(eval $(CLI_ARGS):;@:)
+endif
 
-run-server-engine-sampler:
-	@-kill -9 $$(lsof -ti:8000) 2>/dev/null || true
-	cd server && ENABLE_GCP_TRACE=$(ENABLE_GCP_TRACE) UV_INDEX_URL="https://pypi.org/simple" SAMPLER_BACKEND=torch VLLM_MODEL="$(VLLM_MODEL)" uv run --extra cpu uvicorn src.gateway:app --host 127.0.0.1 --port 8000
+cli:
+	@cd client && uv run python cli.py $(CLI_ARGS)
 
-run-function-gemma-server:
-	@-kill -9 $$(lsof -ti:9000) 2>/dev/null || true
-	cd server && OPEN_RL_SINGLE_PROCESS=1 SAMPLER_BACKEND=torch OPEN_RL_BASE_MODEL="google/functiongemma-270m-it" PYTHONUNBUFFERED=1 uv run --extra cpu uvicorn src.gateway:app --host 127.0.0.1 --port 9000 $(ARGS)
-
-run-function-gemma:
-	cd client && uv run --python 3.12 functiongemma-demo $(ARGS)
-
-run-pig-latin-server:
-	@-kill -9 $$(lsof -ti:9001) 2>/dev/null || true
-	cd server && ENABLE_GCP_TRACE=$(ENABLE_GCP_TRACE) UV_INDEX_URL="https://pypi.org/simple" OPEN_RL_SINGLE_PROCESS=1 OPEN_RL_BASE_MODEL="Qwen/Qwen3-0.6B" SAMPLER_BACKEND=torch VLLM_MODEL="Qwen/Qwen3-0.6B" uv run --extra cpu uvicorn src.gateway:app --host 127.0.0.1 --port 9001
-
-run-pig-latin-sft:
-	cd client && uv run --python 3.12 -i https://pypi.org/simple python -u piglatin_sft.py qwen $(ARGS)
-
-run-pig-latin-gemma-server:
-	@-kill -9 $$(lsof -ti:9002) 2>/dev/null || true
-	cd server && ENABLE_GCP_TRACE=$(ENABLE_GCP_TRACE) UV_INDEX_URL="https://pypi.org/simple" OPEN_RL_SINGLE_PROCESS=1 OPEN_RL_BASE_MODEL="google/gemma-3-1b-it" SAMPLER_BACKEND=torch VLLM_MODEL="google/gemma-3-1b-it" uv run --extra cpu uvicorn src.gateway:app --host 127.0.0.1 --port 9002
-
-run-pig-latin-gemma-sft:
-	cd client && uv run --python 3.12 -i https://pypi.org/simple python -u piglatin_sft.py gemma base_url="http://127.0.0.1:9002" $(ARGS)
-
-TEXT_TO_SQL_SERVER_EXTRA ?= cpu
-TEXT_TO_SQL_BASE_MODEL ?= google/gemma-3-1b-pt
-TEXT_TO_SQL_SAMPLER_BACKEND ?= torch
-TEXT_TO_SQL_VLLM_URL ?= http://127.0.0.1:8001
-
-run-text-to-sql-server:
-	@-kill -9 $$(lsof -ti:9003) 2>/dev/null || true
-	cd server && ENABLE_GCP_TRACE=$(ENABLE_GCP_TRACE) UV_INDEX_URL="https://pypi.org/simple" CUDA_VISIBLE_DEVICES="$(TRAINER_GPU)" OPEN_RL_SINGLE_PROCESS=1 OPEN_RL_BASE_MODEL="$(TEXT_TO_SQL_BASE_MODEL)" SAMPLER_BACKEND="$(TEXT_TO_SQL_SAMPLER_BACKEND)" VLLM_MODEL="$(TEXT_TO_SQL_BASE_MODEL)" VLLM_URL="$(TEXT_TO_SQL_VLLM_URL)" uv run --extra $(TEXT_TO_SQL_SERVER_EXTRA) uvicorn src.gateway:app --host 127.0.0.1 --port 9003
-
-run-text-to-sql-server-gpu:
-	$(MAKE) run-text-to-sql-server TEXT_TO_SQL_SERVER_EXTRA=gpu TEXT_TO_SQL_SAMPLER_BACKEND=vllm
-
-run-text-to-sql-vllm:
-	cd server && UV_INDEX_URL="https://pypi.org/simple" CUDA_VISIBLE_DEVICES="$(VLLM_GPU)" VLLM_MODEL="$(TEXT_TO_SQL_BASE_MODEL)" uv run --extra gpu --extra vllm python -m src.vllm_sampler
-
-TEXT_TO_SQL_PRESET ?= gemma
-
-run-text-to-sql-sft:
-	cd client && uv run --python 3.12 -i https://pypi.org/simple python -u texttosql_sft.py $(TEXT_TO_SQL_PRESET) base_url="http://127.0.0.1:9003" $(ARGS)
-
+# ---------------------------------------------------------------------------
+# Dev
+# ---------------------------------------------------------------------------
 test:
 	cd client && uv run python -m unittest discover tests
 
@@ -77,218 +51,48 @@ fmt:
 	uvx ruff check --fix .
 	uvx ruff format .
 
-# Client test targets
-run-sft:
-	cd client && uv run -i https://pypi.org/simple python sft.py --base-model "$(VLLM_MODEL)" $(ARGS)
-
-run-sft-parallel:
-	cd client && uv run -i https://pypi.org/simple python sft.py --parallel --base-model "$(VLLM_MODEL)"
-
-# Default concurrent jobs for parallel execution
-JOBS ?= 2
-STEPS ?= 15
-
-# OpenTelemetry Tracing Toggles (0 = disabled, 1 = enabled)
-ENABLE_GCP_TRACE ?= 0
-ENABLE_CONSOLE_TRACE ?= 0
-
-run-rlvr:
-	cd client && ENABLE_GCP_TRACE=$(ENABLE_GCP_TRACE) ENABLE_CONSOLE_TRACE=$(ENABLE_CONSOLE_TRACE) uv run -i https://pypi.org/simple python rlvr.py --jobs 1 --steps $(STEPS) --base-model "$(VLLM_MODEL)"
-
-run-rlvr-parallel:
-	cd client && ENABLE_GCP_TRACE=$(ENABLE_GCP_TRACE) ENABLE_CONSOLE_TRACE=$(ENABLE_CONSOLE_TRACE) uv run -i https://pypi.org/simple python rlvr.py --jobs $(JOBS) --steps $(STEPS) --base-model "$(VLLM_MODEL)"
-
-# Plot metrics from a JSONL file
-# Usage: make plot-metrics [FILE=path/to/metrics.jsonl]
-plot-metrics:
-	cd client && uv run -i https://pypi.org/simple python plot_metrics.py $(FILE)
-
-# Plot parallel metrics from the RLVR log file
-# Usage: make plot-logs [LOG_FILE=client/rlvr_parallel_results.log] [WATCH=1]
-plot-logs:
-	cd client && uv run -i https://pypi.org/simple python plot_logs.py $(or $(LOG_FILE),rlvr_parallel_results.log) $(if $(WATCH),--watch,)
-
-# Generate diagrams using local mmdc zsh alias
-diagrams:
-	zsh -ic "mmdc -i assets/architecture.mmd -o assets/architecture.svg -b transparent"
-	zsh -ic "mmdc -i assets/architecture.mmd -o assets/architecture.png -s 3 -b transparent"
-
-HOST ?= mars
-
-# Sync server to remote host $(HOST)
-# TODO: sync only server directory
-server-sync:
-	rsync -avz --exclude '.git' --exclude '.venv' --exclude '__pycache__' --exclude '*.pyc' --exclude '.DS_Store' ./ $(HOST):~/work/open-rl
-
-server-tunnel:
-	ssh -fN -L 8000:localhost:8000 $(HOST)
-
-# CLI Targets
-# Usage: make run-cli list OR make run-cli chat --model ...
-# This hack allows passing arguments directly after the target name
-ifeq (run-cli,$(firstword $(MAKECMDGOALS)))
-  # use the rest as arguments for "run-cli"
-  CLI_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
-  # ...and turn them into do-nothing targets so make doesn't complain
-  $(eval $(CLI_ARGS):;@:)
-endif
-
-run-cli:
-	@cd client && uv run -i https://pypi.org/simple python cli.py $(CLI_ARGS)
-
-# Shortcut: make run-cli-list
-run-cli-list:
-	@cd client && uv run -i https://pypi.org/simple python cli.py list
-
-# Shortcut: make run-cli-chat MODEL=... [PROMPT="..."]
-run-cli-chat:
-	@test -n "$(MODEL)" || (echo "Error: MODEL argument is required. Usage: make run-cli-chat MODEL=<model_id>" && exit 1)
-	@cd client && uv run -i https://pypi.org/simple python cli.py chat --model $(MODEL) --system-prompt "$(or $(PROMPT),You are helpful geography assistant.)"
-
-# --- Deployment Targets ---
-
+# ---------------------------------------------------------------------------
+# Deployment (GKE)
+# ---------------------------------------------------------------------------
 GCP_PROJECT ?= cdrollouts-sunilarora
-GCR_REPO ?= gcr.io/$(GCP_PROJECT)/open-rl-server
-GATEWAY_GCR_REPO ?= gcr.io/$(GCP_PROJECT)/open-rl-gateway
-CLIENT_GCR_REPO ?= gcr.io/$(GCP_PROJECT)/open-rl-client
-TINKER_GCR_REPO ?= gcr.io/$(GCP_PROJECT)/tinker-cookbook
-IMAGE_TAG ?= latest
+IMAGE_TAG   ?= latest
 
-build-server-images:
-	@echo "--- Building Server Docker Images ---"
-	cd server && DOCKER_BUILDKIT=1 docker build -t $(GCR_REPO):$(IMAGE_TAG) -f Dockerfile .
-	cd server && DOCKER_BUILDKIT=1 docker build -t $(GATEWAY_GCR_REPO):$(IMAGE_TAG) -f Dockerfile.gateway .
+build-images:
+	cd server && DOCKER_BUILDKIT=1 docker build -t gcr.io/$(GCP_PROJECT)/open-rl-server:$(IMAGE_TAG) -f Dockerfile .
+	cd server && DOCKER_BUILDKIT=1 docker build -t gcr.io/$(GCP_PROJECT)/open-rl-gateway:$(IMAGE_TAG) -f Dockerfile.gateway .
 
-push-server-images:
-	@echo "--- Pushing Server Images to GCR ---"
-	docker push $(GCR_REPO):$(IMAGE_TAG)
-	docker push $(GATEWAY_GCR_REPO):$(IMAGE_TAG)
+push-images:
+	docker push gcr.io/$(GCP_PROJECT)/open-rl-server:$(IMAGE_TAG)
+	docker push gcr.io/$(GCP_PROJECT)/open-rl-gateway:$(IMAGE_TAG)
 
-deploy-server:
-	@echo "-- Deploy OpenRL Stack to Kubernetes Cluster ---"
+deploy:
 	kubectl apply -k server/kubernetes/distributed-lustre/
 
 rollout:
-	@echo "--- Rolling out latest server deployments ---"
 	kubectl rollout restart deployment redis-store open-rl-gateway open-rl-trainer-worker vllm-worker
-	kubectl rollout status deployment open-rl-gateway
-	kubectl rollout status deployment open-rl-trainer-worker
 
-build-client-image:
-	@echo "--- Building Client Docker Image ---"
-	cd client && DOCKER_BUILDKIT=1 docker build -t $(CLIENT_GCR_REPO):$(IMAGE_TAG) .
+# Local Redis (for testing distributed mode):
+#   sudo apt install redis-server && sudo service redis-server start
+#   redis-cli ping   # should print PONG
+#   sudo service redis-server stop
 
-push-client-image:
-	@echo "--- Pushing Client Image to GCR ---"
-	docker push $(CLIENT_GCR_REPO):$(IMAGE_TAG)
+# GKE client jobs — run directly:
+#   kubectl apply -f client/kubernetes/rlvr-job.yaml
+#   kubectl apply -f client/kubernetes/tinker-rl-basic-job.yaml   (or -2, -3)
+#   kubectl logs -f job/<job-name>
+#   kubectl delete job <job-name>
 
-build-tinker-image:
-	@echo "--- Building tinker-cookbook Docker Image ---"
-	cd ../tinker-cookbook && DOCKER_BUILDKIT=1 docker build -t $(TINKER_GCR_REPO):$(IMAGE_TAG) .
-
-push-tinker-image:
-	@echo "--- Pushing tinker-cookbook Image to GCR ---"
-	docker push $(TINKER_GCR_REPO):$(IMAGE_TAG)
-
-run-client-job:
-	@echo "--- Deploying RLVR Client Job to GKE ---"
-	kubectl delete job open-rl-client-job --ignore-not-found=true
-	kubectl apply -f client/kubernetes/rlvr-job.yaml
-	@echo "Waiting for job to start..."
-	@sleep 4
-	kubectl logs -f job/open-rl-client-job
-
-stop-client-job:
-	@echo "--- Stopping RLVR Client Job ---"
-	kubectl delete job open-rl-client-job open-rl-client-job-parallel --ignore-not-found=true
-
-logs-client-job:
-	@echo "--- Fetching RLVR Client Job Logs ---"
-	kubectl logs -f job/open-rl-client-job
-
-
-run-tinker-job:
-	@echo "--- Deploying Tinker RL Basic Job to GKE ---"
-	kubectl delete job tinker-rl-basic-job --ignore-not-found=true
-	kubectl apply -f client/kubernetes/tinker-rl-basic-job.yaml
-	@echo "Waiting for job to start..."
-	@sleep 4
-	kubectl logs -f job/tinker-rl-basic-job
-
-stop-tinker-job:
-	@echo "--- Stopping Tinker RL Basic Job ---"
-	kubectl delete job tinker-rl-basic-job --ignore-not-found=true
-
-logs-tinker-job:
-	@echo "--- Fetching Tinker RL Basic Job Logs ---"
-	kubectl logs -f job/tinker-rl-basic-job
-
-run-tinker-job-2:
-	@echo "--- Deploying Tinker RL Basic Job 2 to GKE ---"
-	kubectl delete job tinker-rl-basic-job-2 --ignore-not-found=true
-	kubectl apply -f client/kubernetes/tinker-rl-basic-job-2.yaml
-	@echo "Waiting for job to start..."
-	@sleep 4
-	kubectl logs -f job/tinker-rl-basic-job-2
-
-stop-tinker-job-2:
-	@echo "--- Stopping Tinker RL Basic Job 2 ---"
-	kubectl delete job tinker-rl-basic-job-2 --ignore-not-found=true
-
-logs-tinker-job-2:
-	@echo "--- Fetching Tinker RL Basic Job 2 Logs ---"
-	kubectl logs -f job/tinker-rl-basic-job-2
-
-run-tinker-job-3:
-	@echo "--- Deploying Tinker RL Basic Job 3 to GKE ---"
-	kubectl delete job tinker-rl-basic-job-3 --ignore-not-found=true
-	kubectl apply -f client/kubernetes/tinker-rl-basic-job-3.yaml
-	@echo "Waiting for job to start..."
-	@sleep 4
-	kubectl logs -f job/tinker-rl-basic-job-3
-
-stop-tinker-job-3:
-	@echo "--- Stopping Tinker RL Basic Job 3 ---"
-	kubectl delete job tinker-rl-basic-job-3 --ignore-not-found=true
-
-logs-tinker-job-3:
-	@echo "--- Fetching Tinker RL Basic Job 3 Logs ---"
-	kubectl logs -f job/tinker-rl-basic-job-3
-
-run-client-job-parallel:
-	@echo "--- Deploying Distributed RLVR Client Job Array to GKE ---"
-	kubectl delete job open-rl-client-job-parallel --ignore-not-found=true
-	kubectl apply -f client/kubernetes/rlvr-job-parallel.yaml
-	@echo "Waiting for jobs to start..."
-	@sleep 6
-	@echo "Tailing one of the array pods..."
-	kubectl logs -f job/open-rl-client-job-parallel
-
-# --- Redis Management (Linux) ---
-
-.PHONY: install-redis start-redis stop-redis
-
-# Install redis-server if not present (assuming Debian/Ubuntu)
-install-redis:
-	@echo "--- Checking/Installing Redis Server ---"
-	@if ! command -v redis-server >/dev/null 2>&1; then \
-		echo "Redis not found. Installing via apt-get..."; \
-		sudo apt-get update && sudo apt-get install -y redis-server; \
-	else \
-		echo "Redis is already installed."; \
-	fi
-
-# Start the local redis service
-start-redis:
-	@echo "--- Starting Redis Server ---"
-	sudo service redis-server start
-	@echo "Redis started. Check with: redis-cli ping"
-
-# Stop the local redis service
-stop-redis:
-	@echo "--- Stopping Redis Server ---"
-	sudo service redis-server stop
-
-# --- Cloud Monitoring Dashboard ---
 dashboard-apply:
 	@scripts/apply_dashboard.sh $(GCP_PROJECT)
+
+# ---------------------------------------------------------------------------
+# Misc
+# ---------------------------------------------------------------------------
+HOST ?= mars
+
+server-sync:
+	rsync -avz --exclude '.git' --exclude '.venv' --exclude '__pycache__' --exclude '*.pyc' --exclude '.DS_Store' ./ $(HOST):~/work/open-rl
+
+diagrams:
+	zsh -ic "mmdc -i assets/architecture.mmd -o assets/architecture.svg -b transparent"
+	zsh -ic "mmdc -i assets/architecture.mmd -o assets/architecture.png -s 3 -b transparent"

--- a/client/README.md
+++ b/client/README.md
@@ -90,8 +90,8 @@ Start a standalone vLLM worker (or use `make vllm`):
 
 ```bash
 cd server
-BASE_MODEL="Qwen/Qwen3-4B-Instruct-2507" \
-uv run --extra gpu --extra vllm python -m src.vllm_sampler
+BASE_MODEL="Qwen/Qwen3-0.6B" \
+uv run --extra vllm python -m src.vllm_sampler
 ```
 
 Run the Pig Latin SFT example:

--- a/client/README.md
+++ b/client/README.md
@@ -80,7 +80,7 @@ Start the server (or use `make server`):
 
 ```bash
 cd server
-OPEN_RL_SINGLE_PROCESS=1 \
+SINGLE_PROCESS=1 \
 BASE_MODEL="Qwen/Qwen3-0.6B" \
 SAMPLER=torch \
 uv run --extra cpu uvicorn src.gateway:app --host 127.0.0.1 --port 9003

--- a/client/README.md
+++ b/client/README.md
@@ -76,29 +76,21 @@ cd ..
 
 ### 4. Run common workflows with `uv`
 
-Start the gateway directly:
-
-```bash
-cd server
-uv run uvicorn src.gateway:app --host 127.0.0.1 --port 8000
-```
-
-Start the local single-process Pig Latin server:
+Start the server (or use `make server`):
 
 ```bash
 cd server
 OPEN_RL_SINGLE_PROCESS=1 \
-OPEN_RL_BASE_MODEL="Qwen/Qwen3-0.6B" \
-SAMPLER_BACKEND=torch \
-uv run --extra cpu uvicorn src.gateway:app --host 127.0.0.1 --port 9001
+BASE_MODEL="Qwen/Qwen3-0.6B" \
+SAMPLER=torch \
+uv run --extra cpu uvicorn src.gateway:app --host 127.0.0.1 --port 9003
 ```
 
-Start the Linux GPU/vLLM worker:
+Start a standalone vLLM worker (or use `make vllm`):
 
 ```bash
 cd server
-CUDA_VISIBLE_DEVICES=0 \
-VLLM_MODEL="Qwen/Qwen3-4B-Instruct-2507" \
+BASE_MODEL="Qwen/Qwen3-4B-Instruct-2507" \
 uv run --extra gpu --extra vllm python -m src.vllm_sampler
 ```
 

--- a/client/functiongemma_sft.py
+++ b/client/functiongemma_sft.py
@@ -129,8 +129,7 @@ def require_server(base_url: str, expected_model: str | None = None) -> dict[str
     capabilities = response.json()
   except Exception as exc:
     raise RuntimeError(
-      f"Open-RL server at {base_url} is not reachable.\n"
-      f"Start it with:  make server BASE_MODEL={expected_model or '<model-id>'}"
+      f"Open-RL server at {base_url} is not reachable.\nStart it with:  make server BASE_MODEL={expected_model or '<model-id>'}"
     ) from exc
 
   server_model = capabilities.get("default_model")

--- a/client/functiongemma_sft.py
+++ b/client/functiongemma_sft.py
@@ -122,13 +122,25 @@ def plot_metrics(losses: list[float], before: float, after: float, plot_path: Pa
   plt.close(fig)
 
 
-def require_server(base_url: str) -> dict[str, Any]:
+def require_server(base_url: str, expected_model: str | None = None) -> dict[str, Any]:
   try:
     response = requests.get(f"{base_url.rstrip('/')}/api/v1/get_server_capabilities", timeout=5.0)
     response.raise_for_status()
-    return response.json()
+    capabilities = response.json()
   except Exception as exc:
-    raise RuntimeError(f"Open-RL server at {base_url} is not reachable. Start it with `make run-function-gemma-server`.") from exc
+    raise RuntimeError(
+      f"Open-RL server at {base_url} is not reachable.\n"
+      f"Start it with:  make server BASE_MODEL={expected_model or '<model-id>'}"
+    ) from exc
+
+  server_model = capabilities.get("default_model")
+  if expected_model and server_model and server_model != expected_model:
+    raise RuntimeError(
+      f"Open-RL server at {base_url} is running {server_model!r}, "
+      f"but this recipe expects {expected_model!r}.\n"
+      f"Restart the server with:  make server BASE_MODEL={expected_model}"
+    )
+  return capabilities
 
 
 async def run_training(config: Config) -> None:
@@ -136,7 +148,7 @@ async def run_training(config: Config) -> None:
   if config.ci and not os.getenv("HF_TOKEN"):
     raise RuntimeError("CI mode requires HF_TOKEN")
 
-  capabilities = require_server(config.base_url)
+  capabilities = require_server(config.base_url, expected_model=config.base_model)
   print(f"Server ready at {config.base_url} | model={capabilities.get('default_model') or 'unset'}")
 
   # 2. Data

--- a/client/piglatin_sft.py
+++ b/client/piglatin_sft.py
@@ -87,8 +87,7 @@ def require_server(base_url: str, expected_model: str | None = None) -> dict[str
     capabilities = resp.json()
   except Exception as exc:
     raise RuntimeError(
-      f"Open-RL server at {base_url} is not reachable.\n"
-      f"Start it with:  make server BASE_MODEL={expected_model or '<model-id>'}"
+      f"Open-RL server at {base_url} is not reachable.\nStart it with:  make server BASE_MODEL={expected_model or '<model-id>'}"
     ) from exc
 
   server_model = capabilities.get("default_model")

--- a/client/piglatin_sft.py
+++ b/client/piglatin_sft.py
@@ -80,13 +80,25 @@ PRESETS = {
 }
 
 
-def require_server(base_url: str) -> dict[str, Any]:
+def require_server(base_url: str, expected_model: str | None = None) -> dict[str, Any]:
   try:
     resp = requests.get(f"{base_url.rstrip('/')}/api/v1/get_server_capabilities", timeout=5.0)
     resp.raise_for_status()
-    return resp.json()
+    capabilities = resp.json()
   except Exception as exc:
-    raise RuntimeError(f"Open-RL server at {base_url} is not reachable. Start it with `make run-pig-latin-server`.") from exc
+    raise RuntimeError(
+      f"Open-RL server at {base_url} is not reachable.\n"
+      f"Start it with:  make server BASE_MODEL={expected_model or '<model-id>'}"
+    ) from exc
+
+  server_model = capabilities.get("default_model")
+  if expected_model and server_model and server_model != expected_model:
+    raise RuntimeError(
+      f"Open-RL server at {base_url} is running {server_model!r}, "
+      f"but this recipe expects {expected_model!r}.\n"
+      f"Restart the server with:  make server BASE_MODEL={expected_model}"
+    )
+  return capabilities
 
 
 def normalize(text: str) -> str:
@@ -170,7 +182,7 @@ def plot_metrics(losses: list[float], eval_steps: list[int], eval_exact: list[fl
 
 
 def run_training(config: Config) -> dict[str, float]:
-  capabilities = require_server(config.base_url)
+  capabilities = require_server(config.base_url, expected_model=config.base_model)
   print(f"Server ready at {config.base_url} | model={capabilities.get('default_model') or 'unset'}")
 
   client = tinker.ServiceClient(api_key=os.getenv("TINKER_API_KEY", "tml-dummy-key"), base_url=config.base_url)

--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -3,9 +3,9 @@ requires = ["setuptools>=68"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "client"
+name = "open-rl-client"
 version = "0.1.0"
-description = "Add your description here"
+description = "Open-RL client: CLI and shared utilities for talking to an Open-RL server."
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
@@ -21,11 +21,12 @@ dependencies = [
     "opentelemetry-exporter-gcp-trace>=1.11.0",
     "opentelemetry-sdk>=1.40.0",
     "transformers>=5.5.0",
+    "ipykernel",
 ]
 
 [project.scripts]
-functiongemma-demo = "functiongemma_sft:cli"
+open-rl = "cli:main"
 
 [tool.setuptools]
 packages = []
-py-modules = ["cli", "sft", "rlvr", "functiongemma_sft", "piglatin_sft", "texttosql_sft", "verify_ppo", "plot_metrics", "plot_logs"]
+py-modules = ["cli"]

--- a/client/tests/test_piglatin_gemma.py
+++ b/client/tests/test_piglatin_gemma.py
@@ -30,13 +30,11 @@ class TestPigLatinGemma(unittest.TestCase):
     # We start the server directly using uv run to ensure we can kill it easily
     server_dir = client_dir.parent / "server"
 
-    # Mimic `make run-pig-latin-gemma-server`
+    # Mimic `make server BASE_MODEL=google/gemma-3-1b-it`
     env["ENABLE_GCP_TRACE"] = env.get("ENABLE_GCP_TRACE", "0")
-    env["UV_INDEX_URL"] = "https://pypi.org/simple"
     env["OPEN_RL_SINGLE_PROCESS"] = "1"
-    env["OPEN_RL_BASE_MODEL"] = "google/gemma-3-1b-it"
-    env["SAMPLER_BACKEND"] = "torch"
-    env["VLLM_MODEL"] = "google/gemma-3-1b-it"
+    env["BASE_MODEL"] = "google/gemma-3-1b-it"
+    env["SAMPLER"] = "torch"
 
     cmd = ["uv", "run", "--extra", "cpu", "uvicorn", "src.gateway:app", "--host", "127.0.0.1", "--port", "9002"]
 

--- a/client/tests/test_piglatin_gemma.py
+++ b/client/tests/test_piglatin_gemma.py
@@ -32,7 +32,7 @@ class TestPigLatinGemma(unittest.TestCase):
 
     # Mimic `make server BASE_MODEL=google/gemma-3-1b-it`
     env["ENABLE_GCP_TRACE"] = env.get("ENABLE_GCP_TRACE", "0")
-    env["OPEN_RL_SINGLE_PROCESS"] = "1"
+    env["SINGLE_PROCESS"] = "1"
     env["BASE_MODEL"] = "google/gemma-3-1b-it"
     env["SAMPLER"] = "torch"
 

--- a/client/texttosql_sft.py
+++ b/client/texttosql_sft.py
@@ -232,8 +232,7 @@ async def require_server(service_client: tinker.ServiceClient, base_url: str, ex
     capabilities = await service_client.get_server_capabilities_async()
   except Exception as exc:
     raise RuntimeError(
-      f"Open-RL server at {base_url} is not reachable.\n"
-      f"Start it with:  make server BASE_MODEL={expected_model or '<model-id>'}"
+      f"Open-RL server at {base_url} is not reachable.\nStart it with:  make server BASE_MODEL={expected_model or '<model-id>'}"
     ) from exc
 
   model_names = [model.model_name for model in capabilities.supported_models if getattr(model, "model_name", None)]

--- a/client/texttosql_sft.py
+++ b/client/texttosql_sft.py
@@ -121,7 +121,7 @@ async def run_training(config: Config, preset: str) -> dict[str, float | str]:
   ml_logger = ml_log.setup_logging(log_dir=str(log_dir), config=config, do_configure_logging_module=True)
   metrics_path = log_dir / "metrics.jsonl"
   client = tinker.ServiceClient(api_key=os.getenv("TINKER_API_KEY", "tml-dummy-key"), base_url=config.base_url)
-  server_model = await require_server(client, config.base_url)
+  server_model = await require_server(client, config.base_url, expected_model=config.base_model)
   logging.info("Server ready at %s | model=%s", config.base_url, server_model or "unset")
 
   trainer = await client.create_lora_training_client_async(
@@ -227,14 +227,25 @@ async def run_training(config: Config, preset: str) -> dict[str, float | str]:
   }
 
 
-async def require_server(service_client: tinker.ServiceClient, base_url: str) -> str | None:
+async def require_server(service_client: tinker.ServiceClient, base_url: str, expected_model: str | None = None) -> str | None:
   try:
     capabilities = await service_client.get_server_capabilities_async()
   except Exception as exc:
-    raise RuntimeError(f"Open-RL server at {base_url} is not reachable. Start it with `make run-text-to-sql-server`.") from exc
+    raise RuntimeError(
+      f"Open-RL server at {base_url} is not reachable.\n"
+      f"Start it with:  make server BASE_MODEL={expected_model or '<model-id>'}"
+    ) from exc
 
   model_names = [model.model_name for model in capabilities.supported_models if getattr(model, "model_name", None)]
-  return model_names[0] if model_names else None
+  server_model = model_names[0] if model_names else None
+
+  if expected_model and server_model and server_model != expected_model:
+    raise RuntimeError(
+      f"Open-RL server at {base_url} is running {server_model!r}, "
+      f"but this recipe expects {expected_model!r}.\n"
+      f"Restart the server with:  make server BASE_MODEL={expected_model}"
+    )
+  return server_model
 
 
 def normalize_sql(text: str) -> str:

--- a/docs/blog/from-mac-to-gke.md
+++ b/docs/blog/from-mac-to-gke.md
@@ -15,8 +15,8 @@ You can fine-tune Gemma 3 1B on a Text-to-SQL task locally — no cloud, no GPUs
 Start the server:
 
 ```bash
-OPEN_RL_BASE_MODEL="google/gemma-3-1b-pt" \
-  uv run uvicorn src.gateway:app --host 0.0.0.0 --port 8000
+BASE_MODEL="google/gemma-3-1b-pt" \
+  uv run uvicorn src.gateway:app --host 0.0.0.0 --port 9003
 ```
 
 Then write your training loop with the Tinker SDK — 4 API primitives are all you need:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,7 +9,7 @@ The Makefile wraps the common ones; k8s manifests set them in pod specs.
 | --- | --- | --- |
 | `BASE_MODEL` | *(required in single-process mode)* | The Hugging Face model id to load in the trainer **and** the vLLM sampler. Example: `google/gemma-4-e2b`. |
 | `SAMPLER` | `torch` when single-process, `vllm` otherwise | Which sampling backend to use. `torch` runs in the gateway process (CPU-friendly). `vllm` forwards sampling requests to a separate `python -m src.vllm_sampler` worker. |
-| `SINGLE_PROCESS` | auto-detected | `1` forces gateway + trainer + sampler into one process. Unset falls back to auto-detect: if `BASE_MODEL` is set and `REDIS_URL` is not, assume single-process. Distributed deployments shouldn't set this. |
+| `SINGLE_PROCESS` | auto-detected | `1` forces gateway + trainer into one process (the sampler is separate iff `SAMPLER=vllm`). Unset falls back to auto-detect: if `BASE_MODEL` is set and `REDIS_URL` is not, assume single-process. Distributed deployments shouldn't set this. |
 | `REDIS_URL` | unset | When set, the request store switches to Redis and the system runs in distributed mode (gateway, vLLM worker, and trainer worker as separate pods coordinating via Redis). Used by the k8s manifests in `server/kubernetes/distributed-{shared,lustre}/`. |
 | `VLLM_URL` | `http://127.0.0.1:8001` | Where the gateway looks for the vLLM worker when `SAMPLER=vllm`. The `make vllm` target starts the worker on this port. |
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,50 @@
+# Configuration
+
+All knobs that control Open-RL at runtime. Read from environment variables.
+The Makefile wraps the common ones; k8s manifests set them in pod specs.
+
+## Core
+
+| Env var | Default | What it does |
+| --- | --- | --- |
+| `BASE_MODEL` | *(required in single-process mode)* | The Hugging Face model id to load in the trainer **and** the vLLM sampler. Example: `google/gemma-4-e2b`. |
+| `SAMPLER` | `torch` when single-process, `vllm` otherwise | Which sampling backend to use. `torch` runs in the gateway process (CPU-friendly). `vllm` forwards sampling requests to a separate `python -m src.vllm_sampler` worker. |
+| `SINGLE_PROCESS` | auto-detected | `1` forces gateway + trainer + sampler into one process. Unset falls back to auto-detect: if `BASE_MODEL` is set and `REDIS_URL` is not, assume single-process. Distributed deployments shouldn't set this. |
+| `REDIS_URL` | unset | When set, the request store switches to Redis and the system runs in distributed mode (gateway, vLLM worker, and trainer worker as separate pods coordinating via Redis). Used by the k8s manifests in `server/kubernetes/distributed-{shared,lustre}/`. |
+| `VLLM_URL` | `http://127.0.0.1:8001` | Where the gateway looks for the vLLM worker when `SAMPLER=vllm`. The `make vllm` target starts the worker on this port. |
+
+## Server paths
+
+| Env var | Default | What it does |
+| --- | --- | --- |
+| `OPEN_RL_TMP_DIR` | `/tmp/open-rl` | Root dir for adapter snapshots (`peft/`) and saved state checkpoints (`checkpoints/`). |
+| `CUDA_VISIBLE_DEVICES` | unset | Standard PyTorch GPU selector. Pinned per-deployment in the k8s manifests. |
+
+## vLLM worker tuning
+
+| Env var | Default | What it does |
+| --- | --- | --- |
+| `MOCK_VLLM` | `0` | `1` stubs out vLLM so the worker returns dummy tokens. Useful on a Mac where vLLM isn't installable. |
+
+## Client
+
+| Env var | Default | What it does |
+| --- | --- | --- |
+| `TINKER_BASE_URL` / `OPEN_RL_BASE_URL` | `http://127.0.0.1:9003` | Where the client scripts point the tinker SDK. |
+| `TINKER_API_KEY` | `tml-dummy-key` | Passed through to the SDK. No real auth on the local server; any value works. |
+| `HF_TOKEN` | unset | Required for gated models (Gemma 3, FunctionGemma). `uv run hf auth login` is the easiest way to set it. |
+| `ENABLE_GCP_TRACE` | `0` | `1` exports OpenTelemetry traces to Google Cloud Trace. |
+| `ENABLE_CONSOLE_TRACE` | `0` | `1` prints trace spans to stdout (debugging). |
+
+## Quick reference
+
+```bash
+# Local single-process, torch sampler (default):
+make server BASE_MODEL=Qwen/Qwen3-0.6B
+
+# Local single-process, vLLM sampler (GPU):
+make vllm   BASE_MODEL=google/gemma-4-e2b   # terminal 1
+make server BASE_MODEL=google/gemma-4-e2b SAMPLER=vllm   # terminal 2
+
+# Distributed (GKE): configured via k8s manifests, no local command.
+```

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -6,11 +6,11 @@ The open-rl server is designed to run on a Kubernetes cluster with NVIDIA GPUs.
 The image is built using Docker BuildKit and pushed to Google Container Registry (GCR).
 
 > [!TIP]
-> You can change your GCP Project by editing the `GCP_PROJECT` variable in the `Makefile` (defaults to `cdrollouts-sunilarora`), or pass it via CLI: `make build-server-images GCP_PROJECT=my-project-id`.
+> You can change your GCP Project by editing the `GCP_PROJECT` variable in the `Makefile` (defaults to `cdrollouts-sunilarora`), or pass it via CLI: `make build-images GCP_PROJECT=my-project-id`.
 
 ```bash
-make build-server-images
-make push-server-images
+make build-images
+make push-images
 ```
 
 ### Configure Hugging Face Access
@@ -121,4 +121,4 @@ kubectl port-forward svc/open-rl-gateway-service 8000:8000
 Your SDK clients (e.g. `ServiceClient(base_url="http://localhost:8000")`) will now route traffic directly to the distributed GKE cluster.
 
 > [!TIP]
-> If a local process gets stuck on port 8000 from an old port-forward or server run, you can instantly terminate it with `make kill-server`.
+> If a local process gets stuck on a port from an old port-forward or server run, kill it with `kill -9 $(lsof -ti:<port>)`.

--- a/docs/guides/cli-tool.md
+++ b/docs/guides/cli-tool.md
@@ -6,7 +6,7 @@ The project includes a CLI tool for inspecting and interacting with trained adap
 View all fine-tuned sessions, including their aliases and creation timestamps.
 
 ```bash
-make run-cli-list
+make cli list
 ```
 
 **Output Example:**
@@ -21,18 +21,19 @@ ID                                       | ALIAS                          | CREA
 Interactively test a specific adapter model.
 
 ```bash
-make run-cli-chat MODEL=<model_id>
+make cli chat --model <model_id>
 ```
 
-**Optional: System Prompt Override**
+### 3. Other Commands
+For other arguments:
+
 ```bash
-make run-cli-chat MODEL=<model_id> PROMPT="You are a pirate."
+make cli chat --model <id> --temperature 0.9 --system-prompt "You are a pirate."
 ```
 
-### 3. Generic Usage
-For other commands or arguments not covered by shortcuts:
+Or run directly (after `uv sync`):
 
 ```bash
-make run-cli list
-make run-cli chat --model <id> --temperature 0.9
+open-rl list
+open-rl chat --model <id>
 ```

--- a/docs/guides/supervised/function-gemma.md
+++ b/docs/guides/supervised/function-gemma.md
@@ -25,7 +25,7 @@ Or manually:
 
 ```bash
 cd server
-OPEN_RL_SINGLE_PROCESS=1 \
+SINGLE_PROCESS=1 \
 SAMPLER=torch \
 BASE_MODEL="google/functiongemma-270m-it" \
 uv run --extra cpu uvicorn src.gateway:app --host 127.0.0.1 --port 9003

--- a/docs/guides/supervised/function-gemma.md
+++ b/docs/guides/supervised/function-gemma.md
@@ -18,16 +18,18 @@ This guide shows how to run the local FunctionGemma SFT demo.
 ## Running the Training Server
 
 ```bash
-cd server
-OPEN_RL_SINGLE_PROCESS=1 \
-SAMPLER_BACKEND=torch \
-OPEN_RL_BASE_MODEL="google/functiongemma-270m-it" \
-uv run --extra cpu uvicorn src.gateway:app --host 127.0.0.1 --port 9000
+make server BASE_MODEL=google/functiongemma-270m-it
 ```
 
-This starts a local server on port 9000, preloads `google/functiongemma-270m-it`, and runs the gateway plus engine loop in one process.
+Or manually:
 
-You can use `make run-function-gemma-server` as a wrapper around the same `uv run --extra cpu ...` flow.
+```bash
+cd server
+OPEN_RL_SINGLE_PROCESS=1 \
+SAMPLER=torch \
+BASE_MODEL="google/functiongemma-270m-it" \
+uv run --extra cpu uvicorn src.gateway:app --host 127.0.0.1 --port 9003
+```
 
 ## Running the SFT Script
 
@@ -35,7 +37,7 @@ In a second terminal, run:
 
 ```bash
 cd client
-uv run --python 3.12 functiongemma-demo
+uv run --python 3.12 python -u functiongemma_sft.py base_url="http://127.0.0.1:9003"
 ```
 
 This runs `client/functiongemma_sft.py`. The script:
@@ -48,17 +50,18 @@ This runs `client/functiongemma_sft.py`. The script:
 
 ## Common arguments
 
-Pass arguments through the Make target with `ARGS="..."`. `chz` expects `key=value` arguments:
+Pass `chz` arguments as `key=value`:
 
 ```bash
-make run-function-gemma ARGS="epochs=5 assert_loss_drop=true"
+cd client
+uv run --python 3.12 python -u functiongemma_sft.py epochs=5 assert_loss_drop=true
 ```
 
 Supported arguments in `functiongemma_sft.py`:
 - `epochs=<int>`: Number of training epochs (default 10).
 - `eval_limit=<int>`: Max number of evaluation examples (default 20).
 - `base_model=<str>`: The model repository (default `google/functiongemma-270m-it`).
-- `base_url=<str>`: The training server URL (default `http://127.0.0.1:9000`).
+- `base_url=<str>`: The training server URL (default `http://127.0.0.1:9003`).
 - `dataset=<str>`: The dataset to train on (default `bebechien/SimpleToolCalling`).
 - `rank=<int>`: The LoRA rank to use (default 16).
 - `plot_path=<str>`: Output path for the metrics chart.

--- a/docs/guides/supervised/pig-latin.md
+++ b/docs/guides/supervised/pig-latin.md
@@ -4,21 +4,21 @@ This script demonstrates fine-tuning a model to translate English into Pig Latin
 
 ### Option 1: Qwen (Default)
 
-Start the local single-process Open-RL server for Qwen:
+Start the local single-process Open-RL server for Qwen (`BASE_MODEL` defaults to `Qwen/Qwen3-0.6B`):
 
 ```bash
-make run-pig-latin-server
+make server
 ```
 
 Then run the training demo in a second terminal:
 
 ```bash
-make run-pig-latin-sft
+cd client && uv run --python 3.12 python -u piglatin_sft.py qwen
 ```
 
 What it does:
 
-- starts a local Open-RL server on `http://127.0.0.1:9001`
+- starts a local Open-RL server on `http://127.0.0.1:9003`
 - loads `Qwen/Qwen3-0.6B`
 - trains a LoRA adapter on word-level Pig Latin pairs
 - runs pre/post translation evaluation and saves plots into `artifacts/`
@@ -27,21 +27,21 @@ What it does:
 
 ### Option 2: Gemma
 
-Start the local single-process Open-RL server for Gemma:
+Start the local single-process Open-RL server for Gemma (set `BASE_MODEL`):
 
 ```bash
-make run-pig-latin-gemma-server
+make server BASE_MODEL=google/gemma-3-1b-it
 ```
 
 Then run the training demo in a second terminal:
 
 ```bash
-make run-pig-latin-gemma-sft
+cd client && uv run --python 3.12 python -u piglatin_sft.py gemma
 ```
 
 What it does:
 
-- starts a local Open-RL server on `http://127.0.0.1:9002`
+- starts a local Open-RL server on `http://127.0.0.1:9003`
 - loads `google/gemma-3-1b-it`
 - trains a LoRA adapter on word-level Pig Latin pairs
 - runs pre/post translation evaluation and saves plots into `artifacts/`

--- a/server/README.md
+++ b/server/README.md
@@ -7,6 +7,6 @@ Use the client README for the full repo bootstrap flow:
 Then pick the server environment that matches your local workflow:
 
 - local single-process (CPU, torch sampler):
-  `cd server && uv sync --extra cpu && OPEN_RL_SINGLE_PROCESS=1 SAMPLER=torch BASE_MODEL="Qwen/Qwen3-0.6B" uv run --extra cpu uvicorn src.gateway:app --host 127.0.0.1 --port 9003`
+  `cd server && uv sync --extra cpu && SINGLE_PROCESS=1 SAMPLER=torch BASE_MODEL="Qwen/Qwen3-0.6B" uv run --extra cpu uvicorn src.gateway:app --host 127.0.0.1 --port 9003`
 - standalone vLLM worker (GPU):
   `cd server && uv sync --extra gpu --extra vllm && BASE_MODEL="Qwen/Qwen3-4B-Instruct-2507" uv run --extra gpu --extra vllm python -m src.vllm_sampler`

--- a/server/README.md
+++ b/server/README.md
@@ -6,9 +6,7 @@ Use the client README for the full repo bootstrap flow:
 
 Then pick the server environment that matches your local workflow:
 
-- gateway/core only:
-  `cd server && uv sync && uv run uvicorn src.gateway:app --host 127.0.0.1 --port 8000`
-- local single-process training (CPU PyTorch):
-  `cd server && uv sync --extra cpu && OPEN_RL_SINGLE_PROCESS=1 SAMPLER_BACKEND=torch OPEN_RL_BASE_MODEL="Qwen/Qwen3-0.6B" uv run --extra cpu uvicorn src.gateway:app --host 127.0.0.1 --port 9001`
-- Linux GPU/vLLM worker (CUDA PyTorch):
-  `cd server && uv sync --extra gpu --extra vllm && CUDA_VISIBLE_DEVICES=0 VLLM_MODEL="Qwen/Qwen3-4B-Instruct-2507" uv run --extra gpu --extra vllm python -m src.vllm_sampler`
+- local single-process (CPU, torch sampler):
+  `cd server && uv sync --extra cpu && OPEN_RL_SINGLE_PROCESS=1 SAMPLER=torch BASE_MODEL="Qwen/Qwen3-0.6B" uv run --extra cpu uvicorn src.gateway:app --host 127.0.0.1 --port 9003`
+- standalone vLLM worker (GPU):
+  `cd server && uv sync --extra gpu --extra vllm && BASE_MODEL="Qwen/Qwen3-4B-Instruct-2507" uv run --extra gpu --extra vllm python -m src.vllm_sampler`

--- a/server/kubernetes/distributed-lustre/03-vllm.yaml
+++ b/server/kubernetes/distributed-lustre/03-vllm.yaml
@@ -38,7 +38,7 @@ spec:
         ports:
         - containerPort: 8001
         env:
-        - name: VLLM_MODEL
+        - name: BASE_MODEL
           value: "Qwen/Qwen3-4B-Instruct-2507"
         - name: CUDA_VISIBLE_DEVICES
           value: "0"

--- a/server/kubernetes/distributed-lustre/04-gateway.yaml
+++ b/server/kubernetes/distributed-lustre/04-gateway.yaml
@@ -50,7 +50,7 @@ spec:
           value: "redis://redis-service:6379"
         - name: VLLM_URL
           value: "http://vllm-service:8001"
-        - name: VLLM_MODEL
+        - name: BASE_MODEL
           value: "Qwen/Qwen3-4B-Instruct-2507"
         - name: OPEN_RL_TMP_DIR
           value: "/mnt/lustre/open-rl"

--- a/server/kubernetes/distributed-lustre/05-trainer-worker.yaml
+++ b/server/kubernetes/distributed-lustre/05-trainer-worker.yaml
@@ -29,7 +29,7 @@ spec:
           value: "redis://redis-service:6379"
         - name: CUDA_VISIBLE_DEVICES
           value: "0"
-        - name: VLLM_MODEL
+        - name: BASE_MODEL
           value: "Qwen/Qwen3-4B-Instruct-2507"
         - name: OPEN_RL_TMP_DIR
           value: "/mnt/lustre/open-rl"

--- a/server/kubernetes/distributed-shared/03-vllm.yaml
+++ b/server/kubernetes/distributed-shared/03-vllm.yaml
@@ -38,7 +38,7 @@ spec:
         ports:
         - containerPort: 8001
         env:
-        - name: VLLM_MODEL
+        - name: BASE_MODEL
           value: "Qwen/Qwen3-4B-Instruct-2507"
         - name: CUDA_VISIBLE_DEVICES
           value: "0"

--- a/server/kubernetes/distributed-shared/04-gateway.yaml
+++ b/server/kubernetes/distributed-shared/04-gateway.yaml
@@ -50,7 +50,7 @@ spec:
           value: "redis://redis-service:6379"
         - name: VLLM_URL
           value: "http://vllm-service:8001"
-        - name: VLLM_MODEL
+        - name: BASE_MODEL
           value: "Qwen/Qwen3-4B-Instruct-2507"
         - name: OPEN_RL_TMP_DIR
           value: "/mnt/shared/open-rl"

--- a/server/kubernetes/distributed-shared/05-trainer-worker.yaml
+++ b/server/kubernetes/distributed-shared/05-trainer-worker.yaml
@@ -29,7 +29,7 @@ spec:
           value: "redis://redis-service:6379"
         - name: CUDA_VISIBLE_DEVICES
           value: "0"
-        - name: VLLM_MODEL
+        - name: BASE_MODEL
           value: "Qwen/Qwen3-4B-Instruct-2507"
         - name: OPEN_RL_TMP_DIR
           value: "/mnt/shared/open-rl"

--- a/server/kubernetes/single-process-gke/04-deployment.yaml
+++ b/server/kubernetes/single-process-gke/04-deployment.yaml
@@ -31,11 +31,9 @@ spec:
           env:
             - name: OPEN_RL_SINGLE_PROCESS
               value: "1"
-            - name: SAMPLER_BACKEND
+            - name: SAMPLER
               value: "torch"
-            - name: OPEN_RL_BASE_MODEL
-              value: "google/gemma-4-e2b"
-            - name: VLLM_MODEL
+            - name: BASE_MODEL
               value: "google/gemma-4-e2b"
             - name: CUDA_VISIBLE_DEVICES
               value: "0"

--- a/server/kubernetes/single-process-gke/04-deployment.yaml
+++ b/server/kubernetes/single-process-gke/04-deployment.yaml
@@ -29,7 +29,7 @@ spec:
           ports:
             - containerPort: 8000
           env:
-            - name: OPEN_RL_SINGLE_PROCESS
+            - name: SINGLE_PROCESS
               value: "1"
             - name: SAMPLER
               value: "torch"

--- a/server/src/clock_cycle.py
+++ b/server/src/clock_cycle.py
@@ -168,13 +168,13 @@ def main() -> None:
   cuda_devs = os.getenv("CUDA_VISIBLE_DEVICES", "ALL")
   print(f"-> Hardware : CUDA_VISIBLE_DEVICES={cuda_devs}\n")
 
-  preload_target = os.getenv("OPEN_RL_BASE_MODEL") or os.getenv("VLLM_MODEL")
+  preload_target = os.getenv("BASE_MODEL")
   is_ready = False
   if preload_target:
     engine.load_base_model(preload_target)
     is_ready = True
   else:
-    print("[WARNING] OPEN_RL_BASE_MODEL / VLLM_MODEL not provided. Cold-start penalty will apply on first request.")
+    print("[WARNING] BASE_MODEL not provided. Cold-start penalty will apply on first request.")
     is_ready = True
 
   probe_app = FastAPI()

--- a/server/src/gateway.py
+++ b/server/src/gateway.py
@@ -54,13 +54,12 @@ def is_single_process_mode() -> bool:
   explicit = os.getenv("OPEN_RL_SINGLE_PROCESS")
   if explicit is not None:
     return explicit == "1"
-  return bool(os.getenv("OPEN_RL_BASE_MODEL")) and not bool(os.getenv("REDIS_URL"))
+  return bool(os.getenv("BASE_MODEL")) and not bool(os.getenv("REDIS_URL"))
 
 
 def get_sampler_backend() -> str:
-  explicit = os.getenv("SAMPLER_BACKEND")
-  if explicit:
-    return explicit.lower()
+  if sampler := os.getenv("SAMPLER"):
+    return sampler.lower()
   return "torch" if is_single_process_mode() else "vllm"
 
 
@@ -70,7 +69,7 @@ def get_default_model_name() -> str | None:
 
     if clock_cycle.engine.base_model_name:
       return clock_cycle.engine.base_model_name
-  return os.getenv("OPEN_RL_BASE_MODEL") or os.getenv("VLLM_MODEL")
+  return os.getenv("BASE_MODEL")
 
 
 async def _enqueue(payload: dict) -> str:
@@ -85,18 +84,40 @@ async def _enqueue(payload: dict) -> str:
   return req_id
 
 
+async def _preflight_vllm() -> None:
+  """If SAMPLER=vllm, verify the vLLM worker is reachable at VLLM_URL.
+
+  Prints a clear, actionable error instead of letting the first asample
+  request fall through with a raw httpx connection refused.
+  """
+  if get_sampler_backend() != "vllm":
+    return
+  healthz = f"{VLLM_URL.rstrip('/')}/healthz"
+  try:
+    async with httpx.AsyncClient(timeout=3.0) as client:
+      resp = await client.get(healthz)
+      resp.raise_for_status()
+  except Exception as exc:
+    raise RuntimeError(
+      f"SAMPLER=vllm but no vLLM worker is reachable at {VLLM_URL}.\n"
+      f"Start it first with:  make vllm BASE_MODEL={os.getenv('BASE_MODEL') or '<model-id>'}"
+    ) from exc
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
   task = None
   if is_single_process_mode():
     from . import clock_cycle
 
-    base_model = os.getenv("OPEN_RL_BASE_MODEL")
+    base_model = os.getenv("BASE_MODEL")
     print("\n" + "=" * 50)
     print(" Open-RL Single-Process Mode")
     print("=" * 50)
     print(f"-> Base model: {base_model or 'unset'}")
+    print(f"-> Sampler   : {get_sampler_backend()}")
     print("-> Backend   : gateway + worker loop in one process\n")
+    await _preflight_vllm()
     if base_model:
       await asyncio.to_thread(clock_cycle.engine.load_base_model, base_model)
     task = asyncio.create_task(clock_cycle.clock_cycle_loop())

--- a/server/src/gateway.py
+++ b/server/src/gateway.py
@@ -51,7 +51,7 @@ VLLM_URL = os.getenv("VLLM_URL", "http://127.0.0.1:8001")
 
 
 def is_single_process_mode() -> bool:
-  explicit = os.getenv("OPEN_RL_SINGLE_PROCESS")
+  explicit = os.getenv("SINGLE_PROCESS")
   if explicit is not None:
     return explicit == "1"
   return bool(os.getenv("BASE_MODEL")) and not bool(os.getenv("REDIS_URL"))

--- a/server/src/vllm_sampler.py
+++ b/server/src/vllm_sampler.py
@@ -45,22 +45,21 @@ async def startup():
   print("        Open-RL vLLM Inference Engine")
   print("=" * 50)
   cuda_devs = os.environ.get("CUDA_VISIBLE_DEVICES", "ALL")
-  model_name = os.environ.get("VLLM_MODEL", "Not Set")
+  model_name = os.environ.get("BASE_MODEL")
   print(f"-> Hardware     : CUDA_VISIBLE_DEVICES={cuda_devs}")
-  print(f"-> Memory Matrix: {model_name}\n")
+  print(f"-> Memory Matrix: {model_name or 'Not Set'}\n")
 
   mock_vllm = os.environ.get("MOCK_VLLM", "0") == "1"
   if mock_vllm or AsyncLLMEngine is None:
     print("[vLLM Subprocess] MOCK_VLLM=1 or vllm not installed, bypassing real engine init for local dev.")
     return
 
-  # Use arguments suitable for the v2 architecture
-  if not os.environ.get("VLLM_MODEL"):
-    print("[vLLM Subprocess] Error: VLLM_MODEL environment variable is required.")
+  if not model_name:
+    print("[vLLM Subprocess] Error: BASE_MODEL environment variable is required.")
     sys.exit(1)
 
   engine_args = AsyncEngineArgs(
-    model=os.environ.get("VLLM_MODEL"),
+    model=model_name,
     enable_lora=True,
     max_loras=8,
     max_lora_rank=64,

--- a/server/src/vllm_sampler.py
+++ b/server/src/vllm_sampler.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from contextlib import asynccontextmanager
 
 import uvicorn
 from fastapi import FastAPI, Request
@@ -31,14 +32,12 @@ if os.environ.get("ENABLE_GCP_TRACE", "0") == "1":
     print("OpenTelemetry: opentelemetry-exporter-gcp-trace is not installed")
 
 tracer = trace.get_tracer("vllm.inference.worker")
-app = FastAPI(title="Open-RL vLLM Subprocess")
-FastAPIInstrumentor.instrument_app(app, excluded_urls="/healthz")
 
 engine = None
 
 
-@app.on_event("startup")
-async def startup():
+@asynccontextmanager
+async def lifespan(app: FastAPI):
   global engine
 
   print("\n" + "=" * 50)
@@ -47,29 +46,33 @@ async def startup():
   cuda_devs = os.environ.get("CUDA_VISIBLE_DEVICES", "ALL")
   model_name = os.environ.get("BASE_MODEL")
   print(f"-> Hardware     : CUDA_VISIBLE_DEVICES={cuda_devs}")
-  print(f"-> Memory Matrix: {model_name or 'Not Set'}\n")
+  print(f"-> Model        : {model_name or 'Not Set'}\n")
 
   mock_vllm = os.environ.get("MOCK_VLLM", "0") == "1"
   if mock_vllm or AsyncLLMEngine is None:
     print("[vLLM Subprocess] MOCK_VLLM=1 or vllm not installed, bypassing real engine init for local dev.")
-    return
-
-  if not model_name:
+  elif not model_name:
     print("[vLLM Subprocess] Error: BASE_MODEL environment variable is required.")
     sys.exit(1)
+  else:
+    engine_args = AsyncEngineArgs(
+      model=model_name,
+      enable_lora=True,
+      max_loras=8,
+      max_lora_rank=64,
+      max_model_len=8192,
+      gpu_memory_utilization=0.60,
+      enable_prefix_caching=False,
+      enforce_eager=True,
+    )
+    engine = AsyncLLMEngine.from_engine_args(engine_args)
+    print("[vLLM Subprocess] Engine initialized and ready to serve IPC requests.")
 
-  engine_args = AsyncEngineArgs(
-    model=model_name,
-    enable_lora=True,
-    max_loras=8,
-    max_lora_rank=64,
-    max_model_len=8192,  # Prevent KV cache OOM on massive context windows
-    gpu_memory_utilization=0.60,  # Leave room for other things if needed
-    enable_prefix_caching=False,  # Disable prefix caching to test concurrent throughput
-    enforce_eager=True,  # Useful for small setups
-  )
-  engine = AsyncLLMEngine.from_engine_args(engine_args)
-  print("[vLLM Subprocess] Engine initialized and ready to serve IPC requests.")
+  yield
+
+
+app = FastAPI(title="Open-RL vLLM Subprocess", lifespan=lifespan)
+FastAPIInstrumentor.instrument_app(app, excluded_urls="/healthz")
 
 
 @app.get("/healthz")


### PR DESCRIPTION
Fixes #18 

This simplifies the amount of knobs we have on starting a server and the makefile. We now only have BASE_MODEL and SAMPLER (torch, vllm). I also documented all the configuration we have [here](https://github.com/ShubyM/open-rl/blob/21782d469f105e952f953efdbbf21f52177cefbe/docs/configuration.md).  As a result the makefile does not contain custom targets for each possible of configuration for server and client. We have the user run commands like `make server BASE_MODEL=google/gemma-4-e2b SAMPLER=vllm`. The client can then directly run the client side script using uv run. The diff is very nosiy because I also had to update documentation in a lot of places.