### PR TITLE
feat: upgrade vllm to 0.20.0

### DIFF
--- a/examples/rl/text-to-sql/README.md
+++ b/examples/rl/text-to-sql/README.md
@@ -111,7 +111,7 @@ All commands below assume you are in the **repository root** directory.
 
 ### 1. Patch vLLM
 
-Patch vLLM for Gemma 4 LoRA support. This is a temporary local patch for duplicate LoRA module registration, related to [vllm-project/vllm#39246](https://github.com/vllm-project/vllm/issues/39246).
+Patch vLLM `0.20.0` for Gemma 4 LoRA support. This is a temporary local patch for duplicate LoRA module registration, related to [vllm-project/vllm#39246](https://github.com/vllm-project/vllm/issues/39246).
 
 ```bash
 (cd src/server && \

--- a/src/server/pyproject.toml
+++ b/src/server/pyproject.toml
@@ -35,7 +35,7 @@ gpu = [
 vllm = [
     "torch; sys_platform == 'linux'",
     "torch-c-dlpack-ext; sys_platform == 'linux'",
-    "vllm==0.19.1; sys_platform == 'linux'",
+    "vllm==0.20.0; sys_platform == 'linux'",
 ]
 
 [tool.uv]
@@ -62,7 +62,12 @@ explicit = true
 
 [[tool.uv.index]]
 name = "torch-gpu"
-url = "https://download.pytorch.org/whl/cu128"
+url = "https://download.pytorch.org/whl/cu129"
+explicit = true
+
+[[tool.uv.index]]
+name = "vllm-cu129"
+url = "https://wheels.vllm.ai/0.20.0/cu129"
 explicit = true
 
 [tool.uv.sources]
@@ -71,4 +76,7 @@ torch = [
     { index = "torch-cpu", extra = "cpu" },
     { index = "torch-gpu", extra = "gpu", marker = "sys_platform == 'linux'" },
     { index = "torch-gpu", extra = "vllm", marker = "sys_platform == 'linux'" },
+]
+vllm = [
+    { index = "vllm-cu129", extra = "vllm", marker = "sys_platform == 'linux'" },
 ]

--- a/src/server/scripts/patch_vllm_lora_dedup.py
+++ b/src/server/scripts/patch_vllm_lora_dedup.py
@@ -1,13 +1,15 @@
-"""Patch vLLM's LoRA module registration to avoid duplicate Gemma4 modules.
+"""Patch vLLM's LoRA activation to avoid duplicate Gemma4 module aliases.
 
 Gemma4's YOCO decoder split introduces shared module references. Older vLLM
-builds register those duplicates separately with
-`named_modules(remove_duplicate=False)`, which causes LoRA weights to be set on
-one path and then immediately zeroed out on the duplicate path.
+builds register those aliases separately with `named_modules(remove_duplicate=False)`.
+The aliases are needed by vLLM 0.20's torch compile path, but activation then
+iterates those aliases and can set LoRA weights on one path before immediately
+resetting the same wrapper object through an alias with no matching adapter
+weights.
 
-This helper makes the tiny local patch that switches back to the default
-deduping `named_modules()` behavior. Run it after installing or upgrading vLLM
-until the upstream fix lands everywhere we care about.
+This helper keeps the alias registration intact and dedupes only activation by
+wrapper object identity. Run it after installing or upgrading vLLM until the
+upstream fix lands everywhere we care about.
 """
 
 from __future__ import annotations
@@ -17,8 +19,45 @@ import importlib.util
 import sys
 from pathlib import Path
 
-BAD = "self.model.named_modules(remove_duplicate=False)"
-GOOD = "self.model.named_modules()"
+BAD = """        for module_name, module in self.modules.items():
+            module_lora = self._get_lora_layer_weights(lora_model, module_name)
+            if not module_lora:
+                module.reset_lora(index)
+                logger.debug(
+                    "No LoRA weights found for module %s, skipping.", module_name
+                )
+                continue
+
+            module.set_lora(
+                index,
+                module_lora.lora_a,
+                module_lora.lora_b,
+            )
+            logger.debug("Successfully loaded LoRA weights for module %s.", module_name)
+"""
+
+GOOD = """        seen_modules: set[int] = set()
+        for module_name, module in self.modules.items():
+            module_key = id(module)
+            if module_key in seen_modules:
+                continue
+            seen_modules.add(module_key)
+
+            module_lora = self._get_lora_layer_weights(lora_model, module_name)
+            if not module_lora:
+                module.reset_lora(index)
+                logger.debug(
+                    "No LoRA weights found for module %s, skipping.", module_name
+                )
+                continue
+
+            module.set_lora(
+                index,
+                module_lora.lora_a,
+                module_lora.lora_b,
+            )
+            logger.debug("Successfully loaded LoRA weights for module %s.", module_name)
+"""
 
 
 def find_model_manager(venv: str | None = None) -> Path:
@@ -42,14 +81,14 @@ def main() -> int:
   source = path.read_text()
 
   if BAD not in source:
-    if GOOD in source:
+    if "seen_modules: set[int] = set()" in source:
       print(f"OK: {path} is already patched")
       return 0
     print(f"WARN: {path} has neither the buggy nor fixed pattern")
     return 1
 
   if args.check:
-    print(f"NEEDS_PATCH: {path} has the buggy remove_duplicate=False pattern")
+    print(f"NEEDS_PATCH: {path} activates duplicate LoRA module aliases")
     return 2
 
   path.write_text(source.replace(BAD, GOOD, 1))

--- a/src/server/scripts/patch_vllm_lora_dedup.py
+++ b/src/server/scripts/patch_vllm_lora_dedup.py
@@ -2,7 +2,7 @@
 
 Gemma4's YOCO decoder split introduces shared module references. Older vLLM
 builds register those aliases separately with `named_modules(remove_duplicate=False)`.
-The aliases are needed by vLLM 0.20's torch compile path, but activation then
+The aliases are needed by vLLM 0.20.0's torch compile path, but activation then
 iterates those aliases and can set LoRA weights on one path before immediately
 resetting the same wrapper object through an alias with no matching adapter
 weights.

--- a/src/server/trainer.py
+++ b/src/server/trainer.py
@@ -50,6 +50,7 @@ class TrainerEngine:
 
     # Store optimizers per model_id (adapter ID)
     self.optimizers: dict[str, torch.optim.Optimizer] = {}
+    self.lora_target_modules: dict[tuple[bool, bool, bool], list[str]] = {}
 
     # Decide device
     if torch.cuda.is_available():
@@ -73,6 +74,31 @@ class TrainerEngine:
     self.base_model = AutoModelForCausalLM.from_pretrained(base_model_name, dtype=dtype, device_map=self.device)
     print("Successfully loaded.")
 
+  def _target_lora_modules(self, config: LoraConfig) -> list[str]:
+    assert self.base_model is not None
+
+    cache_key = (config.train_attn, config.train_mlp, config.train_unembed)
+    if cache_key in self.lora_target_modules:
+      return self.lora_target_modules[cache_key]
+
+    target_suffixes: list[str] = []
+    if config.train_attn:
+      target_suffixes.extend(["q_proj", "k_proj", "v_proj", "o_proj"])
+    if config.train_mlp:
+      # TODO: Revisit MLP targets for packed/MoE module names across supported backends.
+      target_suffixes.extend(["gate_proj", "up_proj", "down_proj"])
+    if config.train_unembed and not target_suffixes:
+      target_suffixes.append("lm_head")
+
+    target_names = set(target_suffixes)
+    target_modules = [
+      name for name, module in self.base_model.named_modules() if name.rsplit(".", 1)[-1] in target_names and isinstance(module, torch.nn.Linear)
+    ]
+    if not target_modules:
+      raise ValueError(f"No supported LoRA target modules found for suffixes: {target_suffixes}")
+    self.lora_target_modules[cache_key] = target_modules
+    return target_modules
+
   def create_adapter(self, adapter_id: str, config: LoraConfig) -> None:
     """Create a new LoRA adapter on top of the loaded base model."""
     assert self.base_model is not None, "Base model is not loaded. Call load_base_model first."
@@ -85,44 +111,13 @@ class TrainerEngine:
 
     print(f"Creating LoRA adapter '{adapter_id}'...")
 
-    target_suffixes: list[str] = []
-    if config.train_attn:
-      target_suffixes.extend(["q_proj", "k_proj", "v_proj", "o_proj"])
-    if config.train_mlp:
-      target_suffixes.extend(["gate_proj", "up_proj", "down_proj"])
-
-    # Decide target_modules based on model type and config
-    explicit_target_modules = os.getenv("OPEN_RL_TARGET_MODULES")
-    use_text_tower_lora = getattr(self.base_model.config, "model_type", None) == "gemma4"
-    target_modules: str | list[str]
-    layers_to_transform = None
-    layers_pattern = None
-
-    if explicit_target_modules == "all-linear":
-      target_modules = "all-linear"
-      print("[trainer] Forcing PEFT target_modules=all-linear via OPEN_RL_TARGET_MODULES")
-    elif use_text_tower_lora:
-      if target_suffixes:
-        target_modules = target_suffixes
-        model_config = getattr(self.base_model.config, "text_config", self.base_model.config)
-        layers_to_transform = list(range(model_config.num_hidden_layers))
-        layers_pattern = "language_model.layers"
-      else:
-        target_modules = []
-    elif config.train_attn and config.train_mlp and config.train_unembed:
-      target_modules = "all-linear"
-    else:
-      target_modules = target_suffixes
-
     peft_config = PeftLoraConfig(
       task_type="CAUSAL_LM",
       r=config.rank,
       lora_alpha=config.lora_alpha,
       lora_dropout=config.lora_dropout,
       bias="none",
-      target_modules=target_modules,
-      layers_to_transform=layers_to_transform,
-      layers_pattern=layers_pattern,
+      target_modules=self._target_lora_modules(config),
       modules_to_save=["lm_head", "embed_tokens"] if config.train_unembed else None,
     )
 

--- a/src/server/trainer.py
+++ b/src/server/trainer.py
@@ -87,7 +87,7 @@ class TrainerEngine:
     if config.train_mlp:
       # TODO: Revisit MLP targets for packed/MoE module names across supported backends.
       target_suffixes.extend(["gate_proj", "up_proj", "down_proj"])
-    if config.train_unembed and not target_suffixes:
+    if config.train_unembed:
       target_suffixes.append("lm_head")
 
     target_names = set(target_suffixes)
@@ -118,7 +118,7 @@ class TrainerEngine:
       lora_dropout=config.lora_dropout,
       bias="none",
       target_modules=self._target_lora_modules(config),
-      modules_to_save=["lm_head", "embed_tokens"] if config.train_unembed else None,
+      modules_to_save=None,
     )
 
     if config.seed is not None:

--- a/src/server/uv.lock
+++ b/src/server/uv.lock
@@ -2,9 +2,10 @@ version = 1
 revision = 3
 requires-python = "==3.12.*"
 resolution-markers = [
+    "sys_platform == 'darwin' and extra != 'extra-6-server-cpu' and extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm'",
     "sys_platform == 'win32' and extra != 'extra-6-server-cpu' and extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm'",
     "sys_platform == 'emscripten' and extra != 'extra-6-server-cpu' and extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm'",
-    "sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-6-server-cpu' and extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm'",
+    "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-6-server-cpu' and extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm'",
     "sys_platform == 'win32' and extra != 'extra-6-server-cpu' and extra == 'extra-6-server-gpu' and extra != 'extra-6-server-vllm'",
     "sys_platform == 'emscripten' and extra != 'extra-6-server-cpu' and extra == 'extra-6-server-gpu' and extra != 'extra-6-server-vllm'",
     "sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-6-server-cpu' and extra == 'extra-6-server-gpu' and extra != 'extra-6-server-vllm'",
@@ -12,7 +13,8 @@ resolution-markers = [
     "sys_platform == 'emscripten' and extra == 'extra-6-server-cpu' and extra != 'extra-6-server-gpu' and extra != 'extra-6-server-vllm'",
     "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-cpu' and extra != 'extra-6-server-gpu' and extra != 'extra-6-server-vllm'",
     "sys_platform == 'darwin' and extra == 'extra-6-server-cpu' and extra != 'extra-6-server-gpu' and extra != 'extra-6-server-vllm'",
-    "extra != 'extra-6-server-cpu' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm'",
+    "sys_platform == 'darwin' and extra != 'extra-6-server-cpu' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm'",
+    "sys_platform != 'darwin' and extra != 'extra-6-server-cpu' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm'",
     "extra != 'extra-6-server-cpu' and extra != 'extra-6-server-gpu' and extra != 'extra-6-server-vllm'",
 ]
 conflicts = [[
@@ -37,9 +39,10 @@ dependencies = [
     { name = "psutil" },
     { name = "pyyaml" },
     { name = "safetensors" },
-    { name = "torch", version = "2.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "extra == 'extra-6-server-gpu' or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
     { name = "torch", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-6-server-cpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+    { name = "torch", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform == 'emscripten' and extra == 'extra-6-server-gpu') or (sys_platform == 'win32' and extra == 'extra-6-server-gpu') or (sys_platform == 'darwin' and extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
     { name = "torch", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-cpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+    { name = "torch", version = "2.11.0+cu129", source = { registry = "https://download.pytorch.org/whl/cu129" }, marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-gpu') or (sys_platform == 'darwin' and extra == 'extra-6-server-gpu' and extra != 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ca/14/787e5498cd062640f0f3d92ef4ae4063174f76f9afd29d13fc52a319daae/accelerate-1.13.0.tar.gz", hash = "sha256:d631b4e0f5b3de4aff2d7e9e6857d164810dfc3237d54d017f075122d057b236", size = 402835, upload-time = "2026-03-04T19:34:12.359Z" }
 wheels = [
@@ -60,13 +63,13 @@ name = "aiohttp"
 version = "3.13.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiohappyeyeballs" },
-    { name = "aiosignal" },
-    { name = "attrs" },
-    { name = "frozenlist" },
-    { name = "multidict" },
-    { name = "propcache" },
-    { name = "yarl" },
+    { name = "aiohappyeyeballs", marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-vllm') or extra == 'extra-6-server-cpu' or extra == 'extra-6-server-gpu'" },
+    { name = "aiosignal", marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-vllm') or extra == 'extra-6-server-cpu' or extra == 'extra-6-server-gpu'" },
+    { name = "attrs", marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-vllm') or extra == 'extra-6-server-cpu' or extra == 'extra-6-server-gpu'" },
+    { name = "frozenlist", marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-vllm') or extra == 'extra-6-server-cpu' or extra == 'extra-6-server-gpu'" },
+    { name = "multidict", marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-vllm') or extra == 'extra-6-server-cpu' or extra == 'extra-6-server-gpu'" },
+    { name = "propcache", marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-vllm') or extra == 'extra-6-server-cpu' or extra == 'extra-6-server-gpu'" },
+    { name = "yarl", marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-vllm') or extra == 'extra-6-server-cpu' or extra == 'extra-6-server-gpu'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/77/9a/152096d4808df8e4268befa55fba462f440f14beab85e8ad9bf990516918/aiohttp-3.13.5.tar.gz", hash = "sha256:9d98cc980ecc96be6eb4c1994ce35d28d8b1f5e5208a23b421187d1209dbb7d1", size = 7858271, upload-time = "2026-03-31T22:01:03.343Z" }
 wheels = [
@@ -94,8 +97,8 @@ name = "aiosignal"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "frozenlist" },
-    { name = "typing-extensions" },
+    { name = "frozenlist", marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-vllm') or extra == 'extra-6-server-cpu' or extra == 'extra-6-server-gpu'" },
+    { name = "typing-extensions", marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-vllm') or extra == 'extra-6-server-cpu' or extra == 'extra-6-server-gpu'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
 wheels = [
@@ -125,14 +128,14 @@ name = "anthropic"
 version = "0.97.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "distro" },
-    { name = "docstring-parser" },
-    { name = "httpx" },
-    { name = "jiter" },
-    { name = "pydantic" },
-    { name = "sniffio" },
-    { name = "typing-extensions" },
+    { name = "anyio", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "distro", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "docstring-parser", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "httpx", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "jiter", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "pydantic", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "sniffio", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "typing-extensions", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/14/93/f66ea8bfe39f2e6bb9da8e27fa5457ad2520e8f7612dfc547b17fad55c4d/anthropic-0.97.0.tar.gz", hash = "sha256:021e79fd8e21e90ad94dc5ba2bbbd8b1599f424f5b1fab6c06204009cab764be", size = 669502, upload-time = "2026-04-23T20:52:34.445Z" }
 wheels = [
@@ -154,19 +157,19 @@ wheels = [
 
 [[package]]
 name = "apache-tvm-ffi"
-version = "0.1.10"
+version = "0.1.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/17/b0/5114e30faffe3279a51a5f3b45dd1b7ce09af1246b62447b45a39a374e54/apache_tvm_ffi-0.1.10.tar.gz", hash = "sha256:974c208766c304c780c17c6d405449e862f83b22c7b6b2b8c28b29d55a806ae3", size = 2691605, upload-time = "2026-04-07T19:58:51.767Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/60/1e787a0b5ebf318483235be2a689ee367173983067e441b8379564f667c0/apache_tvm_ffi-0.1.9.tar.gz", hash = "sha256:d2d402587e8906de0a07f4746aa78f3d452c7efe3625d4bb39ac2ad693bce530", size = 2513731, upload-time = "2026-02-27T19:28:06.602Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1a/12/0ba672dba52f9ecc813ce7ff4ef4aa5a2c5f27243d26165f09053f057a76/apache_tvm_ffi-0.1.10-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:52ed8fec82451c3af1e205f55500e5adc5eaa1913c82ce15b2064d305d7f880b", size = 2285850, upload-time = "2026-04-07T19:58:12.784Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/2a/1978a1c827e1212de4f369ec08cfeb44719bbe6cbeab90b15e967c68c108/apache_tvm_ffi-0.1.10-cp312-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ec5c4a81e294e6379e4dea68c86266924d3f22829c3de272806c980238e43e59", size = 2476596, upload-time = "2026-04-07T19:58:14.316Z" },
-    { url = "https://files.pythonhosted.org/packages/50/6f/23740f06829030704e6f8f1f7093a06b7a68f904baa40053a5f594705bae/apache_tvm_ffi-0.1.10-cp312-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:73d478395a8625dd92fde7b7fd92b4719f18f480b78336e422cb66cc7985213d", size = 2589574, upload-time = "2026-04-07T19:58:15.94Z" },
-    { url = "https://files.pythonhosted.org/packages/92/d0/54badf5c8f6208e06f331a20ddd154f19c94c2e906da5b8cce7d60727d4b/apache_tvm_ffi-0.1.10-cp312-abi3-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3829216a8500c2f61062e48c627f6db6c3fa49416b3ffa85bc04243ae5d759f7", size = 2396434, upload-time = "2026-04-07T19:58:17.519Z" },
-    { url = "https://files.pythonhosted.org/packages/51/f7/ca3fdadc2468e8b67a2f3f13bb7aa132c584feefd8a25dbf920e4bf0a03b/apache_tvm_ffi-0.1.10-cp312-abi3-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:96b69030c722572e13e30182733adfa2d604258e988b3f6630a16f397c7f9288", size = 2571084, upload-time = "2026-04-07T19:58:20.399Z" },
-    { url = "https://files.pythonhosted.org/packages/23/2d/bf899e1ba4ea1da6a55a04ad3e9c07338ee06a140862b05310bae9a00cf9/apache_tvm_ffi-0.1.10-cp312-abi3-win_amd64.whl", hash = "sha256:14e59f6f69881d37a25b03943cfac33317a06f6745df0ff2dfb3b0cd3ed3698f", size = 2261853, upload-time = "2026-04-07T19:58:21.772Z" },
+    { url = "https://files.pythonhosted.org/packages/df/f2/b8c4b151169f6d7ba8773c8af68b2e0c1013d7fb3f1bdf87573f47157ce9/apache_tvm_ffi-0.1.9-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:49e52350b0470654847de752e65603b604a4d3323e7e9f5e8a982f44acc4c143", size = 2041756, upload-time = "2026-02-27T19:27:23.931Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/c0/6d3d54f50012255b41bc3e24944c086f63c4707c8686c7c6780e9283eb96/apache_tvm_ffi-0.1.9-cp312-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7d503029e66c43b1a1cb1a42a1e9bb428c8a28dcbdec31c28e705472ca648a3a", size = 2203712, upload-time = "2026-02-27T19:27:25.867Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/dd/2bab4c6cd86257dbf99e93452a1af833113f8dc3e25a25579f6e4e4c8a94/apache_tvm_ffi-0.1.9-cp312-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28241371934ea8af10d5067087ba1229ebddded7b2c02d33a258ec2a96df8c46", size = 2299704, upload-time = "2026-02-27T19:27:27.477Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/4a/b469bcb2e1014cb84d336d2a59f42958a058251c577a4c2680cacad346e2/apache_tvm_ffi-0.1.9-cp312-abi3-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:87cacce81df55685fc6a76e1e3c5db1200e85e87bf5974b692c59d131b7bc622", size = 2130865, upload-time = "2026-02-27T19:27:29.092Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ef/5402da5d37f5270fd88ea0348acca78dba9be8bdbf6c2bcae0935eb03ef1/apache_tvm_ffi-0.1.9-cp312-abi3-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f45eb43499acac45ff6c93564f0ff2d3ca27b69656d540fd56ce59d51c0b4c65", size = 2278991, upload-time = "2026-02-27T19:27:30.729Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/23/1b7dc5f0807f83098183a57db6ee85b2c93b646d74a6e03781c9208aaeb0/apache_tvm_ffi-0.1.9-cp312-abi3-win_amd64.whl", hash = "sha256:d1dcf4c041d5ec05e3da1d545800c33cdbb95c113baa7705085ff79fa262752b", size = 1973200, upload-time = "2026-02-27T19:27:32.367Z" },
 ]
 
 [[package]]
@@ -332,10 +335,10 @@ name = "compressed-tensors"
 version = "0.15.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "loguru" },
-    { name = "pydantic" },
-    { name = "torch", version = "2.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" } },
-    { name = "transformers" },
+    { name = "loguru", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "pydantic", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "torch", version = "2.11.0+cu129", source = { registry = "https://download.pytorch.org/whl/cu129" }, marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "transformers", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/41/1b/c3c4a98ec5f2727656336f07a0c35862195c310d8eb0b2fa5b4be6848680/compressed_tensors-0.15.0.1.tar.gz", hash = "sha256:a8e93054e8a5ec49c980b09ed36c4c1249b4a8ee167920a8e461c4da26e78d99", size = 229412, upload-time = "2026-04-10T14:23:54.708Z" }
 wheels = [
@@ -383,15 +386,15 @@ wheels = [
 
 [[package]]
 name = "cuda-bindings"
-version = "12.9.4"
+version = "12.9.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "extra == 'extra-6-server-gpu' or extra == 'extra-6-server-vllm'" },
+    { name = "cuda-pathfinder", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-gpu') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-vllm') or (sys_platform == 'darwin' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'darwin' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'darwin' and extra == 'extra-6-server-gpu' and extra != 'extra-6-server-vllm') or (sys_platform == 'emscripten' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'win32' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/c2/65bfd79292b8ff18be4dd7f7442cea37bcbc1a228c1886f1dea515c45b67/cuda_bindings-12.9.4-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:694ba35023846625ef471257e6b5a4bc8af690f961d197d77d34b1d1db393f56", size = 11760260, upload-time = "2025-10-21T14:51:40.79Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/c1/dabe88f52c3e3760d861401bb994df08f672ec893b8f7592dc91626adcf3/cuda_bindings-12.9.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fda147a344e8eaeca0c6ff113d2851ffca8f7dfc0a6c932374ee5c47caa649c8", size = 12151019, upload-time = "2025-10-21T14:51:43.167Z" },
-    { url = "https://files.pythonhosted.org/packages/df/6b/9c1b1a6c01392bfdd758e9486f52a1a72bc8f49e98f9355774ef98b5fb4e/cuda_bindings-12.9.4-cp312-cp312-win_amd64.whl", hash = "sha256:696ca75d249ddf287d01b9a698b8e2d8a05046495a9c051ca15659dc52d17615", size = 11586961, upload-time = "2025-10-21T14:51:45.394Z" },
+    { url = "https://files.pythonhosted.org/packages/50/04/8a4d45dc154a8a32982658cc55be291e9778d1197834b15d33427e2f65c1/cuda_bindings-12.9.6-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea331bc47d9988cc61f0ecc5fa8df9dd188b4493ae1c6688bb1ee8ce8ba1af4", size = 7050347, upload-time = "2026-03-11T14:47:35.221Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/69/4b0375e1b120dfa7427c31c8420cfdee596ecd03955fd291a96116fa375d/cuda_bindings-12.9.6-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b2b54b95a47104eff56b5155818ab5790e3ccdba8dd51e2928ae56782aaf5b02", size = 7590574, upload-time = "2026-03-11T14:47:37.452Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/35/71b818233e1ea503face2a0e6f6f2c73ca02b946ca9613104667ba4a8454/cuda_bindings-12.9.6-cp312-cp312-win_amd64.whl", hash = "sha256:407b85671c363a5ddf77cd4bdeb05355340a88ac2cd0c6adc1a0f4b4d11c13c2", size = 7364562, upload-time = "2026-03-11T14:47:39.188Z" },
 ]
 
 [[package]]
@@ -404,57 +407,79 @@ wheels = [
 
 [[package]]
 name = "cuda-python"
-version = "12.9.4"
+version = "12.9.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-bindings" },
+    { name = "cuda-bindings", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/af/f3/6b032a554019cfb3447e671798c1bd3e79b5f1af20d10253f56cea269ef2/cuda_python-12.9.4-py3-none-any.whl", hash = "sha256:d2cacea882a69863f1e7d27ee71d75f0684f4c76910aff839067e4f89c902279", size = 7594, upload-time = "2025-10-21T14:55:12.846Z" },
+    { url = "https://files.pythonhosted.org/packages/57/69/4a79126959ad6f1653504122ee1eb22d089dd6272d3fa37694dcdeb78ba5/cuda_python-12.9.6-py3-none-any.whl", hash = "sha256:ed5cf30e1129729eecf4605dff6e8bce84f2d30c17b17c7e5ac4b76448de35d2", size = 7596, upload-time = "2026-03-11T15:35:17.282Z" },
 ]
 
 [[package]]
-name = "datasets"
-version = "1.1.1"
+name = "cuda-tile"
+version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "sys_platform == 'win32'",
-]
 dependencies = [
-    { name = "dill", marker = "sys_platform == 'win32' and extra == 'extra-6-server-vllm'" },
-    { name = "filelock", marker = "sys_platform == 'win32' and extra == 'extra-6-server-vllm'" },
-    { name = "multiprocess", marker = "sys_platform == 'win32' and extra == 'extra-6-server-vllm'" },
-    { name = "numpy", marker = "sys_platform == 'win32' and extra == 'extra-6-server-vllm'" },
-    { name = "pandas", marker = "sys_platform == 'win32' and extra == 'extra-6-server-vllm'" },
-    { name = "pyarrow", marker = "sys_platform == 'win32' and extra == 'extra-6-server-vllm'" },
-    { name = "requests", marker = "sys_platform == 'win32' and extra == 'extra-6-server-vllm'" },
-    { name = "tqdm", marker = "sys_platform == 'win32' and extra == 'extra-6-server-vllm'" },
-    { name = "xxhash", marker = "sys_platform == 'win32' and extra == 'extra-6-server-vllm'" },
+    { name = "typing-extensions", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/16/85/e332903c871a408704fce3070fbe0f583ec44913cf09bdcef85e6a2c126f/datasets-1.1.1.tar.gz", hash = "sha256:631247aa4016c00a01f9be1debcbe84264921cf44c268153f6495c55be5dd985", size = 124852, upload-time = "2020-10-06T09:33:17.533Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/30/1f/3fb5efd047a171ee0f08bfcf076145dd11c4d3c5be14976fd8ab4fa453e8/datasets-1.1.1-py3-none-any.whl", hash = "sha256:752db31563e396fedbc6020dfa10a1aa22dadf4f614750a75fa8e924ce1e6524", size = 147101, upload-time = "2020-10-06T09:33:15.983Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/49/4592bc94ca05a07c7947ea114fd12734c8497f2daffee9faa79a03e39fb5/cuda_tile-1.3.0-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:375316b64c51ee7cfadb2f170a30c1547bc41eb39f1e233a6556713857d2e81f", size = 245744, upload-time = "2026-04-20T15:52:09.621Z" },
+    { url = "https://files.pythonhosted.org/packages/40/76/84cb68be463c827bf79da9fa0aa5140838de6455ef6f438bbe0ffa75d378/cuda_tile-1.3.0-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:e4865acbff1172aaee304bf9c550586088d8b4545a384423597a590899386709", size = 247301, upload-time = "2026-04-20T15:51:04.042Z" },
+    { url = "https://files.pythonhosted.org/packages/db/6f/d2fd16c2b0d878021dc703eea5f8fe09599d6b04bdc2531a36fc617751fd/cuda_tile-1.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:93e20ed31e46e5bf704fb31d13e1c08338d2177838798876f7ee9ec4384b75ba", size = 240923, upload-time = "2026-04-20T15:52:14.939Z" },
+]
+
+[[package]]
+name = "cuda-toolkit"
+version = "12.9.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/8f/a28e7da158e96ad61f7e1035e53851fafaddf22445300d664e68ec657fdc/cuda_toolkit-12.9.1-py2.py3-none-any.whl", hash = "sha256:0c8636dfacbecfe9867a949a211864f080a805bc54023ce4a361aa4e1fd8738b", size = 2303, upload-time = "2025-08-13T02:03:10.699Z" },
+]
+
+[package.optional-dependencies]
+cublas = [
+    { name = "nvidia-cublas-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+]
+cudart = [
+    { name = "nvidia-cuda-runtime-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+]
+cufft = [
+    { name = "nvidia-cufft-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+]
+cufile = [
+    { name = "nvidia-cufile-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+]
+cupti = [
+    { name = "nvidia-cuda-cupti-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+]
+curand = [
+    { name = "nvidia-curand-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+]
+cusolver = [
+    { name = "nvidia-cusolver-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+]
+cusparse = [
+    { name = "nvidia-cusparse-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+]
+nvjitlink = [
+    { name = "nvidia-nvjitlink-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+]
+nvrtc = [
+    { name = "nvidia-cuda-nvrtc-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+]
+nvtx = [
+    { name = "nvidia-nvtx-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
 ]
 
 [[package]]
 name = "datasets"
 version = "4.8.5"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "sys_platform == 'emscripten' and extra != 'extra-6-server-cpu' and extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm'",
-    "sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-6-server-cpu' and extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm'",
-    "sys_platform == 'win32' and extra != 'extra-6-server-cpu' and extra == 'extra-6-server-gpu' and extra != 'extra-6-server-vllm'",
-    "sys_platform == 'emscripten' and extra != 'extra-6-server-cpu' and extra == 'extra-6-server-gpu' and extra != 'extra-6-server-vllm'",
-    "sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-6-server-cpu' and extra == 'extra-6-server-gpu' and extra != 'extra-6-server-vllm'",
-    "sys_platform == 'win32' and extra == 'extra-6-server-cpu' and extra != 'extra-6-server-gpu' and extra != 'extra-6-server-vllm'",
-    "sys_platform == 'emscripten' and extra == 'extra-6-server-cpu' and extra != 'extra-6-server-gpu' and extra != 'extra-6-server-vllm'",
-    "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-cpu' and extra != 'extra-6-server-gpu' and extra != 'extra-6-server-vllm'",
-    "sys_platform == 'darwin' and extra == 'extra-6-server-cpu' and extra != 'extra-6-server-gpu' and extra != 'extra-6-server-vllm'",
-]
 dependencies = [
     { name = "dill" },
     { name = "filelock" },
-    { name = "fsspec", version = "2026.2.0", source = { registry = "https://pypi.org/simple" }, extra = ["http"], marker = "(sys_platform != 'win32' and extra == 'extra-6-server-gpu') or extra == 'extra-6-server-cpu' or (extra == 'extra-6-server-gpu' and extra != 'extra-6-server-vllm')" },
+    { name = "fsspec", extra = ["http"], marker = "extra == 'extra-6-server-cpu' or extra == 'extra-6-server-gpu'" },
     { name = "httpx" },
     { name = "huggingface-hub" },
     { name = "multiprocess" },
@@ -477,8 +502,8 @@ name = "depyf"
 version = "0.20.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "astor" },
-    { name = "dill" },
+    { name = "astor", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "dill", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/88/35/83fb0178212279aa0af031031905804c6de5618435d229f41ed21bb9ad2c/depyf-0.20.0.tar.gz", hash = "sha256:fb7683bd72c44f67b56029df2c47721e9a02ffa4d7b19095f1c54c4ebf797a98", size = 6168761, upload-time = "2025-10-13T12:33:38.589Z" }
 wheels = [
@@ -544,8 +569,8 @@ name = "email-validator"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "dnspython" },
-    { name = "idna" },
+    { name = "dnspython", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "idna", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
 wheels = [
@@ -570,15 +595,15 @@ wheels = [
 
 [package.optional-dependencies]
 standard = [
-    { name = "email-validator" },
-    { name = "fastapi-cli", extra = ["standard"], marker = "(extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra != 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "fastar" },
-    { name = "httpx" },
-    { name = "jinja2" },
-    { name = "pydantic-extra-types" },
-    { name = "pydantic-settings" },
-    { name = "python-multipart" },
-    { name = "uvicorn", extra = ["standard"], marker = "(extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra != 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+    { name = "email-validator", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "fastapi-cli", extra = ["standard"], marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-vllm') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+    { name = "fastar", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "httpx", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "jinja2", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "pydantic-extra-types", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "pydantic-settings", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "python-multipart", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "uvicorn", extra = ["standard"], marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-vllm') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
 ]
 
 [[package]]
@@ -586,9 +611,9 @@ name = "fastapi-cli"
 version = "0.0.24"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "rich-toolkit" },
-    { name = "typer" },
-    { name = "uvicorn", extra = ["standard"], marker = "(extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra != 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+    { name = "rich-toolkit", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "typer", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "uvicorn", extra = ["standard"], marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-vllm') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6e/58/74797ae9e4610cfa0c6b34c8309096d3b20bb29be3b8b5fbf1004d10fa5f/fastapi_cli-0.0.24.tar.gz", hash = "sha256:1afc9c9e21d7ebc8a3ca5e31790cd8d837742be7e4f8b9236e99cb3451f0de00", size = 19043, upload-time = "2026-02-24T10:45:10.476Z" }
 wheels = [
@@ -597,8 +622,8 @@ wheels = [
 
 [package.optional-dependencies]
 standard = [
-    { name = "fastapi-cloud-cli" },
-    { name = "uvicorn", extra = ["standard"], marker = "(extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra != 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+    { name = "fastapi-cloud-cli", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "uvicorn", extra = ["standard"], marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-vllm') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
 ]
 
 [[package]]
@@ -606,14 +631,14 @@ name = "fastapi-cloud-cli"
 version = "0.17.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "fastar" },
-    { name = "httpx" },
-    { name = "pydantic", extra = ["email"], marker = "(extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra != 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "rich-toolkit" },
-    { name = "rignore" },
-    { name = "sentry-sdk" },
-    { name = "typer" },
-    { name = "uvicorn", extra = ["standard"], marker = "(extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra != 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+    { name = "fastar", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "httpx", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "pydantic", extra = ["email"], marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-vllm') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+    { name = "rich-toolkit", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "rignore", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "sentry-sdk", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "typer", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "uvicorn", extra = ["standard"], marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-vllm') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/96/57/cee8e91b83f39e75ae5562a2237261442a8179dcb3b631c7398113157398/fastapi_cloud_cli-0.17.1.tar.gz", hash = "sha256:0baece208fa88063bec46dccb5fb512f3199162092165e57654b44e64adbc44d", size = 47409, upload-time = "2026-04-27T13:38:07.094Z" }
 wheels = [
@@ -645,6 +670,18 @@ wheels = [
 ]
 
 [[package]]
+name = "fastsafetensors"
+version = "0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typer", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/98/053c622e61bb766d31327a88215082320a4ba8bd6a62c4c5435221844103/fastsafetensors-0.3.tar.gz", hash = "sha256:89f392569d2281d1a966d3b64f99a6386149116e37eef4f4890168c87a8c4f19", size = 57500, upload-time = "2026-04-22T07:16:30.84Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/06/bca80663bf8136f273643d149953dd29ca2c52aa4faac4b67506b871a5ec/fastsafetensors-0.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3ce38241c5afedf94ef37531b8b8703016b2ea39350cfd33e819e65d4d5305e0", size = 1855661, upload-time = "2026-04-22T07:16:25.833Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.29.0"
 source = { registry = "https://pypi.org/simple" }
@@ -655,34 +692,35 @@ wheels = [
 
 [[package]]
 name = "flashinfer-cubin"
-version = "0.6.6"
+version = "0.6.8.post1"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/e8/826f9452bc5f76b94d7eb025f03dcaf1b51b9ed7790386c0285191e69be4/flashinfer_cubin-0.6.6-py3-none-any.whl", hash = "sha256:36508dfc792eb5ecfb15d2c140a7702812e1fa1ab0fb03929b2ed55e3e8191f3", size = 267661457, upload-time = "2026-03-11T01:36:36.538Z" },
+    { url = "https://files.pythonhosted.org/packages/11/b7/5e3b1a8c67031b421a8bd29c2bc29b900a550bb3392e8bda18bb15b5e476/flashinfer_cubin-0.6.8.post1-py3-none-any.whl", hash = "sha256:43636d4cd39e694a83d76a89f87fefcdf4cecb4c4f7dd22dac25ec368c1e901f", size = 295154113, upload-time = "2026-04-18T18:28:21.738Z" },
 ]
 
 [[package]]
 name = "flashinfer-python"
-version = "0.6.6"
+version = "0.6.8.post1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "apache-tvm-ffi" },
-    { name = "click" },
-    { name = "einops" },
-    { name = "ninja" },
-    { name = "numpy" },
-    { name = "nvidia-cudnn-frontend" },
-    { name = "nvidia-cutlass-dsl" },
-    { name = "nvidia-ml-py" },
-    { name = "packaging" },
-    { name = "requests" },
-    { name = "tabulate" },
-    { name = "torch", version = "2.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" } },
-    { name = "tqdm" },
+    { name = "apache-tvm-ffi", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "click", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "cuda-tile", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "einops", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "ninja", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "numpy", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "nvidia-cudnn-frontend", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "nvidia-cutlass-dsl", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "nvidia-ml-py", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "packaging", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "requests", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "tabulate", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "torch", version = "2.11.0+cu129", source = { registry = "https://download.pytorch.org/whl/cu129" }, marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "tqdm", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/03/70/c5a235297351021f5d3d3233523a85f5a6468495587489ad2f257e8eafe2/flashinfer_python-0.6.6.tar.gz", hash = "sha256:0730ba7c7aad332961933bcebc5119762797161ede57d955f6fd199818ed1d92", size = 5344156, upload-time = "2026-03-11T01:36:21.434Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/1e/2760fef9e74abc4480961048e5790b4c9e955872fb4d7d97900cfddced5a/flashinfer_python-0.6.8.post1.tar.gz", hash = "sha256:b18e4121baf9b93fa9a9f368ba9b981a0342895f50ab9dddc224aeb964ed346f", size = 6675885, upload-time = "2026-04-18T18:28:13.299Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/61/385d06755f3ab66333018285657adf0daf8a90a129448231fd09e315bd2e/flashinfer_python-0.6.6-py3-none-any.whl", hash = "sha256:078f158636969eec1a0d3dea19c3ca90b426b66df89bbf7b7b8276ce2ec08148", size = 7817047, upload-time = "2026-03-11T01:36:19.198Z" },
+    { url = "https://files.pythonhosted.org/packages/73/6d/1e8a8533913e33a50a486332ce0673f4fdb860f6eb9ed450327c5c1762cb/flashinfer_python-0.6.8.post1-py3-none-any.whl", hash = "sha256:818f9b8cc2fe66c42a1f6264be4841ac8821ada703685a02cfccb2b5124a710b", size = 9385316, upload-time = "2026-04-18T18:28:10.285Z" },
 ]
 
 [[package]]
@@ -714,17 +752,6 @@ wheels = [
 name = "fsspec"
 version = "2026.2.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "sys_platform == 'emscripten' and extra != 'extra-6-server-cpu' and extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm'",
-    "sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-6-server-cpu' and extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm'",
-    "sys_platform == 'win32' and extra != 'extra-6-server-cpu' and extra == 'extra-6-server-gpu' and extra != 'extra-6-server-vllm'",
-    "sys_platform == 'emscripten' and extra != 'extra-6-server-cpu' and extra == 'extra-6-server-gpu' and extra != 'extra-6-server-vllm'",
-    "sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-6-server-cpu' and extra == 'extra-6-server-gpu' and extra != 'extra-6-server-vllm'",
-    "sys_platform == 'win32' and extra == 'extra-6-server-cpu' and extra != 'extra-6-server-gpu' and extra != 'extra-6-server-vllm'",
-    "sys_platform == 'emscripten' and extra == 'extra-6-server-cpu' and extra != 'extra-6-server-gpu' and extra != 'extra-6-server-vllm'",
-    "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-cpu' and extra != 'extra-6-server-gpu' and extra != 'extra-6-server-vllm'",
-    "sys_platform == 'darwin' and extra == 'extra-6-server-cpu' and extra != 'extra-6-server-gpu' and extra != 'extra-6-server-vllm'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/51/7c/f60c259dcbf4f0c47cc4ddb8f7720d2dcdc8888c8e5ad84c73ea4531cc5b/fsspec-2026.2.0.tar.gz", hash = "sha256:6544e34b16869f5aacd5b90bdf1a71acb37792ea3ddf6125ee69a22a53fb8bff", size = 313441, upload-time = "2026-02-05T21:50:53.743Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/ab/fb21f4c939bb440104cc2b396d3be1d9b7a9fd3c6c2a53d98c45b3d7c954/fsspec-2026.2.0-py3-none-any.whl", hash = "sha256:98de475b5cb3bd66bedd5c4679e87b4fdfe1a3bf4d707b151b3c07e58c9a2437", size = 202505, upload-time = "2026-02-05T21:50:51.819Z" },
@@ -736,27 +763,14 @@ http = [
 ]
 
 [[package]]
-name = "fsspec"
-version = "2026.4.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "sys_platform == 'win32' and extra != 'extra-6-server-cpu' and extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm'",
-    "extra != 'extra-6-server-cpu' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/8d/1c51c094345df128ca4a990d633fe1a0ff28726c9e6b3c41ba65087bba1d/fsspec-2026.4.0.tar.gz", hash = "sha256:301d8ac70ae90ef3ad05dcf94d6c3754a097f9b5fe4667d2787aa359ec7df7e4", size = 312760, upload-time = "2026-04-29T20:42:38.635Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/0c/043d5e551459da400957a1395e0febbf771446ff34291afcbe3d8be2a279/fsspec-2026.4.0-py3-none-any.whl", hash = "sha256:11ef7bb35dab8a394fde6e608221d5cf3e8499401c249bebaeaad760a1a8dec2", size = 203402, upload-time = "2026-04-29T20:42:36.842Z" },
-]
-
-[[package]]
 name = "gguf"
 version = "0.18.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
-    { name = "pyyaml" },
-    { name = "requests" },
-    { name = "tqdm" },
+    { name = "numpy", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "pyyaml", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "requests", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "tqdm", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3f/26/7622a41c39db9d7090225a4bf8368550e59694dcf7313b44f9a82b501209/gguf-0.18.0.tar.gz", hash = "sha256:b4659093d5d0dccdb5902a904d54b327f4052879fe5e90946ad5fce9f8018c2e", size = 107170, upload-time = "2026-02-27T15:05:39.254Z" }
 wheels = [
@@ -943,16 +957,15 @@ name = "huggingface-hub"
 version = "1.12.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "filelock" },
-    { name = "fsspec", version = "2026.2.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'win32' and extra == 'extra-6-server-gpu') or extra == 'extra-6-server-cpu' or (extra == 'extra-6-server-gpu' and extra != 'extra-6-server-vllm')" },
-    { name = "fsspec", version = "2026.4.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform == 'win32' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
-    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
-    { name = "httpx" },
-    { name = "packaging" },
-    { name = "pyyaml" },
-    { name = "tqdm" },
-    { name = "typer" },
-    { name = "typing-extensions" },
+    { name = "filelock", marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-vllm') or extra == 'extra-6-server-cpu' or extra == 'extra-6-server-gpu'" },
+    { name = "fsspec", marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-vllm') or extra == 'extra-6-server-cpu' or extra == 'extra-6-server-gpu'" },
+    { name = "hf-xet", marker = "(platform_machine == 'AMD64' and sys_platform != 'darwin' and extra == 'extra-6-server-vllm') or (platform_machine == 'aarch64' and sys_platform != 'darwin' and extra == 'extra-6-server-vllm') or (platform_machine == 'amd64' and sys_platform != 'darwin' and extra == 'extra-6-server-vllm') or (platform_machine == 'arm64' and sys_platform != 'darwin' and extra == 'extra-6-server-vllm') or (platform_machine == 'x86_64' and sys_platform != 'darwin' and extra == 'extra-6-server-vllm') or (platform_machine == 'AMD64' and extra == 'extra-6-server-cpu') or (platform_machine == 'AMD64' and extra == 'extra-6-server-gpu') or (platform_machine == 'aarch64' and extra == 'extra-6-server-cpu') or (platform_machine == 'aarch64' and extra == 'extra-6-server-gpu') or (platform_machine == 'amd64' and extra == 'extra-6-server-cpu') or (platform_machine == 'amd64' and extra == 'extra-6-server-gpu') or (platform_machine == 'arm64' and extra == 'extra-6-server-cpu') or (platform_machine == 'arm64' and extra == 'extra-6-server-gpu') or (platform_machine == 'x86_64' and extra == 'extra-6-server-cpu') or (platform_machine == 'x86_64' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+    { name = "httpx", marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-vllm') or extra == 'extra-6-server-cpu' or extra == 'extra-6-server-gpu'" },
+    { name = "packaging", marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-vllm') or extra == 'extra-6-server-cpu' or extra == 'extra-6-server-gpu'" },
+    { name = "pyyaml", marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-vllm') or extra == 'extra-6-server-cpu' or extra == 'extra-6-server-gpu'" },
+    { name = "tqdm", marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-vllm') or extra == 'extra-6-server-cpu' or extra == 'extra-6-server-gpu'" },
+    { name = "typer", marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-vllm') or extra == 'extra-6-server-cpu' or extra == 'extra-6-server-gpu'" },
+    { name = "typing-extensions", marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-vllm') or extra == 'extra-6-server-cpu' or extra == 'extra-6-server-gpu'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3e/9f/3fda8b014db3ae239addc9b48b35c2cf7d318950b430712f34a2473ef81d/huggingface_hub-1.12.2.tar.gz", hash = "sha256:282c4999e641c89affdc4c02c265eddea944c1390dc19e89dac8ad3ae76dbdaf", size = 763393, upload-time = "2026-04-29T09:45:09.202Z" }
 wheels = [
@@ -1013,7 +1026,7 @@ name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "markupsafe" },
+    { name = "markupsafe", marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-vllm') or extra == 'extra-6-server-cpu' or extra == 'extra-6-server-gpu'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
@@ -1060,10 +1073,10 @@ name = "jsonschema"
 version = "4.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs" },
-    { name = "jsonschema-specifications" },
-    { name = "referencing" },
-    { name = "rpds-py" },
+    { name = "attrs", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "jsonschema-specifications", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "referencing", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "rpds-py", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
 wheels = [
@@ -1075,7 +1088,7 @@ name = "jsonschema-specifications"
 version = "2025.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "referencing" },
+    { name = "referencing", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
@@ -1108,15 +1121,14 @@ wheels = [
 
 [[package]]
 name = "llvmlite"
-version = "0.44.0"
+version = "0.47.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/89/6a/95a3d3610d5c75293d5dbbb2a76480d5d4eeba641557b69fe90af6c5b84e/llvmlite-0.44.0.tar.gz", hash = "sha256:07667d66a5d150abed9157ab6c0b9393c9356f229784a4385c02f99e94fc94d4", size = 171880, upload-time = "2025-01-20T11:14:41.342Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/88/a8952b6d5c21e74cbf158515b779666f692846502623e9e3c39d8e8ba25f/llvmlite-0.47.0.tar.gz", hash = "sha256:62031ce968ec74e95092184d4b0e857e444f8fdff0b8f9213707699570c33ccc", size = 193614, upload-time = "2026-03-31T18:29:53.497Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/86/e3c3195b92e6e492458f16d233e58a1a812aa2bfbef9bdd0fbafcec85c60/llvmlite-0.44.0-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:1d671a56acf725bf1b531d5ef76b86660a5ab8ef19bb6a46064a705c6ca80aad", size = 28132297, upload-time = "2025-01-20T11:13:32.57Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/53/373b6b8be67b9221d12b24125fd0ec56b1078b660eeae266ec388a6ac9a0/llvmlite-0.44.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5f79a728e0435493611c9f405168682bb75ffd1fbe6fc360733b850c80a026db", size = 26201105, upload-time = "2025-01-20T11:13:38.744Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/da/8341fd3056419441286c8e26bf436923021005ece0bff5f41906476ae514/llvmlite-0.44.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c0143a5ef336da14deaa8ec26c5449ad5b6a2b564df82fcef4be040b9cacfea9", size = 42361901, upload-time = "2025-01-20T11:13:46.711Z" },
-    { url = "https://files.pythonhosted.org/packages/53/ad/d79349dc07b8a395a99153d7ce8b01d6fcdc9f8231355a5df55ded649b61/llvmlite-0.44.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d752f89e31b66db6f8da06df8b39f9b91e78c5feea1bf9e8c1fba1d1c24c065d", size = 41184247, upload-time = "2025-01-20T11:13:56.159Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/3b/a9a17366af80127bd09decbe2a54d8974b6d8b274b39bf47fbaedeec6307/llvmlite-0.44.0-cp312-cp312-win_amd64.whl", hash = "sha256:eae7e2d4ca8f88f89d315b48c6b741dcb925d6a1042da694aa16ab3dd4cbd3a1", size = 30332380, upload-time = "2025-01-20T11:14:02.442Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/48/4b7fe0e34c169fa2f12532916133e0b219d2823b540733651b34fdac509a/llvmlite-0.47.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:306a265f408c259067257a732c8e159284334018b4083a9e35f67d19792b164f", size = 37232769, upload-time = "2026-03-31T18:28:43.735Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/4b/e3f2cd17822cf772a4a51a0a8080b0032e6d37b2dbe8cfb724eac4e31c52/llvmlite-0.47.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5853bf26160857c0c2573415ff4efe01c4c651e59e2c55c2a088740acfee51cd", size = 56275178, upload-time = "2026-03-31T18:28:48.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/55/a3b4a543185305a9bdf3d9759d53646ed96e55e7dfd43f53e7a421b8fbae/llvmlite-0.47.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:003bcf7fa579e14db59c1a1e113f93ab8a06b56a4be31c7f08264d1d4072d077", size = 55128632, upload-time = "2026-03-31T18:28:52.901Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/f5/d281ae0f79378a5a91f308ea9fdb9f9cc068fddd09629edc0725a5a8fde1/llvmlite-0.47.0-cp312-cp312-win_amd64.whl", hash = "sha256:f3079f25bdc24cd9d27c4b2b5e68f5f60c4fdb7e8ad5ee2b9b006007558f9df7", size = 38138692, upload-time = "2026-03-31T18:28:57.147Z" },
 ]
 
 [[package]]
@@ -1124,10 +1136,10 @@ name = "lm-format-enforcer"
 version = "0.11.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "interegular" },
-    { name = "packaging" },
-    { name = "pydantic" },
-    { name = "pyyaml" },
+    { name = "interegular", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "packaging", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "pydantic", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "pyyaml", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/84/d5/41cd417ba7dfdbbcfe46cebf81fb3dfd7c591b89897560ad05bb410a465d/lm_format_enforcer-0.11.3.tar.gz", hash = "sha256:e68081c108719cce284a9bcc889709b26ffb085a1945b5eba3a12cfa96d528da", size = 40258, upload-time = "2025-08-24T19:37:47.527Z" }
 wheels = [
@@ -1139,8 +1151,8 @@ name = "loguru"
 version = "0.7.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "win32-setctime", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' and extra != 'extra-6-server-gpu'" },
+    { name = "win32-setctime", marker = "sys_platform == 'win32' and extra != 'extra-6-server-gpu'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6", size = 63559, upload-time = "2024-12-06T11:20:56.608Z" }
 wheels = [
@@ -1152,7 +1164,7 @@ name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mdurl" },
+    { name = "mdurl", marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-vllm') or extra == 'extra-6-server-cpu' or extra == 'extra-6-server-gpu'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
 wheels = [
@@ -1183,20 +1195,20 @@ name = "mcp"
 version = "1.27.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
-    { name = "jsonschema" },
-    { name = "pydantic" },
-    { name = "pydantic-settings" },
-    { name = "pyjwt", extra = ["crypto"], marker = "(extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra != 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "python-multipart" },
-    { name = "pywin32", marker = "sys_platform == 'win32'" },
-    { name = "sse-starlette" },
-    { name = "starlette" },
-    { name = "typing-extensions" },
-    { name = "typing-inspection" },
-    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+    { name = "anyio", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "httpx", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "httpx-sse", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "jsonschema", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "pydantic", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "pydantic-settings", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "pyjwt", extra = ["crypto"], marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-vllm') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+    { name = "python-multipart", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "pywin32", marker = "sys_platform == 'win32' and extra != 'extra-6-server-gpu'" },
+    { name = "sse-starlette", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "starlette", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "typing-extensions", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "typing-inspection", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "uvicorn", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8b/eb/c0cfc62075dc6e1ec1c64d352ae09ac051d9334311ed226f1f425312848a/mcp-1.27.0.tar.gz", hash = "sha256:d3dc35a7eec0d458c1da4976a48f982097ddaab87e278c5511d5a4a56e852b83", size = 607509, upload-time = "2026-04-02T14:48:08.88Z" }
 wheels = [
@@ -1217,14 +1229,14 @@ name = "mistral-common"
 version = "1.11.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jsonschema" },
-    { name = "numpy" },
-    { name = "pillow" },
-    { name = "pydantic" },
-    { name = "pydantic-extra-types", extra = ["pycountry"], marker = "(extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra != 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "requests" },
-    { name = "tiktoken" },
-    { name = "typing-extensions" },
+    { name = "jsonschema", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "numpy", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "pillow", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "pydantic", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "pydantic-extra-types", extra = ["pycountry"], marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-vllm') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+    { name = "requests", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "tiktoken", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "typing-extensions", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7d/15/12076a58b9dde4ad486b6de4afd2dfe3e8226fd049ef44553892e62f2e92/mistral_common-1.11.1.tar.gz", hash = "sha256:b784e1f9141bbcb26ab1f61b724c709f08cd3543e81730cb7248721499491840", size = 6356869, upload-time = "2026-04-29T07:24:43.234Z" }
 wheels = [
@@ -1233,7 +1245,23 @@ wheels = [
 
 [package.optional-dependencies]
 image = [
-    { name = "opencv-python-headless" },
+    { name = "opencv-python-headless", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+]
+
+[[package]]
+name = "ml-dtypes"
+version = "0.5.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/4a/c27b42ed9b1c7d13d9ba8b6905dece787d6259152f2309338aed29b2447b/ml_dtypes-0.5.4.tar.gz", hash = "sha256:8ab06a50fb9bf9666dd0fe5dfb4676fa2b0ac0f31ecff72a6c3af8e22c063453", size = 692314, upload-time = "2025-11-17T22:32:31.031Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/b8/3c70881695e056f8a32f8b941126cf78775d9a4d7feba8abcb52cb7b04f2/ml_dtypes-0.5.4-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a174837a64f5b16cab6f368171a1a03a27936b31699d167684073ff1c4237dac", size = 676927, upload-time = "2025-11-17T22:31:48.182Z" },
+    { url = "https://files.pythonhosted.org/packages/54/0f/428ef6881782e5ebb7eca459689448c0394fa0a80bea3aa9262cba5445ea/ml_dtypes-0.5.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a7f7c643e8b1320fd958bf098aa7ecf70623a42ec5154e3be3be673f4c34d900", size = 5028464, upload-time = "2025-11-17T22:31:50.135Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/cb/28ce52eb94390dda42599c98ea0204d74799e4d8047a0eb559b6fd648056/ml_dtypes-0.5.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9ad459e99793fa6e13bd5b7e6792c8f9190b4e5a1b45c63aba14a4d0a7f1d5ff", size = 5009002, upload-time = "2025-11-17T22:31:52.001Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/f0/0cfadd537c5470378b1b32bd859cf2824972174b51b873c9d95cfd7475a5/ml_dtypes-0.5.4-cp312-cp312-win_amd64.whl", hash = "sha256:c1a953995cccb9e25a4ae19e34316671e4e2edaebe4cf538229b1fc7109087b7", size = 212222, upload-time = "2025-11-17T22:31:53.742Z" },
+    { url = "https://files.pythonhosted.org/packages/16/2e/9acc86985bfad8f2c2d30291b27cd2bb4c74cea08695bd540906ed744249/ml_dtypes-0.5.4-cp312-cp312-win_arm64.whl", hash = "sha256:9bad06436568442575beb2d03389aa7456c690a5b05892c471215bfd8cf39460", size = 160793, upload-time = "2025-11-17T22:31:55.358Z" },
 ]
 
 [[package]]
@@ -1241,13 +1269,13 @@ name = "model-hosting-container-standards"
 version = "0.1.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "fastapi" },
-    { name = "httpx" },
-    { name = "jmespath" },
-    { name = "pydantic" },
-    { name = "setuptools" },
-    { name = "starlette" },
-    { name = "supervisor" },
+    { name = "fastapi", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "httpx", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "jmespath", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "pydantic", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "setuptools", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "starlette", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "supervisor", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c6/3d/cf5c6029648cb0a116f7b5c2f74aa155ab0c6dd723a1f204a6d7ff354526/model_hosting_container_standards-0.1.14.tar.gz", hash = "sha256:b6cf4c46d88ce6acd6e543a578bb88ffd55d1179a7c09c22e61ae1d8a567c564", size = 90386, upload-time = "2026-03-18T21:25:14.513Z" }
 wheels = [
@@ -1358,90 +1386,90 @@ wheels = [
 
 [[package]]
 name = "numba"
-version = "0.61.2"
+version = "0.65.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "llvmlite" },
-    { name = "numpy" },
+    { name = "llvmlite", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "numpy", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1c/a0/e21f57604304aa03ebb8e098429222722ad99176a4f979d34af1d1ee80da/numba-0.61.2.tar.gz", hash = "sha256:8750ee147940a6637b80ecf7f95062185ad8726c8c28a2295b8ec1160a196f7d", size = 2820615, upload-time = "2025-04-09T02:58:07.659Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/61/7299643b9c18d669e04be7c5bcb64d985070d07553274817b45b049e7bfe/numba-0.65.0.tar.gz", hash = "sha256:edad0d9f6682e93624c00125a471ae4df186175d71fd604c983c377cdc03e68b", size = 2764131, upload-time = "2026-04-01T03:52:01.946Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b4/a0/c6b7b9c615cfa3b98c4c63f4316e3f6b3bbe2387740277006551784218cd/numba-0.61.2-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:34fba9406078bac7ab052efbf0d13939426c753ad72946baaa5bf9ae0ebb8dd2", size = 2776626, upload-time = "2025-04-09T02:57:51.857Z" },
-    { url = "https://files.pythonhosted.org/packages/92/4a/fe4e3c2ecad72d88f5f8cd04e7f7cff49e718398a2fac02d2947480a00ca/numba-0.61.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4ddce10009bc097b080fc96876d14c051cc0c7679e99de3e0af59014dab7dfe8", size = 2779287, upload-time = "2025-04-09T02:57:53.658Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/2d/e518df036feab381c23a624dac47f8445ac55686ec7f11083655eb707da3/numba-0.61.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5b1bb509d01f23d70325d3a5a0e237cbc9544dd50e50588bc581ba860c213546", size = 3885928, upload-time = "2025-04-09T02:57:55.206Z" },
-    { url = "https://files.pythonhosted.org/packages/10/0f/23cced68ead67b75d77cfcca3df4991d1855c897ee0ff3fe25a56ed82108/numba-0.61.2-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:48a53a3de8f8793526cbe330f2a39fe9a6638efcbf11bd63f3d2f9757ae345cd", size = 3577115, upload-time = "2025-04-09T02:57:56.818Z" },
-    { url = "https://files.pythonhosted.org/packages/68/1d/ddb3e704c5a8fb90142bf9dc195c27db02a08a99f037395503bfbc1d14b3/numba-0.61.2-cp312-cp312-win_amd64.whl", hash = "sha256:97cf4f12c728cf77c9c1d7c23707e4d8fb4632b46275f8f3397de33e5877af18", size = 2831929, upload-time = "2025-04-09T02:57:58.45Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/2f/8bd31a1ea43c01ac215283d83aa5f8d5acbe7a36c85b82f1757bfe9ccb31/numba-0.65.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:b27ee4847e1bfb17e9604d100417ee7c1d10f15a6711c6213404b3da13a0b2aa", size = 2680705, upload-time = "2026-04-01T03:51:32.597Z" },
+    { url = "https://files.pythonhosted.org/packages/73/36/88406bd58600cc696417b8e5dd6a056478da808f3eaf48d18e2421e0c2d9/numba-0.65.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a52d92ffd297c10364bce60cd1fcb88f99284ab5df085f2c6bcd1cb33b529a6f", size = 3801411, upload-time = "2026-04-01T03:51:34.321Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/61/ce753a1d7646dd477e16d15e89473703faebb8995d2f71d7ad69a540b565/numba-0.65.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:da8e371e328c06d0010c3d8b44b21858652831b85bcfba78cb22c042e22dbd8e", size = 3501622, upload-time = "2026-04-01T03:51:36.348Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/86/db87a5393f1b1fabef53ac3ba4e6b938bb27e40a04ad7cc512098fcae032/numba-0.65.0-cp312-cp312-win_amd64.whl", hash = "sha256:59bb9f2bb9f1238dfd8e927ba50645c18ae769fef4f3d58ea0ea22a2683b91f5", size = 2749979, upload-time = "2026-04-01T03:51:37.88Z" },
 ]
 
 [[package]]
 name = "numpy"
-version = "2.2.6"
+version = "2.3.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/76/21/7d2a95e4bba9dc13d043ee156a356c0a8f0c6309dff6b21b4d71a073b8a8/numpy-2.2.6.tar.gz", hash = "sha256:e29554e2bef54a90aa5cc07da6ce955accb83f21ab5de01a62c8478897b264fd", size = 20276440, upload-time = "2025-05-17T22:38:04.611Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/65/21b3bc86aac7b8f2862db1e808f1ea22b028e30a225a34a5ede9bf8678f2/numpy-2.3.5.tar.gz", hash = "sha256:784db1dcdab56bf0517743e746dfb0f885fc68d948aba86eeec2cba234bdf1c0", size = 20584950, upload-time = "2025-11-16T22:52:42.067Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/5d/c00588b6cf18e1da539b45d3598d3557084990dcc4331960c15ee776ee41/numpy-2.2.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:41c5a21f4a04fa86436124d388f6ed60a9343a6f767fced1a8a71c3fbca038ff", size = 20875348, upload-time = "2025-05-17T21:34:39.648Z" },
-    { url = "https://files.pythonhosted.org/packages/66/ee/560deadcdde6c2f90200450d5938f63a34b37e27ebff162810f716f6a230/numpy-2.2.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:de749064336d37e340f640b05f24e9e3dd678c57318c7289d222a8a2f543e90c", size = 14119362, upload-time = "2025-05-17T21:35:01.241Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/65/4baa99f1c53b30adf0acd9a5519078871ddde8d2339dc5a7fde80d9d87da/numpy-2.2.6-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:894b3a42502226a1cac872f840030665f33326fc3dac8e57c607905773cdcde3", size = 5084103, upload-time = "2025-05-17T21:35:10.622Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/89/e5a34c071a0570cc40c9a54eb472d113eea6d002e9ae12bb3a8407fb912e/numpy-2.2.6-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:71594f7c51a18e728451bb50cc60a3ce4e6538822731b2933209a1f3614e9282", size = 6625382, upload-time = "2025-05-17T21:35:21.414Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/35/8c80729f1ff76b3921d5c9487c7ac3de9b2a103b1cd05e905b3090513510/numpy-2.2.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f2618db89be1b4e05f7a1a847a9c1c0abd63e63a1607d892dd54668dd92faf87", size = 14018462, upload-time = "2025-05-17T21:35:42.174Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/3d/1e1db36cfd41f895d266b103df00ca5b3cbe965184df824dec5c08c6b803/numpy-2.2.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd83c01228a688733f1ded5201c678f0c53ecc1006ffbc404db9f7a899ac6249", size = 16527618, upload-time = "2025-05-17T21:36:06.711Z" },
-    { url = "https://files.pythonhosted.org/packages/61/c6/03ed30992602c85aa3cd95b9070a514f8b3c33e31124694438d88809ae36/numpy-2.2.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:37c0ca431f82cd5fa716eca9506aefcabc247fb27ba69c5062a6d3ade8cf8f49", size = 15505511, upload-time = "2025-05-17T21:36:29.965Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/25/5761d832a81df431e260719ec45de696414266613c9ee268394dd5ad8236/numpy-2.2.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fe27749d33bb772c80dcd84ae7e8df2adc920ae8297400dabec45f0dedb3f6de", size = 18313783, upload-time = "2025-05-17T21:36:56.883Z" },
-    { url = "https://files.pythonhosted.org/packages/57/0a/72d5a3527c5ebffcd47bde9162c39fae1f90138c961e5296491ce778e682/numpy-2.2.6-cp312-cp312-win32.whl", hash = "sha256:4eeaae00d789f66c7a25ac5f34b71a7035bb474e679f410e5e1a94deb24cf2d4", size = 6246506, upload-time = "2025-05-17T21:37:07.368Z" },
-    { url = "https://files.pythonhosted.org/packages/36/fa/8c9210162ca1b88529ab76b41ba02d433fd54fecaf6feb70ef9f124683f1/numpy-2.2.6-cp312-cp312-win_amd64.whl", hash = "sha256:c1f9540be57940698ed329904db803cf7a402f3fc200bfe599334c9bd84a40b2", size = 12614190, upload-time = "2025-05-17T21:37:26.213Z" },
+    { url = "https://files.pythonhosted.org/packages/44/37/e669fe6cbb2b96c62f6bbedc6a81c0f3b7362f6a59230b23caa673a85721/numpy-2.3.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:74ae7b798248fe62021dbf3c914245ad45d1a6b0cb4a29ecb4b31d0bfbc4cc3e", size = 16733873, upload-time = "2025-11-16T22:49:49.84Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/65/df0db6c097892c9380851ab9e44b52d4f7ba576b833996e0080181c0c439/numpy-2.3.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ee3888d9ff7c14604052b2ca5535a30216aa0a58e948cdd3eeb8d3415f638769", size = 12259838, upload-time = "2025-11-16T22:49:52.863Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/e1/1ee06e70eb2136797abe847d386e7c0e830b67ad1d43f364dd04fa50d338/numpy-2.3.5-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:612a95a17655e213502f60cfb9bf9408efdc9eb1d5f50535cc6eb365d11b42b5", size = 5088378, upload-time = "2025-11-16T22:49:55.055Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/9c/1ca85fb86708724275103b81ec4cf1ac1d08f465368acfc8da7ab545bdae/numpy-2.3.5-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:3101e5177d114a593d79dd79658650fe28b5a0d8abeb8ce6f437c0e6df5be1a4", size = 6628559, upload-time = "2025-11-16T22:49:57.371Z" },
+    { url = "https://files.pythonhosted.org/packages/74/78/fcd41e5a0ce4f3f7b003da85825acddae6d7ecb60cf25194741b036ca7d6/numpy-2.3.5-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b973c57ff8e184109db042c842423ff4f60446239bd585a5131cc47f06f789d", size = 14250702, upload-time = "2025-11-16T22:49:59.632Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/23/2a1b231b8ff672b4c450dac27164a8b2ca7d9b7144f9c02d2396518352eb/numpy-2.3.5-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0d8163f43acde9a73c2a33605353a4f1bc4798745a8b1d73183b28e5b435ae28", size = 16606086, upload-time = "2025-11-16T22:50:02.127Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/c5/5ad26fbfbe2012e190cc7d5003e4d874b88bb18861d0829edc140a713021/numpy-2.3.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:51c1e14eb1e154ebd80e860722f9e6ed6ec89714ad2db2d3aa33c31d7c12179b", size = 16025985, upload-time = "2025-11-16T22:50:04.536Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/fa/dd48e225c46c819288148d9d060b047fd2a6fb1eb37eae25112ee4cb4453/numpy-2.3.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b46b4ec24f7293f23adcd2d146960559aaf8020213de8ad1909dba6c013bf89c", size = 18542976, upload-time = "2025-11-16T22:50:07.557Z" },
+    { url = "https://files.pythonhosted.org/packages/05/79/ccbd23a75862d95af03d28b5c6901a1b7da4803181513d52f3b86ed9446e/numpy-2.3.5-cp312-cp312-win32.whl", hash = "sha256:3997b5b3c9a771e157f9aae01dd579ee35ad7109be18db0e85dbdbe1de06e952", size = 6285274, upload-time = "2025-11-16T22:50:10.746Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/57/8aeaf160312f7f489dea47ab61e430b5cb051f59a98ae68b7133ce8fa06a/numpy-2.3.5-cp312-cp312-win_amd64.whl", hash = "sha256:86945f2ee6d10cdfd67bcb4069c1662dd711f7e2a4343db5cecec06b87cf31aa", size = 12782922, upload-time = "2025-11-16T22:50:12.811Z" },
+    { url = "https://files.pythonhosted.org/packages/78/a6/aae5cc2ca78c45e64b9ef22f089141d661516856cf7c8a54ba434576900d/numpy-2.3.5-cp312-cp312-win_arm64.whl", hash = "sha256:f28620fe26bee16243be2b7b874da327312240a7cdc38b769a697578d2100013", size = 10194667, upload-time = "2025-11-16T22:50:16.16Z" },
 ]
 
 [[package]]
 name = "nvidia-cublas-cu12"
-version = "12.8.4.1"
+version = "12.9.1.4"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/29/99/db44d685f0e257ff0e213ade1964fc459b4a690a73293220e98feb3307cf/nvidia_cublas_cu12-12.8.4.1-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b86f6dd8935884615a0683b663891d43781b819ac4f2ba2b0c9604676af346d0", size = 590537124, upload-time = "2025-03-07T01:43:53.556Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/61/e24b560ab2e2eaeb3c839129175fb330dfcfc29e5203196e5541a4c44682/nvidia_cublas_cu12-12.8.4.1-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:8ac4e771d5a348c551b2a426eda6193c19aa630236b418086020df5ba9667142", size = 594346921, upload-time = "2025-03-07T01:44:31.254Z" },
-    { url = "https://files.pythonhosted.org/packages/70/61/7d7b3c70186fb651d0fbd35b01dbfc8e755f69fd58f817f3d0f642df20c3/nvidia_cublas_cu12-12.8.4.1-py3-none-win_amd64.whl", hash = "sha256:47e9b82132fa8d2b4944e708049229601448aaad7e6f296f630f2d1a32de35af", size = 567544208, upload-time = "2025-03-07T01:53:30.535Z" },
+    { url = "https://files.pythonhosted.org/packages/82/6c/90d3f532f608a03a13c1d6c16c266ffa3828e8011b1549d3b61db2ad59f5/nvidia_cublas_cu12-12.9.1.4-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:7a950dae01add3b415a5a5cdc4ec818fb5858263e9cca59004bb99fdbbd3a5d6", size = 575006342, upload-time = "2025-06-05T20:04:16.902Z" },
+    { url = "https://files.pythonhosted.org/packages/77/3c/aa88abe01f3be3d1f8f787d1d33dc83e76fec05945f9a28fbb41cfb99cd5/nvidia_cublas_cu12-12.9.1.4-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:453611eb21a7c1f2c2156ed9f3a45b691deda0440ec550860290dc901af5b4c2", size = 581242350, upload-time = "2025-06-05T20:04:51.979Z" },
+    { url = "https://files.pythonhosted.org/packages/45/a1/a17fade6567c57452cfc8f967a40d1035bb9301db52f27808167fbb2be2f/nvidia_cublas_cu12-12.9.1.4-py3-none-win_amd64.whl", hash = "sha256:1e5fee10662e6e52bd71dec533fbbd4971bb70a5f24f3bc3793e5c2e9dc640bf", size = 553153899, upload-time = "2025-06-05T20:13:35.556Z" },
 ]
 
 [[package]]
 name = "nvidia-cuda-cupti-cu12"
-version = "12.8.90"
+version = "12.9.79"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/1f/b3bd73445e5cb342727fd24fe1f7b748f690b460acadc27ea22f904502c8/nvidia_cuda_cupti_cu12-12.8.90-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4412396548808ddfed3f17a467b104ba7751e6b58678a4b840675c56d21cf7ed", size = 9533318, upload-time = "2025-03-07T01:40:10.421Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/02/2adcaa145158bf1a8295d83591d22e4103dbfd821bcaf6f3f53151ca4ffa/nvidia_cuda_cupti_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ea0cb07ebda26bb9b29ba82cda34849e73c166c18162d3913575b0c9db9a6182", size = 10248621, upload-time = "2025-03-07T01:40:21.213Z" },
-    { url = "https://files.pythonhosted.org/packages/41/bc/83f5426095d93694ae39fe1311431b5d5a9bb82e48bf0dd8e19be2765942/nvidia_cuda_cupti_cu12-12.8.90-py3-none-win_amd64.whl", hash = "sha256:bb479dcdf7e6d4f8b0b01b115260399bf34154a1a2e9fe11c85c517d87efd98e", size = 7015759, upload-time = "2025-03-07T01:51:11.355Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/78/351b5c8cdbd9a6b4fb0d6ee73fb176dcdc1b6b6ad47c2ffff5ae8ca4a1f7/nvidia_cuda_cupti_cu12-12.9.79-py3-none-manylinux_2_25_aarch64.whl", hash = "sha256:791853b030602c6a11d08b5578edfb957cadea06e9d3b26adbf8d036135a4afe", size = 10077166, upload-time = "2025-06-05T20:01:01.385Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/2e/b84e32197e33f39907b455b83395a017e697c07a449a2b15fd07fc1c9981/nvidia_cuda_cupti_cu12-12.9.79-py3-none-manylinux_2_25_x86_64.whl", hash = "sha256:096bcf334f13e1984ba36685ad4c1d6347db214de03dbb6eebb237b41d9d934f", size = 10814997, upload-time = "2025-06-05T20:01:10.168Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/b4/298983ab1a83de500f77d0add86d16d63b19d1a82c59f8eaf04f90445703/nvidia_cuda_cupti_cu12-12.9.79-py3-none-win_amd64.whl", hash = "sha256:1848a9380067560d5bee10ed240eecc22991713e672c0515f9c3d9396adf93c8", size = 7730496, upload-time = "2025-06-05T20:11:26.444Z" },
 ]
 
 [[package]]
 name = "nvidia-cuda-nvrtc-cu12"
-version = "12.8.93"
+version = "12.9.86"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/6b/32f747947df2da6994e999492ab306a903659555dddc0fbdeb9d71f75e52/nvidia_cuda_nvrtc_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:a7756528852ef889772a84c6cd89d41dfa74667e24cca16bb31f8f061e3e9994", size = 88040029, upload-time = "2025-03-07T01:42:13.562Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/d1/e50d0acaab360482034b84b6e27ee83c6738f7d32182b987f9c7a4e32962/nvidia_cuda_nvrtc_cu12-12.8.93-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fc1fec1e1637854b4c0a65fb9a8346b51dd9ee69e61ebaccc82058441f15bce8", size = 43106076, upload-time = "2025-03-07T01:41:59.817Z" },
-    { url = "https://files.pythonhosted.org/packages/45/51/52a3d84baa2136cc8df15500ad731d74d3a1114d4c123e043cb608d4a32b/nvidia_cuda_nvrtc_cu12-12.8.93-py3-none-win_amd64.whl", hash = "sha256:7a4b6b2904850fe78e0bd179c4b655c404d4bb799ef03ddc60804247099ae909", size = 73586838, upload-time = "2025-03-07T01:52:13.483Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/85/e4af82cc9202023862090bfca4ea827d533329e925c758f0cde964cb54b7/nvidia_cuda_nvrtc_cu12-12.9.86-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:210cf05005a447e29214e9ce50851e83fc5f4358df8b453155d5e1918094dcb4", size = 89568129, upload-time = "2025-06-05T20:02:41.973Z" },
+    { url = "https://files.pythonhosted.org/packages/64/eb/c2295044b8f3b3b08860e2f6a912b702fc92568a167259df5dddb78f325e/nvidia_cuda_nvrtc_cu12-12.9.86-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:096d4de6bda726415dfaf3198d4f5c522b8e70139c97feef5cd2ca6d4cd9cead", size = 44528905, upload-time = "2025-06-05T20:02:29.754Z" },
+    { url = "https://files.pythonhosted.org/packages/52/de/823919be3b9d0ccbf1f784035423c5f18f4267fb0123558d58b813c6ec86/nvidia_cuda_nvrtc_cu12-12.9.86-py3-none-win_amd64.whl", hash = "sha256:72972ebdcf504d69462d3bcd67e7b81edd25d0fb85a2c46d3ea3517666636349", size = 76408187, upload-time = "2025-06-05T20:12:27.819Z" },
 ]
 
 [[package]]
 name = "nvidia-cuda-runtime-cu12"
-version = "12.8.90"
+version = "12.9.79"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/75/f865a3b236e4647605ea34cc450900854ba123834a5f1598e160b9530c3a/nvidia_cuda_runtime_cu12-12.8.90-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:52bf7bbee900262ffefe5e9d5a2a69a30d97e2bc5bb6cc866688caa976966e3d", size = 965265, upload-time = "2025-03-07T01:39:43.533Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/9b/a997b638fcd068ad6e4d53b8551a7d30fe8b404d6f1804abf1df69838932/nvidia_cuda_runtime_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:adade8dcbd0edf427b7204d480d6066d33902cab2a4707dcfc48a2d0fd44ab90", size = 954765, upload-time = "2025-03-07T01:40:01.615Z" },
-    { url = "https://files.pythonhosted.org/packages/30/a5/a515b7600ad361ea14bfa13fb4d6687abf500adc270f19e89849c0590492/nvidia_cuda_runtime_cu12-12.8.90-py3-none-win_amd64.whl", hash = "sha256:c0c6027f01505bfed6c3b21ec546f69c687689aad5f1a377554bc6ca4aa993a8", size = 944318, upload-time = "2025-03-07T01:51:01.794Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e0/0279bd94539fda525e0c8538db29b72a5a8495b0c12173113471d28bce78/nvidia_cuda_runtime_cu12-12.9.79-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:83469a846206f2a733db0c42e223589ab62fd2fabac4432d2f8802de4bded0a4", size = 3515012, upload-time = "2025-06-05T20:00:35.519Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/46/a92db19b8309581092a3add7e6fceb4c301a3fd233969856a8cbf042cd3c/nvidia_cuda_runtime_cu12-12.9.79-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:25bba2dfb01d48a9b59ca474a1ac43c6ebf7011f1b0b8cc44f54eb6ac48a96c3", size = 3493179, upload-time = "2025-06-05T20:00:53.735Z" },
+    { url = "https://files.pythonhosted.org/packages/59/df/e7c3a360be4f7b93cee39271b792669baeb3846c58a4df6dfcf187a7ffab/nvidia_cuda_runtime_cu12-12.9.79-py3-none-win_amd64.whl", hash = "sha256:8e018af8fa02363876860388bd10ccb89eb9ab8fb0aa749aaf58430a9f7c4891", size = 3591604, upload-time = "2025-06-05T20:11:17.036Z" },
 ]
 
 [[package]]
 name = "nvidia-cudnn-cu12"
-version = "9.10.2.21"
+version = "9.17.1.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "extra == 'extra-6-server-gpu' or extra == 'extra-6-server-vllm'" },
+    { name = "nvidia-cublas-cu12", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-gpu') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-vllm') or (sys_platform == 'darwin' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'darwin' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'darwin' and extra == 'extra-6-server-gpu' and extra != 'extra-6-server-vllm') or (sys_platform == 'emscripten' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'win32' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/41/e79269ce215c857c935fd86bcfe91a451a584dfc27f1e068f568b9ad1ab7/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:c9132cc3f8958447b4910a1720036d9eff5928cc3179b0a51fb6d167c6cc87d8", size = 705026878, upload-time = "2025-06-06T21:52:51.348Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/90/0bd6e586701b3a890fd38aa71c387dab4883d619d6e5ad912ccbd05bfd67/nvidia_cudnn_cu12-9.10.2.21-py3-none-win_amd64.whl", hash = "sha256:c6288de7d63e6cf62988f0923f96dc339cea362decb1bf5b3141883392a7d65e", size = 692992268, upload-time = "2025-06-06T21:55:18.114Z" },
+    { url = "https://files.pythonhosted.org/packages/da/55/9987152bd99746b6d5d899a3e920f72f565f5adb4835dc44899382482e2c/nvidia_cudnn_cu12-9.17.1.4-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:d18d61bdd596fca0dbe459c129f6eb7a24ed2e6de1d7988b0a37ac63184ee05d", size = 646648394, upload-time = "2025-12-22T16:42:08.8Z" },
+    { url = "https://files.pythonhosted.org/packages/91/8b/b15aef578b64ff8b72f68f682b6a8254ee6aa6d3d236b4282a4d32dbdf1a/nvidia_cudnn_cu12-9.17.1.4-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:b5083ced291edb2baf8eab09951c6bc58b79b2023c4ec885657a63acdf51d0bd", size = 647835891, upload-time = "2025-12-22T16:43:28.317Z" },
+    { url = "https://files.pythonhosted.org/packages/56/67/e4b10d08c0658bb7e42766fe5cd5c450d0524425e70d12b5eb85a979318e/nvidia_cudnn_cu12-9.17.1.4-py3-none-win_amd64.whl", hash = "sha256:0760c843fb109631edf5bd4234f2a260a13a05c18ee2a20783fbb4eb04d56645", size = 634329630, upload-time = "2025-12-22T16:45:33.451Z" },
 ]
 
 [[package]]
@@ -1456,62 +1484,62 @@ wheels = [
 
 [[package]]
 name = "nvidia-cufft-cu12"
-version = "11.3.3.83"
+version = "11.4.1.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "extra == 'extra-6-server-gpu' or extra == 'extra-6-server-vllm'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-gpu') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-vllm') or (sys_platform == 'darwin' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'darwin' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'darwin' and extra == 'extra-6-server-gpu' and extra != 'extra-6-server-vllm') or (sys_platform == 'emscripten' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'win32' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/60/bc/7771846d3a0272026c416fbb7e5f4c1f146d6d80704534d0b187dd6f4800/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:848ef7224d6305cdb2a4df928759dca7b1201874787083b6e7550dd6765ce69a", size = 193109211, upload-time = "2025-03-07T01:44:56.873Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/ec/ce1629f1e478bb5ccd208986b5f9e0316a78538dd6ab1d0484f012f8e2a1/nvidia_cufft_cu12-11.3.3.83-py3-none-win_amd64.whl", hash = "sha256:7a64a98ef2a7c47f905aaf8931b69a3a43f27c55530c698bb2ed7c75c0b42cb7", size = 192216559, upload-time = "2025-03-07T01:53:57.106Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/2b/76445b0af890da61b501fde30650a1a4bd910607261b209cccb5235d3daa/nvidia_cufft_cu12-11.4.1.4-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1a28c9b12260a1aa7a8fd12f5ebd82d027963d635ba82ff39a1acfa7c4c0fbcf", size = 200822453, upload-time = "2025-06-05T20:05:27.889Z" },
+    { url = "https://files.pythonhosted.org/packages/95/f4/61e6996dd20481ee834f57a8e9dca28b1869366a135e0d42e2aa8493bdd4/nvidia_cufft_cu12-11.4.1.4-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c67884f2a7d276b4b80eb56a79322a95df592ae5e765cf1243693365ccab4e28", size = 200877592, upload-time = "2025-06-05T20:05:45.862Z" },
+    { url = "https://files.pythonhosted.org/packages/20/ee/29955203338515b940bd4f60ffdbc073428f25ef9bfbce44c9a066aedc5c/nvidia_cufft_cu12-11.4.1.4-py3-none-win_amd64.whl", hash = "sha256:8e5bfaac795e93f80611f807d42844e8e27e340e0cde270dcb6c65386d795b80", size = 200067309, upload-time = "2025-06-05T20:13:59.762Z" },
 ]
 
 [[package]]
 name = "nvidia-cufile-cu12"
-version = "1.13.1.3"
+version = "1.14.1.1"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bb/fe/1bcba1dfbfb8d01be8d93f07bfc502c93fa23afa6fd5ab3fc7c1df71038a/nvidia_cufile_cu12-1.13.1.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1d069003be650e131b21c932ec3d8969c1715379251f8d23a1860554b1cb24fc", size = 1197834, upload-time = "2025-03-07T01:45:50.723Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/f5/5607710447a6fe9fd9b3283956fceeee8a06cda1d2f56ce31371f595db2a/nvidia_cufile_cu12-1.13.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:4beb6d4cce47c1a0f1013d72e02b0994730359e17801d395bdcbf20cfb3bb00a", size = 1120705, upload-time = "2025-03-07T01:45:41.434Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/28/b960e06d705a440c030edd84e16888ee14c743390bdb2a6368e92ffe8ef8/nvidia_cufile_cu12-1.14.1.1-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9552e2231792e94b1ff17bc99e958cc0e6bbbaa4a9d91fa2dbeed97716628fe6", size = 1210714, upload-time = "2025-06-05T20:06:11.898Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d2/110af3a1f77999d5eebf6ffae5d2305ab839e53c76eec3696640cc25b35d/nvidia_cufile_cu12-1.14.1.1-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:8dea77590761e02cb6dd955a57cb6414c58aa3cb1b7adbf9919869a11509cf65", size = 1135994, upload-time = "2025-06-05T20:06:03.952Z" },
 ]
 
 [[package]]
 name = "nvidia-curand-cu12"
-version = "10.3.9.90"
+version = "10.3.10.19"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/5e/92aa15eca622a388b80fbf8375d4760738df6285b1e92c43d37390a33a9a/nvidia_curand_cu12-10.3.9.90-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:dfab99248034673b779bc6decafdc3404a8a6f502462201f2f31f11354204acd", size = 63625754, upload-time = "2025-03-07T01:46:10.735Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/aa/6584b56dc84ebe9cf93226a5cde4d99080c8e90ab40f0c27bda7a0f29aa1/nvidia_curand_cu12-10.3.9.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:b32331d4f4df5d6eefa0554c565b626c7216f87a06a4f56fab27c3b68a830ec9", size = 63619976, upload-time = "2025-03-07T01:46:23.323Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/75/70c05b2f3ed5be3bb30b7102b6eb78e100da4bbf6944fd6725c012831cab/nvidia_curand_cu12-10.3.9.90-py3-none-win_amd64.whl", hash = "sha256:f149a8ca457277da854f89cf282d6ef43176861926c7ac85b2a0fbd237c587ec", size = 62765309, upload-time = "2025-03-07T01:54:20.478Z" },
+    { url = "https://files.pythonhosted.org/packages/14/1c/2a45afc614d99558d4a773fa740d8bb5471c8398eeed925fc0fcba020173/nvidia_curand_cu12-10.3.10.19-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:de663377feb1697e1d30ed587b07d5721fdd6d2015c738d7528a6002a6134d37", size = 68292066, upload-time = "2025-05-01T19:39:13.595Z" },
+    { url = "https://files.pythonhosted.org/packages/31/44/193a0e171750ca9f8320626e8a1f2381e4077a65e69e2fb9708bd479e34a/nvidia_curand_cu12-10.3.10.19-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:49b274db4780d421bd2ccd362e1415c13887c53c214f0d4b761752b8f9f6aa1e", size = 68295626, upload-time = "2025-05-01T19:39:38.885Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/98/1bd66fd09cbe1a5920cb36ba87029d511db7cca93979e635fd431ad3b6c0/nvidia_curand_cu12-10.3.10.19-py3-none-win_amd64.whl", hash = "sha256:e8129e6ac40dc123bd948e33d3e11b4aa617d87a583fa2f21b3210e90c743cde", size = 68774847, upload-time = "2025-05-01T19:48:52.93Z" },
 ]
 
 [[package]]
 name = "nvidia-cusolver-cu12"
-version = "11.7.3.90"
+version = "11.7.5.82"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "extra == 'extra-6-server-gpu' or extra == 'extra-6-server-vllm'" },
-    { name = "nvidia-cusparse-cu12", marker = "extra == 'extra-6-server-gpu' or extra == 'extra-6-server-vllm'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "extra == 'extra-6-server-gpu' or extra == 'extra-6-server-vllm'" },
+    { name = "nvidia-cublas-cu12", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-gpu') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-vllm') or (sys_platform == 'darwin' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'darwin' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'darwin' and extra == 'extra-6-server-gpu' and extra != 'extra-6-server-vllm') or (sys_platform == 'emscripten' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'win32' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
+    { name = "nvidia-cusparse-cu12", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-gpu') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-vllm') or (sys_platform == 'darwin' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'darwin' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'darwin' and extra == 'extra-6-server-gpu' and extra != 'extra-6-server-vllm') or (sys_platform == 'emscripten' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'win32' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-gpu') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-vllm') or (sys_platform == 'darwin' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'darwin' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'darwin' and extra == 'extra-6-server-gpu' and extra != 'extra-6-server-vllm') or (sys_platform == 'emscripten' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'win32' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/32/f7cd6ce8a7690544d084ea21c26e910a97e077c9b7f07bf5de623ee19981/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:db9ed69dbef9715071232caa9b69c52ac7de3a95773c2db65bdba85916e4e5c0", size = 267229841, upload-time = "2025-03-07T01:46:54.356Z" },
-    { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
-    { url = "https://files.pythonhosted.org/packages/13/c0/76ca8551b8a84146ffa189fec81c26d04adba4bc0dbe09cd6e6fd9b7de04/nvidia_cusolver_cu12-11.7.3.90-py3-none-win_amd64.whl", hash = "sha256:4a550db115fcabc4d495eb7d39ac8b58d4ab5d8e63274d3754df1c0ad6a22d34", size = 256720438, upload-time = "2025-03-07T01:54:39.898Z" },
+    { url = "https://files.pythonhosted.org/packages/03/99/686ff9bf3a82a531c62b1a5c614476e8dfa24a9d89067aeedf3592ee4538/nvidia_cusolver_cu12-11.7.5.82-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:62efa83e4ace59a4c734d052bb72158e888aa7b770e1a5f601682f16fe5b4fd2", size = 337869834, upload-time = "2025-06-05T20:06:53.125Z" },
+    { url = "https://files.pythonhosted.org/packages/33/40/79b0c64d44d6c166c0964ec1d803d067f4a145cca23e23925fd351d0e642/nvidia_cusolver_cu12-11.7.5.82-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:15da72d1340d29b5b3cf3fd100e3cd53421dde36002eda6ed93811af63c40d88", size = 338117415, upload-time = "2025-06-05T20:07:16.809Z" },
+    { url = "https://files.pythonhosted.org/packages/32/5d/feb7f86b809f89b14193beffebe24cf2e4bf7af08372ab8cdd34d19a65a0/nvidia_cusolver_cu12-11.7.5.82-py3-none-win_amd64.whl", hash = "sha256:77666337237716783c6269a658dea310195cddbd80a5b2919b1ba8735cec8efd", size = 326215953, upload-time = "2025-06-05T20:14:41.76Z" },
 ]
 
 [[package]]
 name = "nvidia-cusparse-cu12"
-version = "12.5.8.93"
+version = "12.5.10.65"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "extra == 'extra-6-server-gpu' or extra == 'extra-6-server-vllm'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-gpu') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-vllm') or (sys_platform == 'darwin' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'darwin' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'darwin' and extra == 'extra-6-server-gpu' and extra != 'extra-6-server-vllm') or (sys_platform == 'emscripten' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'win32' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bc/f7/cd777c4109681367721b00a106f491e0d0d15cfa1fd59672ce580ce42a97/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9b6c161cb130be1a07a27ea6923df8141f3c295852f4b260c65f18f3e0a091dc", size = 288117129, upload-time = "2025-03-07T01:47:40.407Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
-    { url = "https://files.pythonhosted.org/packages/62/07/f3b2ad63f8e3d257a599f422ae34eb565e70c41031aecefa3d18b62cabd1/nvidia_cusparse_cu12-12.5.8.93-py3-none-win_amd64.whl", hash = "sha256:9a33604331cb2cac199f2e7f5104dfbb8a5a898c367a53dfda9ff2acb6b6b4dd", size = 284937404, upload-time = "2025-03-07T01:55:07.742Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/6f/8710fbd17cdd1d0fc3fea7d36d5b65ce1933611c31e1861da330206b253a/nvidia_cusparse_cu12-12.5.10.65-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:221c73e7482dd93eda44e65ce567c031c07e2f93f6fa0ecd3ba876a195023e83", size = 366359408, upload-time = "2025-06-05T20:07:42.501Z" },
+    { url = "https://files.pythonhosted.org/packages/12/46/b0fd4b04f86577921feb97d8e2cf028afe04f614d17fb5013de9282c9216/nvidia_cusparse_cu12-12.5.10.65-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:73060ce019ac064a057267c585bf1fd5a353734151f87472ff02b2c5c9984e78", size = 366465088, upload-time = "2025-06-05T20:08:20.413Z" },
+    { url = "https://files.pythonhosted.org/packages/73/ef/063500c25670fbd1cbb0cd3eb7c8a061585b53adb4dd8bf3492bb49b0df3/nvidia_cusparse_cu12-12.5.10.65-py3-none-win_amd64.whl", hash = "sha256:9e487468a22a1eaf1fbd1d2035936a905feb79c4ce5c2f67626764ee4f90227c", size = 362504719, upload-time = "2025-06-05T20:15:17.947Z" },
 ]
 
 [[package]]
@@ -1529,7 +1557,7 @@ name = "nvidia-cutlass-dsl"
 version = "4.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cutlass-dsl-libs-base" },
+    { name = "nvidia-cutlass-dsl-libs-base", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a9/03/678dab0383db1ddfc449da216220f40404189eb36eeed9d87a4fa4bdb0e6/nvidia_cutlass_dsl-4.4.2-py3-none-any.whl", hash = "sha256:7cfb9ef19062b055b9372c7a627004724e2755e4c8b16c3cc88807d64501a4ae", size = 10167, upload-time = "2026-03-16T02:18:59.043Z" },
@@ -1540,9 +1568,9 @@ name = "nvidia-cutlass-dsl-libs-base"
 version = "4.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-python" },
-    { name = "numpy" },
-    { name = "typing-extensions" },
+    { name = "cuda-python", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "numpy", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "typing-extensions", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8e/7d/0df5e38d11e52cc72095a14d6448bc1c5d0d4b00b069a1189ca417fb225b/nvidia_cutlass_dsl_libs_base-4.4.2-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:2ec8812eeadcbb6fe20bda2e295ed9c00653f8253b78e33cf0ab65a47b829e73", size = 75473821, upload-time = "2026-03-16T02:27:08.371Z" },
@@ -1560,21 +1588,21 @@ wheels = [
 
 [[package]]
 name = "nvidia-nccl-cu12"
-version = "2.27.5"
+version = "2.28.9"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bb/1c/857979db0ef194ca5e21478a0612bcdbbe59458d7694361882279947b349/nvidia_nccl_cu12-2.27.5-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:31432ad4d1fb1004eb0c56203dc9bc2178a1ba69d1d9e02d64a6938ab5e40e7a", size = 322400625, upload-time = "2025-06-26T04:11:04.496Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/89/f7a07dc961b60645dbbf42e80f2bc85ade7feb9a491b11a1e973aa00071f/nvidia_nccl_cu12-2.27.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ad730cf15cb5d25fe849c6e6ca9eb5b76db16a80f13f425ac68d8e2e55624457", size = 322348229, upload-time = "2025-06-26T04:11:28.385Z" },
+    { url = "https://files.pythonhosted.org/packages/08/c4/120d2dfd92dff2c776d68f361ff8705fdea2ca64e20b612fab0fd3f581ac/nvidia_nccl_cu12-2.28.9-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:50a36e01c4a090b9f9c47d92cec54964de6b9fcb3362d0e19b8ffc6323c21b60", size = 296766525, upload-time = "2025-11-18T05:49:16.094Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/4e/44dbb46b3d1b0ec61afda8e84837870f2f9ace33c564317d59b70bc19d3e/nvidia_nccl_cu12-2.28.9-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:485776daa8447da5da39681af455aa3b2c2586ddcf4af8772495e7c532c7e5ab", size = 296782137, upload-time = "2025-11-18T05:49:34.248Z" },
 ]
 
 [[package]]
 name = "nvidia-nvjitlink-cu12"
-version = "12.8.93"
+version = "12.9.86"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/74/86a07f1d0f42998ca31312f998bd3b9a7eff7f52378f4f270c8679c77fb9/nvidia_nvjitlink_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:81ff63371a7ebd6e6451970684f916be2eab07321b73c9d244dc2b4da7f73b88", size = 39254836, upload-time = "2025-03-07T01:49:55.661Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/a2/8cee5da30d13430e87bf99bb33455d2724d0a4a9cb5d7926d80ccb96d008/nvidia_nvjitlink_cu12-12.8.93-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:adccd7161ace7261e01bb91e44e88da350895c270d23f744f0820c818b7229e7", size = 38386204, upload-time = "2025-03-07T01:49:43.612Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/d7/34f02dad2e30c31b10a51f6b04e025e5dd60e5f936af9045a9b858a05383/nvidia_nvjitlink_cu12-12.8.93-py3-none-win_amd64.whl", hash = "sha256:bd93fbeeee850917903583587f4fc3a4eafa022e34572251368238ab5e6bd67f", size = 268553710, upload-time = "2025-03-07T01:56:24.13Z" },
+    { url = "https://files.pythonhosted.org/packages/46/0c/c75bbfb967457a0b7670b8ad267bfc4fffdf341c074e0a80db06c24ccfd4/nvidia_nvjitlink_cu12-12.9.86-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:e3f1171dbdc83c5932a45f0f4c99180a70de9bd2718c1ab77d14104f6d7147f9", size = 39748338, upload-time = "2025-06-05T20:10:25.613Z" },
+    { url = "https://files.pythonhosted.org/packages/97/bc/2dcba8e70cf3115b400fef54f213bcd6715a3195eba000f8330f11e40c45/nvidia_nvjitlink_cu12-12.9.86-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:994a05ef08ef4b0b299829cde613a424382aff7efb08a7172c1fa616cc3af2ca", size = 39514880, upload-time = "2025-06-05T20:10:04.89Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/7e/2eecb277d8a98184d881fb98a738363fd4f14577a4d2d7f8264266e82623/nvidia_nvjitlink_cu12-12.9.86-py3-none-win_amd64.whl", hash = "sha256:cc6fcec260ca843c10e34c936921a1c426b351753587fdd638e8cff7b16bb9db", size = 35584936, upload-time = "2025-06-05T20:16:08.525Z" },
 ]
 
 [[package]]
@@ -1588,12 +1616,12 @@ wheels = [
 
 [[package]]
 name = "nvidia-nvtx-cu12"
-version = "12.8.90"
+version = "12.9.79"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/c0/1b303feea90d296f6176f32a2a70b5ef230f9bdeb3a72bddb0dc922dc137/nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d7ad891da111ebafbf7e015d34879f7112832fc239ff0d7d776b6cb685274615", size = 91161, upload-time = "2025-03-07T01:42:23.922Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/eb/86626c1bbc2edb86323022371c39aa48df6fd8b0a1647bc274577f72e90b/nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5b17e2001cc0d751a5bc2c6ec6d26ad95913324a4adb86788c944f8ce9ba441f", size = 89954, upload-time = "2025-03-07T01:42:44.131Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/99/4c9c0c329bf9fc125008c3b54c7c94c0023518d06fc025ae36431375e1fe/nvidia_nvtx_cu12-12.8.90-py3-none-win_amd64.whl", hash = "sha256:619c8304aedc69f02ea82dd244541a83c3d9d40993381b3b590f1adaed3db41e", size = 56492, upload-time = "2025-03-07T01:52:24.69Z" },
+    { url = "https://files.pythonhosted.org/packages/86/ed/bb230dce7741f2778ba2ae3e8778fdb8bc58eee9fd95f07bf7b2d18e8081/nvidia_nvtx_cu12-12.9.79-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fec150986817f2b4e7eed72ed059f2dcb9ba3856b9a96134e448eac946a6952f", size = 85504, upload-time = "2025-06-05T20:03:10.21Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/e4/82155e4aaedb41621087ba219c95e99c5e417f37a7649b4fb6ec32dcb14d/nvidia_nvtx_cu12-12.9.79-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d1f258e752294acdb4f61c3d31fee87bd0f60e459f1e2f624376369b524cd15d", size = 86120, upload-time = "2025-06-05T20:02:51.838Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/cc/efd28e4b3f4019f7ef176f4baa5c1ef7dcd3ac8c9e6d2b15bcbf3f1297d3/nvidia_nvtx_cu12-12.9.79-py3-none-win_amd64.whl", hash = "sha256:1f504e573b3a955e55aae6c747e2ae561b63fdcafcd591e43d18dae9875504f8", size = 77774, upload-time = "2025-06-05T20:12:39.44Z" },
 ]
 
 [[package]]
@@ -1601,14 +1629,14 @@ name = "openai"
 version = "2.33.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "distro" },
-    { name = "httpx" },
-    { name = "jiter" },
-    { name = "pydantic" },
-    { name = "sniffio" },
-    { name = "tqdm" },
-    { name = "typing-extensions" },
+    { name = "anyio", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "distro", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "httpx", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "jiter", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "pydantic", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "sniffio", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "tqdm", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "typing-extensions", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f0/ee/d056c82f63c05f06baac0cffb4a90952d8274f90c49dfe244f20497b9bbd/openai-2.33.0.tar.gz", hash = "sha256:f850c435e2a4685bba3295bd54912dd26315d9c1b7733068186134d6e0599f9a", size = 693254, upload-time = "2026-04-28T14:04:42.428Z" }
 wheels = [
@@ -1620,7 +1648,7 @@ name = "openai-harmony"
 version = "0.0.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic" },
+    { name = "pydantic", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3e/92/2d038d096f29179c7c9571b431f9e739f87a487121901725e23fe338dd9d/openai_harmony-0.0.8.tar.gz", hash = "sha256:6e43f98e6c242fa2de6f8ea12eab24af63fa2ed3e89c06341fb9d92632c5cbdf", size = 284777, upload-time = "2025-11-05T19:07:06.727Z" }
 wheels = [
@@ -1643,7 +1671,7 @@ name = "opencv-python-headless"
 version = "4.13.0.92"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/42/2310883be3b8826ac58c3f2787b9358a2d46923d61f88fedf930bc59c60c/opencv_python_headless-4.13.0.92-cp37-abi3-macosx_13_0_arm64.whl", hash = "sha256:1a7d040ac656c11b8c38677cc8cccdc149f98535089dbe5b081e80a4e5903209", size = 46247192, upload-time = "2026-02-05T07:01:35.187Z" },
@@ -1689,8 +1717,8 @@ name = "opentelemetry-exporter-otlp"
 version = "1.41.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "opentelemetry-exporter-otlp-proto-grpc" },
-    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "opentelemetry-exporter-otlp-proto-http", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/84/d55baf8e1a222f40282956083e67de9fa92d5fa451108df4839505fa2a24/opentelemetry_exporter_otlp-1.41.1.tar.gz", hash = "sha256:299a2f0541ca175df186f5ac58fd5db177ba1e9b72b0826049062f750d55b47f", size = 6152, upload-time = "2026-04-24T13:15:40.006Z" }
 wheels = [
@@ -1702,7 +1730,7 @@ name = "opentelemetry-exporter-otlp-proto-common"
 version = "1.41.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-proto", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ae/fa/f9e3bd3c4d692b3ce9a2880a167d1f79681a1bea11f00d5bf76adc03e6ea/opentelemetry_exporter_otlp_proto_common-1.41.1.tar.gz", hash = "sha256:0e253156ea9c36b0bd3d2440c5c9ba7dd1f3fb64ba7a08fc85fbac536b56e1fb", size = 20409, upload-time = "2026-04-24T13:15:40.924Z" }
 wheels = [
@@ -1714,13 +1742,13 @@ name = "opentelemetry-exporter-otlp-proto-grpc"
 version = "1.41.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "googleapis-common-protos" },
-    { name = "grpcio" },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-exporter-otlp-proto-common" },
-    { name = "opentelemetry-proto" },
-    { name = "opentelemetry-sdk" },
-    { name = "typing-extensions" },
+    { name = "googleapis-common-protos", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "grpcio", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "opentelemetry-api", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "opentelemetry-exporter-otlp-proto-common", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "opentelemetry-proto", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "opentelemetry-sdk", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "typing-extensions", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1e/9b/e4503060b8695579dbaad187dc8cef4554188de68748c88060599b77489e/opentelemetry_exporter_otlp_proto_grpc-1.41.1.tar.gz", hash = "sha256:b05df8fa1333dc9a3fda36b676b96b5095ab6016d3f0c3296d430d629ba1443b", size = 25755, upload-time = "2026-04-24T13:15:41.93Z" }
 wheels = [
@@ -1732,13 +1760,13 @@ name = "opentelemetry-exporter-otlp-proto-http"
 version = "1.41.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "googleapis-common-protos" },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-exporter-otlp-proto-common" },
-    { name = "opentelemetry-proto" },
-    { name = "opentelemetry-sdk" },
-    { name = "requests" },
-    { name = "typing-extensions" },
+    { name = "googleapis-common-protos", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "opentelemetry-api", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "opentelemetry-exporter-otlp-proto-common", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "opentelemetry-proto", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "opentelemetry-sdk", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "requests", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "typing-extensions", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/5b/9d3c7f70cca10136ba82a81e738dee626c8e7fc61c6887ea9a58bf34c606/opentelemetry_exporter_otlp_proto_http-1.41.1.tar.gz", hash = "sha256:4747a9604c8550ab38c6fd6180e2fcb80de3267060bef2c306bad3cb443302bc", size = 24139, upload-time = "2026-04-24T13:15:42.977Z" }
 wheels = [
@@ -1797,7 +1825,7 @@ name = "opentelemetry-proto"
 version = "1.41.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "protobuf" },
+    { name = "protobuf", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/99/e8/633c6d8a9c8840338b105907e55c32d3da1983abab5e52f899f72a82c3d1/opentelemetry_proto-1.41.1.tar.gz", hash = "sha256:4b9d2eb631237ea43b80e16c073af438554e32bc7e9e3f8ca4a9582f900020e5", size = 45670, upload-time = "2026-04-24T13:15:49.768Z" }
 wheels = [
@@ -1851,8 +1879,8 @@ name = "opentelemetry-semantic-conventions-ai"
 version = "0.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "opentelemetry-sdk" },
-    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-sdk", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "opentelemetry-semantic-conventions", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/24/02/10aeacc37a38a3a8fa16ff67bec1ae3bf882539f6f9efb0f70acf802ca2d/opentelemetry_semantic_conventions_ai-0.5.1.tar.gz", hash = "sha256:153906200d8c1d2f8e09bd78dbef526916023de85ac3dab35912bfafb69ff04c", size = 26533, upload-time = "2026-03-26T14:20:38.73Z" }
 wheels = [
@@ -1870,18 +1898,18 @@ wheels = [
 
 [[package]]
 name = "outlines-core"
-version = "0.2.11"
+version = "0.2.14"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1a/d3/e04e9145f8f806723dec9b9e5227ad695a3efcd3ced7794cf7c22b15df5e/outlines_core-0.2.11.tar.gz", hash = "sha256:dfce56f717ff5083e54cbcfdb66cad243365437fccbb5509adaa7e31e030f1d8", size = 197263, upload-time = "2025-05-19T10:12:51.719Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/04/4a0812eb27c086cfd2e66e7ec9150f33e105912a9b7f8b335e3479f03a06/outlines_core-0.2.14.tar.gz", hash = "sha256:64808deed1591ca3029ff64346ceb974cd5d780c916ea82504951fe83523039e", size = 191539, upload-time = "2026-01-09T15:59:10.016Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/2c/c7636823244c70e2960060bf9bd978248dffb55c5e7c91c46d18354b2a24/outlines_core-0.2.11-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:4a9db4872bae083631d720994f4cee603bce0536b33d5a988814576863b657cf", size = 1957668, upload-time = "2025-05-19T10:12:18.29Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/09/5c62047da139d722317a444a4d01cd5f11943a8c2eaecce784341dd0844a/outlines_core-0.2.11-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:8359a45c59f6a8f2eb717245806501a59044c75f6ea8bd08faaa131cc8cdec45", size = 2130493, upload-time = "2025-05-19T10:12:19.537Z" },
-    { url = "https://files.pythonhosted.org/packages/89/7a/d6a2810f90e37d550168e0c0a9a915086ea721444727e3ca2c630898d1ef/outlines_core-0.2.11-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:5d26a46591377340e0b870b8a96ea8341058341a62ee0bded9098e0c88dd24f4", size = 1956804, upload-time = "2025-05-19T10:12:20.755Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/ea/339e6c273b5581128c3b7ca27d428d8993c3085912af1a467aa32ef0e9d1/outlines_core-0.2.11-cp312-cp312-macosx_15_0_x86_64.whl", hash = "sha256:ae460a34675fb11d92a5c605a480fbae4cd6c1b2d11b3698da64a7fcaba64dcf", size = 2127085, upload-time = "2025-05-19T10:12:22.02Z" },
-    { url = "https://files.pythonhosted.org/packages/92/c7/a65d1fddf49830ebc41422294eacde35286d9f68994a8aa905cb14f5aade/outlines_core-0.2.11-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:86df9740368866295077346440d911df4972da2b3f1f54b8125e6f329e8a8891", size = 2287677, upload-time = "2025-05-19T10:12:24.24Z" },
-    { url = "https://files.pythonhosted.org/packages/23/79/8795aed8be9b77dd69d78e7cfbfcf28c179e6b08da6e56bbbf48a09fe55f/outlines_core-0.2.11-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:96ce4dd78f106799be4a0a5795cefd1352806162973756a4b6fce4bb6eddd7e4", size = 2113000, upload-time = "2025-05-19T10:12:25.446Z" },
-    { url = "https://files.pythonhosted.org/packages/59/e3/cbe9294b06d92ee1892dbb6f2125d833d68e8629d45d080d6daba54eec2d/outlines_core-0.2.11-cp312-cp312-win32.whl", hash = "sha256:358db161cce3650ba822e118dcf0a1efa571c7deb4864ab9d64ca2c9cca7425d", size = 1765703, upload-time = "2025-05-19T10:12:26.693Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/c9/ed3cf362515fac16e313368b9b2f2497051f4ded88679205830b6f889f54/outlines_core-0.2.11-cp312-cp312-win_amd64.whl", hash = "sha256:231f9d20d2630c70665345821780d7808b29539620a75c99f65113b518c51032", size = 2060945, upload-time = "2025-05-19T10:12:28.294Z" },
+    { url = "https://files.pythonhosted.org/packages/66/93/30b9188648a479b32be429a24166db47a7bfdb0f9a8aac4c6dcf569e0a52/outlines_core-0.2.14-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:95e6476d9702d2fcc4e85370dbbfb6933a46c816e9c90107f6ce36eb68b5d64a", size = 2049651, upload-time = "2026-01-09T15:58:28.549Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/06/f3557daa8e87d5b95f64de269a301d73ec3c2202ab897c3e1f1cb93eb1db/outlines_core-0.2.14-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:f04731a5e29a190e2cc9f692a1f3fb2414a645355ca7d01b83df43439c38bea8", size = 2201046, upload-time = "2026-01-09T15:58:29.958Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/67/d8acf778990964c951080d568284e858d466f27dfd6f2674781927faba1c/outlines_core-0.2.14-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:0e4c69f0a8565edb56464c4c9b6c291a10805f3a96dff84182980e90ae1a5e2f", size = 2049558, upload-time = "2026-01-09T15:58:31.003Z" },
+    { url = "https://files.pythonhosted.org/packages/17/e1/0320b14b49b8379ced1ab195ecf5875dbd2267b90148847541f43bfde6c1/outlines_core-0.2.14-cp312-cp312-macosx_15_0_x86_64.whl", hash = "sha256:63f53cfd9614e754499ae86dd699f3abcecf42d6a4e58d80fd80347881d85960", size = 2197854, upload-time = "2026-01-09T15:58:32.39Z" },
+    { url = "https://files.pythonhosted.org/packages/29/29/3a04944407207a5d214879ca5ca33c2bd3e65199a4e927051c1bdaaa4d50/outlines_core-0.2.14-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3bb2060c240c4507f334965a8948dbeeb22007560d797f6debd92346c0b620cb", size = 2341426, upload-time = "2026-01-09T15:58:33.553Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a7/a77f746272504bac3f628047d56ea1731b61549a3e1d9bbfd226f2968246/outlines_core-0.2.14-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:1de34681c7e0e7e1551fc9036e4fa3c57986336c905a10536591ceb6d869c258", size = 2236941, upload-time = "2026-01-09T15:58:35.118Z" },
+    { url = "https://files.pythonhosted.org/packages/99/0d/9f599d938923ab8ceeff26fdf2f9ea53bea3c962085c4927a08338a32349/outlines_core-0.2.14-cp312-cp312-win32.whl", hash = "sha256:870e8e038853818cb202ccc8cde92251f300f96805bfcc3be1c883adda7b5297", size = 1842940, upload-time = "2026-01-09T15:58:36.544Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/df/0f145c52ebd156d80273e2f5278227ea57e0275b2aa863bed33f44f77923/outlines_core-0.2.14-cp312-cp312-win_amd64.whl", hash = "sha256:87b42440478764cce1353a87d8560ef82f3b39b9d753bfe93195ea3584f369e3", size = 2137266, upload-time = "2026-01-09T15:58:37.831Z" },
 ]
 
 [[package]]
@@ -1935,9 +1963,10 @@ dependencies = [
     { name = "psutil" },
     { name = "pyyaml" },
     { name = "safetensors" },
-    { name = "torch", version = "2.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "extra == 'extra-6-server-gpu' or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
     { name = "torch", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-6-server-cpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+    { name = "torch", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform == 'emscripten' and extra == 'extra-6-server-gpu') or (sys_platform == 'win32' and extra == 'extra-6-server-gpu') or (sys_platform == 'darwin' and extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
     { name = "torch", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-cpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+    { name = "torch", version = "2.11.0+cu129", source = { registry = "https://download.pytorch.org/whl/cu129" }, marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-gpu') or (sys_platform == 'darwin' and extra == 'extra-6-server-gpu' and extra != 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
     { name = "tqdm" },
     { name = "transformers" },
 ]
@@ -1979,8 +2008,8 @@ name = "prometheus-fastapi-instrumentator"
 version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "prometheus-client" },
-    { name = "starlette" },
+    { name = "prometheus-client", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "starlette", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/69/6d/24d53033cf93826aa7857699a4450c1c67e5b9c710e925b1ed2b320c04df/prometheus_fastapi_instrumentator-7.1.0.tar.gz", hash = "sha256:be7cd61eeea4e5912aeccb4261c6631b3f227d8924542d79eaf5af3f439cbe5e", size = 20220, upload-time = "2025-03-19T19:35:05.351Z" }
 wheels = [
@@ -2166,7 +2195,7 @@ wheels = [
 
 [package.optional-dependencies]
 email = [
-    { name = "email-validator" },
+    { name = "email-validator", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
 ]
 
 [[package]]
@@ -2204,8 +2233,8 @@ name = "pydantic-extra-types"
 version = "2.11.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic" },
-    { name = "typing-extensions" },
+    { name = "pydantic", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "typing-extensions", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/71/dba38ee2651f84f7842206adbd2233d8bbdb59fb85e9fa14232486a8c471/pydantic_extra_types-2.11.1.tar.gz", hash = "sha256:46792d2307383859e923d8fcefa82108b1a141f8a9c0198982b3832ab5ef1049", size = 172002, upload-time = "2026-03-16T08:08:03.92Z" }
 wheels = [
@@ -2214,7 +2243,7 @@ wheels = [
 
 [package.optional-dependencies]
 pycountry = [
-    { name = "pycountry" },
+    { name = "pycountry", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
 ]
 
 [[package]]
@@ -2222,9 +2251,9 @@ name = "pydantic-settings"
 version = "2.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "typing-inspection" },
+    { name = "pydantic", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "python-dotenv", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "typing-inspection", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/98/c8345dccdc31de4228c039a98f6467a941e39558da41c1744fbe29fa5666/pydantic_settings-2.14.0.tar.gz", hash = "sha256:24285fd4b0e0c06507dd9fdfd331ee23794305352aaec8fc4eb92d4047aeb67d", size = 235709, upload-time = "2026-04-20T13:37:40.293Z" }
 wheels = [
@@ -2251,7 +2280,7 @@ wheels = [
 
 [package.optional-dependencies]
 crypto = [
-    { name = "cryptography" },
+    { name = "cryptography", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
 ]
 
 [[package]]
@@ -2326,7 +2355,7 @@ name = "pyzmq"
 version = "27.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "implementation_name == 'pypy'" },
+    { name = "cffi", marker = "(implementation_name == 'pypy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (implementation_name == 'pypy' and sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (implementation_name == 'pypy' and sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/04/0b/3c9baedbdf613ecaa7aa07027780b8867f57b6293b6ee50de316c9f3222b/pyzmq-27.1.0.tar.gz", hash = "sha256:ac0765e3d44455adb6ddbf4417dcce460fc40a05978c08efdf2948072f6db540", size = 281750, upload-time = "2025-09-08T23:10:18.157Z" }
 wheels = [
@@ -2347,11 +2376,11 @@ name = "quack-kernels"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "apache-tvm-ffi" },
-    { name = "einops" },
-    { name = "nvidia-cutlass-dsl" },
-    { name = "torch", version = "2.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" } },
-    { name = "torch-c-dlpack-ext" },
+    { name = "apache-tvm-ffi", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "einops", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "nvidia-cutlass-dsl", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "torch", version = "2.11.0+cu129", source = { registry = "https://download.pytorch.org/whl/cu129" }, marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "torch-c-dlpack-ext", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fd/40/e9a86b32ee3d44be6301acb9ebe6f299f2b8f0e0fd847f4143139100a2bf/quack_kernels-0.4.0.tar.gz", hash = "sha256:55a3c69bb2219ec6488fe366a21c3da1a50c4640ceb5b9b31d126f8477ad35aa", size = 261153, upload-time = "2026-04-27T15:29:08.588Z" }
 wheels = [
@@ -2372,9 +2401,9 @@ name = "referencing"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs" },
-    { name = "rpds-py" },
-    { name = "typing-extensions" },
+    { name = "attrs", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "rpds-py", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "typing-extensions", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
 wheels = [
@@ -2425,8 +2454,8 @@ name = "rich"
 version = "15.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "markdown-it-py" },
-    { name = "pygments" },
+    { name = "markdown-it-py", marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-vllm') or extra == 'extra-6-server-cpu' or extra == 'extra-6-server-gpu'" },
+    { name = "pygments", marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-vllm') or extra == 'extra-6-server-cpu' or extra == 'extra-6-server-gpu'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
@@ -2438,9 +2467,9 @@ name = "rich-toolkit"
 version = "0.19.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "rich" },
-    { name = "typing-extensions" },
+    { name = "click", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "rich", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "typing-extensions", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/ba/dae9e3096651042754da419a4042bc1c75e07d615f9b15066d738838e4df/rich_toolkit-0.19.7.tar.gz", hash = "sha256:133c0915872da91d4c25d85342d5ec1dfacc69b63448af1a08a0d4b4f23ef46e", size = 195877, upload-time = "2026-02-24T16:06:20.555Z" }
 wheels = [
@@ -2536,8 +2565,8 @@ name = "sentry-sdk"
 version = "2.58.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "certifi" },
-    { name = "urllib3" },
+    { name = "certifi", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "urllib3", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/26/b3/fb8291170d0e844173164709fc0fa0c221ed75a5da740c8746f2a83b4eb1/sentry_sdk-2.58.0.tar.gz", hash = "sha256:c1144d947352d54e5b7daa63596d9f848adf684989c06c4f5a659f0c85a18f6f", size = 438764, upload-time = "2026-04-13T17:23:26.265Z" }
 wheels = [
@@ -2563,7 +2592,7 @@ dependencies = [
 
 [package.optional-dependencies]
 cpu = [
-    { name = "datasets", version = "4.8.5", source = { registry = "https://pypi.org/simple" } },
+    { name = "datasets" },
     { name = "numpy" },
     { name = "peft" },
     { name = "torch", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-6-server-cpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
@@ -2571,15 +2600,14 @@ cpu = [
     { name = "transformers" },
 ]
 gpu = [
-    { name = "datasets", version = "1.1.1", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform == 'win32' and extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "datasets", version = "4.8.5", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'win32' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-gpu' and extra != 'extra-6-server-vllm')" },
+    { name = "datasets" },
     { name = "numpy" },
     { name = "peft" },
-    { name = "torch", version = "2.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "sys_platform == 'linux'" },
+    { name = "torch", version = "2.11.0+cu129", source = { registry = "https://download.pytorch.org/whl/cu129" }, marker = "sys_platform == 'linux'" },
     { name = "transformers" },
 ]
 vllm = [
-    { name = "torch", version = "2.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "sys_platform == 'linux'" },
+    { name = "torch", version = "2.11.0+cu129", source = { registry = "https://download.pytorch.org/whl/cu129" }, marker = "sys_platform == 'linux'" },
     { name = "torch-c-dlpack-ext", marker = "sys_platform == 'linux'" },
     { name = "vllm", marker = "sys_platform == 'linux'" },
 ]
@@ -2600,15 +2628,15 @@ requires-dist = [
     { name = "peft", marker = "extra == 'gpu'" },
     { name = "pydantic" },
     { name = "redis", specifier = ">=5.0.0" },
-    { name = "torch", marker = "sys_platform == 'linux' and extra == 'gpu'", index = "https://download.pytorch.org/whl/cu128", conflict = { package = "server", extra = "gpu" } },
-    { name = "torch", marker = "sys_platform == 'linux' and extra == 'vllm'", index = "https://download.pytorch.org/whl/cu128", conflict = { package = "server", extra = "vllm" } },
+    { name = "torch", marker = "sys_platform == 'linux' and extra == 'gpu'", index = "https://download.pytorch.org/whl/cu129", conflict = { package = "server", extra = "gpu" } },
+    { name = "torch", marker = "sys_platform == 'linux' and extra == 'vllm'", index = "https://download.pytorch.org/whl/cu129", conflict = { package = "server", extra = "vllm" } },
     { name = "torch", marker = "extra == 'cpu'", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "server", extra = "cpu" } },
     { name = "torch-c-dlpack-ext", marker = "sys_platform == 'linux' and extra == 'vllm'" },
     { name = "tqdm", specifier = ">=4.50" },
     { name = "transformers", marker = "extra == 'cpu'", specifier = ">=5.5.4" },
     { name = "transformers", marker = "extra == 'gpu'", specifier = ">=5.5.4" },
     { name = "uvicorn" },
-    { name = "vllm", marker = "sys_platform == 'linux' and extra == 'vllm'", specifier = "==0.19.1" },
+    { name = "vllm", marker = "sys_platform == 'linux' and extra == 'vllm'", specifier = "==0.20.0", index = "https://wheels.vllm.ai/0.20.0/cu129", conflict = { package = "server", extra = "vllm" } },
 ]
 provides-extras = ["cpu", "gpu", "vllm"]
 
@@ -2671,8 +2699,8 @@ name = "sse-starlette"
 version = "3.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "starlette" },
+    { name = "anyio", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "starlette", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e1/9a/f35932a8c0eb6b2287b66fa65a0321df8c84e4e355a659c1841a37c39fdb/sse_starlette-3.4.1.tar.gz", hash = "sha256:f780bebcf6c8997fe514e3bd8e8c648d8284976b391c8bed0bcb1f611632b555", size = 35127, upload-time = "2026-04-26T13:32:32.292Z" }
 wheels = [
@@ -2706,7 +2734,7 @@ name = "sympy"
 version = "1.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mpmath" },
+    { name = "mpmath", marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-vllm') or extra == 'extra-6-server-cpu' or extra == 'extra-6-server-gpu'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
 wheels = [
@@ -2727,8 +2755,8 @@ name = "tiktoken"
 version = "0.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "regex" },
-    { name = "requests" },
+    { name = "regex", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "requests", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7d/ab/4d017d0f76ec3171d469d80fc03dfbb4e48a4bcaddaa831b31d526f05edc/tiktoken-0.12.0.tar.gz", hash = "sha256:b18ba7ee2b093863978fcb14f74b3707cdc8d4d4d3836853ce7ec60772139931", size = 37806, upload-time = "2025-10-06T20:22:45.419Z" }
 wheels = [
@@ -2742,11 +2770,34 @@ wheels = [
 ]
 
 [[package]]
+name = "tilelang"
+version = "0.1.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "apache-tvm-ffi", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "cloudpickle", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "ml-dtypes", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "numpy", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "psutil", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "torch", version = "2.11.0+cu129", source = { registry = "https://download.pytorch.org/whl/cu129" }, marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "torch-c-dlpack-ext", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "tqdm", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "typing-extensions", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "z3-solver", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/56/70/5051f65821baa30a3d61fc48f8ba10c776490315e8c90f82559b92089756/tilelang-0.1.9.tar.gz", hash = "sha256:287f727c913bb648fcf6c1968809ba3390e55eeed257a5c6bb9a80bc05966af4", size = 93395292, upload-time = "2026-04-22T09:19:11.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/db/4dd76da8c8585c605639a21bc098d504e317fe324a72f01ce3c7370250b4/tilelang-0.1.9-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:00ed594fdeb229c5505b9ffa895c3c5daeb28641c78f783fa1f724cf1e08cecd", size = 36599020, upload-time = "2026-04-22T09:14:39.366Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/8a/1cbeee79d62abaa02441c2d00621554e41aa62dbf3b94a4feb3867184b01/tilelang-0.1.9-cp38-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4bbccfe9035aed775ffafb6dc25a5994504b24e2c5d95d0f39643edfafa7bf12", size = 45419374, upload-time = "2026-04-22T09:15:56.014Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a7/f4bfb86f87e107703146e703204cec2c0eae2492b633e0052b0ace3febb6/tilelang-0.1.9-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:77ab0ee2f40f66ea015b6b21426d482751e28cbc635ef9d1198cbd6502454a7c", size = 42110365, upload-time = "2026-04-22T09:17:18.292Z" },
+]
+
+[[package]]
 name = "tokenizers"
 version = "0.22.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "huggingface-hub" },
+    { name = "huggingface-hub", marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-vllm') or extra == 'extra-6-server-cpu' or extra == 'extra-6-server-gpu'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/73/6f/f80cfef4a312e1fb34baf7d85c72d4411afde10978d4657f8cdd811d3ccc/tokenizers-0.22.2.tar.gz", hash = "sha256:473b83b915e547aa366d1eee11806deaf419e17be16310ac0a14077f1e28f917", size = 372115, upload-time = "2026-01-05T10:45:15.988Z" }
 wheels = [
@@ -2769,52 +2820,6 @@ wheels = [
 
 [[package]]
 name = "torch"
-version = "2.10.0+cu128"
-source = { registry = "https://download.pytorch.org/whl/cu128" }
-resolution-markers = [
-    "sys_platform == 'win32' and extra != 'extra-6-server-cpu' and extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm'",
-    "sys_platform == 'emscripten' and extra != 'extra-6-server-cpu' and extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm'",
-    "sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-6-server-cpu' and extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm'",
-    "sys_platform == 'win32' and extra != 'extra-6-server-cpu' and extra == 'extra-6-server-gpu' and extra != 'extra-6-server-vllm'",
-    "sys_platform == 'emscripten' and extra != 'extra-6-server-cpu' and extra == 'extra-6-server-gpu' and extra != 'extra-6-server-vllm'",
-    "sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-6-server-cpu' and extra == 'extra-6-server-gpu' and extra != 'extra-6-server-vllm'",
-    "extra != 'extra-6-server-cpu' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm'",
-]
-dependencies = [
-    { name = "cuda-bindings", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "filelock", marker = "extra == 'extra-6-server-gpu' or extra == 'extra-6-server-vllm'" },
-    { name = "fsspec", version = "2026.2.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'win32' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-gpu' and extra != 'extra-6-server-vllm')" },
-    { name = "fsspec", version = "2026.4.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform == 'win32' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
-    { name = "jinja2", marker = "extra == 'extra-6-server-gpu' or extra == 'extra-6-server-vllm'" },
-    { name = "networkx", marker = "extra == 'extra-6-server-gpu' or extra == 'extra-6-server-vllm'" },
-    { name = "nvidia-cublas-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "nvidia-cuda-cupti-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "nvidia-cuda-nvrtc-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "nvidia-cuda-runtime-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "nvidia-cudnn-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "nvidia-cufft-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "nvidia-cufile-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "nvidia-curand-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "nvidia-cusolver-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "nvidia-cusparse-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "nvidia-cusparselt-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "nvidia-nccl-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "nvidia-nvjitlink-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "nvidia-nvshmem-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "nvidia-nvtx-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "setuptools", marker = "extra == 'extra-6-server-gpu' or extra == 'extra-6-server-vllm'" },
-    { name = "sympy", marker = "extra == 'extra-6-server-gpu' or extra == 'extra-6-server-vllm'" },
-    { name = "triton", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "typing-extensions", marker = "extra == 'extra-6-server-gpu' or extra == 'extra-6-server-vllm'" },
-]
-wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:6f09cdf2415516be028ae82e6b985bcfc3eac37bc52ab401142689f6224516ca", upload-time = "2026-01-21T15:22:03Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:628e89bd5110ced7debee2a57c69959725b7fbc64eab81a39dd70e46c7e28ba5", upload-time = "2026-01-21T15:22:11Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp312-cp312-win_amd64.whl", hash = "sha256:fbde8f6a9ec8c76979a0d14df21c10b9e5cab6f0d106a73ca73e2179bc597cae", upload-time = "2026-01-21T15:22:17Z" },
-]
-
-[[package]]
-name = "torch"
 version = "2.11.0"
 source = { registry = "https://download.pytorch.org/whl/cpu" }
 resolution-markers = [
@@ -2822,7 +2827,7 @@ resolution-markers = [
 ]
 dependencies = [
     { name = "filelock", marker = "(sys_platform == 'darwin' and extra == 'extra-6-server-cpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "fsspec", version = "2026.2.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform == 'darwin' and extra == 'extra-6-server-cpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+    { name = "fsspec", marker = "(sys_platform == 'darwin' and extra == 'extra-6-server-cpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
     { name = "jinja2", marker = "(sys_platform == 'darwin' and extra == 'extra-6-server-cpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
     { name = "networkx", marker = "(sys_platform == 'darwin' and extra == 'extra-6-server-cpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
     { name = "setuptools", marker = "(sys_platform == 'darwin' and extra == 'extra-6-server-cpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
@@ -2831,6 +2836,31 @@ dependencies = [
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:43b35116802c85fb88d99f4a396b8bd4472bfca1dd82e69499e5a4f9b8b4e252", upload-time = "2026-03-23T15:16:58Z" },
+]
+
+[[package]]
+name = "torch"
+version = "2.11.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "sys_platform == 'darwin'",
+    "sys_platform == 'win32'",
+    "sys_platform == 'emscripten'",
+]
+dependencies = [
+    { name = "filelock", marker = "(sys_platform == 'emscripten' and extra == 'extra-6-server-gpu') or (sys_platform == 'win32' and extra == 'extra-6-server-gpu') or (sys_platform == 'darwin' and extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+    { name = "fsspec", marker = "(sys_platform == 'emscripten' and extra == 'extra-6-server-gpu') or (sys_platform == 'win32' and extra == 'extra-6-server-gpu') or (sys_platform == 'darwin' and extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+    { name = "jinja2", marker = "(sys_platform == 'emscripten' and extra == 'extra-6-server-gpu') or (sys_platform == 'win32' and extra == 'extra-6-server-gpu') or (sys_platform == 'darwin' and extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+    { name = "networkx", marker = "(sys_platform == 'emscripten' and extra == 'extra-6-server-gpu') or (sys_platform == 'win32' and extra == 'extra-6-server-gpu') or (sys_platform == 'darwin' and extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+    { name = "setuptools", marker = "(sys_platform == 'emscripten' and extra == 'extra-6-server-gpu') or (sys_platform == 'win32' and extra == 'extra-6-server-gpu') or (sys_platform == 'darwin' and extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+    { name = "sympy", marker = "(sys_platform == 'emscripten' and extra == 'extra-6-server-gpu') or (sys_platform == 'win32' and extra == 'extra-6-server-gpu') or (sys_platform == 'darwin' and extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+    { name = "typing-extensions", marker = "(sys_platform == 'emscripten' and extra == 'extra-6-server-gpu') or (sys_platform == 'win32' and extra == 'extra-6-server-gpu') or (sys_platform == 'darwin' and extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/8b/69e3008d78e5cee2b30183340cc425081b78afc5eff3d080daab0adda9aa/torch-2.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4b5866312ee6e52ea625cd211dcb97d6a2cdc1131a5f15cc0d87eec948f6dd34", size = 80606338, upload-time = "2026-03-23T18:11:34.781Z" },
+    { url = "https://files.pythonhosted.org/packages/13/16/42e5915ebe4868caa6bac83a8ed59db57f12e9a61b7d749d584776ed53d5/torch-2.11.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:f99924682ef0aa6a4ab3b1b76f40dc6e273fca09f367d15a524266db100a723f", size = 419731115, upload-time = "2026-03-23T18:11:06.944Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/c9/82638ef24d7877510f83baf821f5619a61b45568ce21c0a87a91576510aa/torch-2.11.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:0f68f4ac6d95d12e896c3b7a912b5871619542ec54d3649cf48cc1edd4dd2756", size = 530712279, upload-time = "2026-03-23T18:10:31.481Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/ff/6756f1c7ee302f6d202120e0f4f05b432b839908f9071157302cedfc5232/torch-2.11.0-cp312-cp312-win_amd64.whl", hash = "sha256:fbf39280699d1b869f55eac536deceaa1b60bd6788ba74f399cc67e60a5fab10", size = 114556047, upload-time = "2026-03-23T18:10:55.931Z" },
 ]
 
 [[package]]
@@ -2844,7 +2874,7 @@ resolution-markers = [
 ]
 dependencies = [
     { name = "filelock", marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-cpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "fsspec", version = "2026.2.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-cpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+    { name = "fsspec", marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-cpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
     { name = "jinja2", marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-cpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
     { name = "networkx", marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-cpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
     { name = "setuptools", marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-cpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
@@ -2859,11 +2889,41 @@ wheels = [
 ]
 
 [[package]]
+name = "torch"
+version = "2.11.0+cu129"
+source = { registry = "https://download.pytorch.org/whl/cu129" }
+resolution-markers = [
+    "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-6-server-cpu' and extra == 'extra-6-server-gpu' and extra == 'extra-6-server-vllm'",
+    "sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-6-server-cpu' and extra == 'extra-6-server-gpu' and extra != 'extra-6-server-vllm'",
+    "sys_platform != 'darwin' and extra != 'extra-6-server-cpu' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm'",
+]
+dependencies = [
+    { name = "cuda-bindings", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+    { name = "cuda-toolkit", extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+    { name = "filelock", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-gpu') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-vllm') or (sys_platform == 'darwin' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'darwin' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'darwin' and extra == 'extra-6-server-gpu' and extra != 'extra-6-server-vllm') or (sys_platform == 'emscripten' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'win32' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
+    { name = "fsspec", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-gpu') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-vllm') or (sys_platform == 'darwin' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'darwin' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'darwin' and extra == 'extra-6-server-gpu' and extra != 'extra-6-server-vllm') or (sys_platform == 'emscripten' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'win32' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
+    { name = "jinja2", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-gpu') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-vllm') or (sys_platform == 'darwin' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'darwin' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'darwin' and extra == 'extra-6-server-gpu' and extra != 'extra-6-server-vllm') or (sys_platform == 'emscripten' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'win32' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
+    { name = "networkx", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-gpu') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-vllm') or (sys_platform == 'darwin' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'darwin' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'darwin' and extra == 'extra-6-server-gpu' and extra != 'extra-6-server-vllm') or (sys_platform == 'emscripten' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'win32' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
+    { name = "nvidia-cudnn-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+    { name = "nvidia-cusparselt-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+    { name = "nvidia-nccl-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+    { name = "nvidia-nvshmem-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+    { name = "setuptools", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-gpu') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-vllm') or (sys_platform == 'darwin' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'darwin' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'darwin' and extra == 'extra-6-server-gpu' and extra != 'extra-6-server-vllm') or (sys_platform == 'emscripten' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'win32' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
+    { name = "sympy", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-gpu') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-vllm') or (sys_platform == 'darwin' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'darwin' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'darwin' and extra == 'extra-6-server-gpu' and extra != 'extra-6-server-vllm') or (sys_platform == 'emscripten' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'win32' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
+    { name = "triton", marker = "(sys_platform == 'linux' and extra == 'extra-6-server-gpu') or (sys_platform == 'linux' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+    { name = "typing-extensions", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-gpu') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-vllm') or (sys_platform == 'darwin' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'darwin' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'darwin' and extra == 'extra-6-server-gpu' and extra != 'extra-6-server-vllm') or (sys_platform == 'emscripten' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'win32' and extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm')" },
+]
+wheels = [
+    { url = "https://download-r2.pytorch.org/whl/cu129/torch-2.11.0%2Bcu129-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:2d053729aa4ca5daa466dc1418fd3770f221017cb94d0d5c0c60c15b2eeedffd", upload-time = "2026-04-27T18:41:08Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu129/torch-2.11.0%2Bcu129-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:68b83cb7d7d43bc67c2833c8aebaea6a966f2017c3389885affa3361c258b7e3", upload-time = "2026-04-27T18:42:10Z" },
+]
+
+[[package]]
 name = "torch-c-dlpack-ext"
 version = "0.1.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "torch", version = "2.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" } },
+    { name = "torch", version = "2.11.0+cu129", source = { registry = "https://download.pytorch.org/whl/cu129" }, marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/37/de/921b6491efce5c389a5ef9bbed3d2d6660005840dae488124173180859ab/torch_c_dlpack_ext-0.1.5.tar.gz", hash = "sha256:d06f0357d575d22a168cc77acb9020fc4bae30968ceb6718a055dcbe92bacabe", size = 12913, upload-time = "2026-01-12T11:25:08.484Z" }
 wheels = [
@@ -2875,32 +2935,29 @@ wheels = [
 
 [[package]]
 name = "torchaudio"
-version = "2.10.0"
+version = "2.11.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "torch", version = "2.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" } },
-]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0f/36/28a6f3e857616cf7576bdbf8170e483b8c5d0a1f8d349ecb2b75921236aa/torchaudio-2.10.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:9d0fbdbfd2f621c51d28571050d6d0c7287791034e5c7303b31480af1258f33f", size = 737144, upload-time = "2026-01-21T16:28:44.189Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/3f/df620439a76ece170472d41438d11a1545d5db5dc9f1eaeab8c6e055a328/torchaudio-2.10.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:42b148a0921a3721abd1f6ae098b1ec9f89703e555c4f7a0d44da87b8decbcb9", size = 391973, upload-time = "2026-01-21T16:28:39.732Z" },
-    { url = "https://files.pythonhosted.org/packages/98/25/e55a30d7138f8fe56ed006df25b0a3c27681f0ec7bc9989e1778e6d559c3/torchaudio-2.10.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:0e77b2956448d63790a99beed0b74ac8b8cd3a94dcdd9ad01974411078f46278", size = 1895234, upload-time = "2026-01-21T16:28:37.034Z" },
-    { url = "https://files.pythonhosted.org/packages/be/a0/da53c7d20fac15f66f8838653b91162de1bf21fb40fee88cf839e4ef5174/torchaudio-2.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:7f76a01ecebf1869e1f2c50a261f1cf07e5fccb24402b4e9bbb82d6725b9c7dd", size = 475470, upload-time = "2026-01-21T16:28:40.615Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b1/77658817acacd01a72b714440c62f419efc4d90170e704e8e7a2c0918988/torchaudio-2.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a1cf1acc883bee9cb906a933572fed6a8a933f86ef34e9ea7d803f72317e8c1b", size = 684226, upload-time = "2026-03-23T18:13:40.023Z" },
+    { url = "https://files.pythonhosted.org/packages/78/28/c7adc053039f286c2aca0038b766cbe3294e66fec6b29a820e95128f9ede/torchaudio-2.11.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:bc653defca1c16154398517a1adc98d0fb7f1dd08e58ced217558d213c2c6e29", size = 1626670, upload-time = "2026-03-23T18:13:42.162Z" },
+    { url = "https://files.pythonhosted.org/packages/88/d8/d6d0f896e064aa67377484efef4911cdcc07bce2929474e1417cc0af18c2/torchaudio-2.11.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:6503c0bdb29daf2e6281bb70ea2dfe2c3553b782b619eb5d73bdadd8a3f7cecf", size = 1771992, upload-time = "2026-03-23T18:13:33.188Z" },
+    { url = "https://files.pythonhosted.org/packages/23/a8/941277ecc39f7a0a169d554302a1f1afd87c1d94a8aec828891916cea59a/torchaudio-2.11.0-cp312-cp312-win_amd64.whl", hash = "sha256:478110f981e5d40a8d82221732c57a56c85a1d5895fb8fe646e86ee15eded3bd", size = 328663, upload-time = "2026-03-23T18:13:19.218Z" },
 ]
 
 [[package]]
 name = "torchvision"
-version = "0.25.0"
+version = "0.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
-    { name = "pillow" },
-    { name = "torch", version = "2.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" } },
+    { name = "numpy", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "pillow", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "torch", version = "2.11.0+cu129", source = { registry = "https://download.pytorch.org/whl/cu129" }, marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/3a/6ea0d73f49a9bef38a1b3a92e8dd455cea58470985d25635beab93841748/torchvision-0.25.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c2abe430c90b1d5e552680037d68da4eb80a5852ebb1c811b2b89d299b10573b", size = 1874920, upload-time = "2026-01-21T16:27:45.348Z" },
-    { url = "https://files.pythonhosted.org/packages/51/f8/c0e1ef27c66e15406fece94930e7d6feee4cb6374bbc02d945a630d6426e/torchvision-0.25.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:b75deafa2dfea3e2c2a525559b04783515e3463f6e830cb71de0fb7ea36fe233", size = 2344556, upload-time = "2026-01-21T16:27:40.125Z" },
-    { url = "https://files.pythonhosted.org/packages/68/2f/f24b039169db474e8688f649377de082a965fbf85daf4e46c44412f1d15a/torchvision-0.25.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:f25aa9e380865b11ea6e9d99d84df86b9cc959f1a007cd966fc6f1ab2ed0e248", size = 8072351, upload-time = "2026-01-21T16:27:21.074Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/16/8f650c2e288977cf0f8f85184b90ee56ed170a4919347fc74ee99286ed6f/torchvision-0.25.0-cp312-cp312-win_amd64.whl", hash = "sha256:f9c55ae8d673ab493325d1267cbd285bb94d56f99626c00ac4644de32a59ede3", size = 4303059, upload-time = "2026-01-21T16:27:11.08Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/e7/56b47cc3b132aea90ccce22bcb8975dec688b002150012acc842846039d0/torchvision-0.26.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c409e1c3fdebec7a3834465086dbda8bf7680eff79abf7fd2f10c6b59520a7a4", size = 1863502, upload-time = "2026-03-23T18:12:57.326Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ec/5c31c92c08b65662fe9604a4067ae8232582805949f11ddc042cebe818ed/torchvision-0.26.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:406557718e62fdf10f5706e88d8a5ec000f872da913bf629aab9297622585547", size = 7767944, upload-time = "2026-03-23T18:12:42.805Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/d8/cb6ccda1a1f35a6597645818641701207b3e8e13553e75fce5d86bac74b2/torchvision-0.26.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:d61a5abb6b42a0c0c311996c2ac4b83a94418a97182c83b055a2a4ae985e05aa", size = 7522205, upload-time = "2026-03-23T18:12:54.654Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/a9/c272623a0f735c35f0f6cd6dc74784d4f970e800cf063bb76687895a2ab9/torchvision-0.26.0-cp312-cp312-win_amd64.whl", hash = "sha256:7993c01648e7c61d191b018e84d38fe0825c8fcb2720cd0f37caf7ba14404aa1", size = 4255155, upload-time = "2026-03-23T18:12:32.652Z" },
 ]
 
 [[package]]
@@ -2920,15 +2977,15 @@ name = "transformers"
 version = "5.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "huggingface-hub" },
-    { name = "numpy" },
-    { name = "packaging" },
-    { name = "pyyaml" },
-    { name = "regex" },
-    { name = "safetensors" },
-    { name = "tokenizers" },
-    { name = "tqdm" },
-    { name = "typer" },
+    { name = "huggingface-hub", marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-vllm') or extra == 'extra-6-server-cpu' or extra == 'extra-6-server-gpu'" },
+    { name = "numpy", marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-vllm') or extra == 'extra-6-server-cpu' or extra == 'extra-6-server-gpu'" },
+    { name = "packaging", marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-vllm') or extra == 'extra-6-server-cpu' or extra == 'extra-6-server-gpu'" },
+    { name = "pyyaml", marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-vllm') or extra == 'extra-6-server-cpu' or extra == 'extra-6-server-gpu'" },
+    { name = "regex", marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-vllm') or extra == 'extra-6-server-cpu' or extra == 'extra-6-server-gpu'" },
+    { name = "safetensors", marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-vllm') or extra == 'extra-6-server-cpu' or extra == 'extra-6-server-gpu'" },
+    { name = "tokenizers", marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-vllm') or extra == 'extra-6-server-cpu' or extra == 'extra-6-server-gpu'" },
+    { name = "tqdm", marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-vllm') or extra == 'extra-6-server-cpu' or extra == 'extra-6-server-gpu'" },
+    { name = "typer", marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-vllm') or extra == 'extra-6-server-cpu' or extra == 'extra-6-server-gpu'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4d/fe/7e84d20ac7d4d5d14bac2eab5976088d86342959fc2c0da54b4c2fc99856/transformers-5.7.0.tar.gz", hash = "sha256:a9d35cf39804e3456c1f9bc1a79ad5ffa878640a61f51f66f71c97f4b4e2ce10", size = 8401287, upload-time = "2026-04-28T18:30:09.75Z" }
 wheels = [
@@ -2949,10 +3006,10 @@ name = "typer"
 version = "0.25.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "annotated-doc" },
-    { name = "click" },
-    { name = "rich" },
-    { name = "shellingham" },
+    { name = "annotated-doc", marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-vllm') or extra == 'extra-6-server-cpu' or extra == 'extra-6-server-gpu'" },
+    { name = "click", marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-vllm') or extra == 'extra-6-server-cpu' or extra == 'extra-6-server-gpu'" },
+    { name = "rich", marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-vllm') or extra == 'extra-6-server-cpu' or extra == 'extra-6-server-gpu'" },
+    { name = "shellingham", marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-vllm') or extra == 'extra-6-server-cpu' or extra == 'extra-6-server-gpu'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7b/27/ede8cec7596e0041ba7e7b80b47d132562f56ff454313a16f6084e555c9f/typer-0.25.0.tar.gz", hash = "sha256:123eaf9f19bb40fd268310e12a542c0c6b4fab9c98d9d23342a01ff95e3ce930", size = 120150, upload-time = "2026-04-26T08:46:14.767Z" }
 wheels = [
@@ -3013,13 +3070,13 @@ wheels = [
 
 [package.optional-dependencies]
 standard = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "httptools" },
-    { name = "python-dotenv" },
-    { name = "pyyaml" },
-    { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'" },
-    { name = "watchfiles" },
-    { name = "websockets" },
+    { name = "colorama", marker = "sys_platform == 'win32' and extra != 'extra-6-server-gpu'" },
+    { name = "httptools", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "python-dotenv", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "pyyaml", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "uvloop", marker = "(platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (platform_python_implementation != 'PyPy' and sys_platform == 'emscripten' and extra != 'extra-6-server-gpu')" },
+    { name = "watchfiles", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "websockets", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
 ]
 
 [[package]]
@@ -3038,79 +3095,81 @@ wheels = [
 
 [[package]]
 name = "vllm"
-version = "0.19.1"
-source = { registry = "https://pypi.org/simple" }
+version = "0.20.0+cu129"
+source = { registry = "https://wheels.vllm.ai/0.20.0/cu129" }
 dependencies = [
-    { name = "aiohttp" },
-    { name = "anthropic" },
-    { name = "blake3" },
-    { name = "cachetools" },
-    { name = "cbor2" },
-    { name = "cloudpickle" },
-    { name = "compressed-tensors" },
-    { name = "depyf" },
-    { name = "diskcache" },
-    { name = "einops" },
-    { name = "fastapi", extra = ["standard"], marker = "(extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra != 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "filelock" },
-    { name = "flashinfer-cubin" },
-    { name = "flashinfer-python" },
-    { name = "gguf" },
-    { name = "ijson" },
-    { name = "lark" },
-    { name = "llguidance", marker = "platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 'ppc64le' or platform_machine == 's390x' or platform_machine == 'x86_64'" },
-    { name = "lm-format-enforcer" },
-    { name = "mcp" },
-    { name = "mistral-common", extra = ["image"], marker = "(extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra != 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
-    { name = "model-hosting-container-standards" },
-    { name = "msgspec" },
-    { name = "ninja" },
-    { name = "numba" },
-    { name = "numpy" },
-    { name = "nvidia-cudnn-frontend" },
-    { name = "nvidia-cutlass-dsl" },
-    { name = "openai" },
-    { name = "openai-harmony" },
-    { name = "opencv-python-headless" },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-exporter-otlp" },
-    { name = "opentelemetry-sdk" },
-    { name = "opentelemetry-semantic-conventions-ai" },
-    { name = "outlines-core" },
-    { name = "partial-json-parser" },
-    { name = "pillow" },
-    { name = "prometheus-client" },
-    { name = "prometheus-fastapi-instrumentator" },
-    { name = "protobuf" },
-    { name = "psutil" },
-    { name = "py-cpuinfo" },
-    { name = "pybase64" },
-    { name = "pydantic" },
-    { name = "python-json-logger" },
-    { name = "pyyaml" },
-    { name = "pyzmq" },
-    { name = "quack-kernels" },
-    { name = "regex" },
-    { name = "requests" },
-    { name = "sentencepiece" },
-    { name = "setproctitle" },
-    { name = "setuptools" },
-    { name = "six" },
-    { name = "tiktoken" },
-    { name = "tokenizers" },
-    { name = "torch", version = "2.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" } },
-    { name = "torchaudio" },
-    { name = "torchvision" },
-    { name = "tqdm" },
-    { name = "transformers" },
-    { name = "typing-extensions" },
-    { name = "watchfiles" },
-    { name = "xgrammar", marker = "platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 'ppc64le' or platform_machine == 's390x' or platform_machine == 'x86_64'" },
+    { name = "aiohttp", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "anthropic", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "apache-tvm-ffi", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "blake3", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "cachetools", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "cbor2", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "cloudpickle", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "compressed-tensors", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "depyf", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "diskcache", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "einops", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "fastapi", extra = ["standard"], marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-vllm') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+    { name = "fastsafetensors", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "filelock", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "flashinfer-cubin", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "flashinfer-python", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "gguf", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "ijson", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "lark", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "llguidance", marker = "(platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (platform_machine == 'arm64' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (platform_machine == 'ppc64le' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (platform_machine == 'x86_64' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (platform_machine == 'aarch64' and sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (platform_machine == 'arm64' and sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (platform_machine == 'ppc64le' and sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (platform_machine == 'x86_64' and sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (platform_machine == 'aarch64' and sys_platform == 'win32' and extra != 'extra-6-server-gpu') or (platform_machine == 'arm64' and sys_platform == 'win32' and extra != 'extra-6-server-gpu') or (platform_machine == 'ppc64le' and sys_platform == 'win32' and extra != 'extra-6-server-gpu') or (platform_machine == 'x86_64' and sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "lm-format-enforcer", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "mcp", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "mistral-common", extra = ["image"], marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-6-server-vllm') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu' and extra == 'extra-6-server-vllm') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-gpu') or (extra == 'extra-6-server-cpu' and extra == 'extra-6-server-vllm')" },
+    { name = "model-hosting-container-standards", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "msgspec", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "ninja", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "numba", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "numpy", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "nvidia-cudnn-frontend", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "nvidia-cutlass-dsl", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "openai", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "openai-harmony", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "opencv-python-headless", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "opentelemetry-api", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "opentelemetry-exporter-otlp", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "opentelemetry-sdk", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "opentelemetry-semantic-conventions-ai", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "outlines-core", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "partial-json-parser", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "pillow", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "prometheus-client", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "prometheus-fastapi-instrumentator", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "protobuf", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "psutil", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "py-cpuinfo", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "pybase64", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "pydantic", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "python-json-logger", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "pyyaml", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "pyzmq", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "quack-kernels", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "regex", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "requests", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "sentencepiece", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "setproctitle", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "setuptools", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "six", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "tiktoken", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "tilelang", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "tokenizers", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "torch", version = "2.11.0+cu129", source = { registry = "https://download.pytorch.org/whl/cu129" }, marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "torchaudio", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "torchvision", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "tqdm", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "transformers", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "typing-extensions", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "watchfiles", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "xgrammar", marker = "(platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (platform_machine == 'arm64' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (platform_machine == 'ppc64le' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (platform_machine == 's390x' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (platform_machine == 'x86_64' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (platform_machine == 'aarch64' and sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (platform_machine == 'arm64' and sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (platform_machine == 'ppc64le' and sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (platform_machine == 's390x' and sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (platform_machine == 'x86_64' and sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (platform_machine == 'aarch64' and sys_platform == 'win32' and extra != 'extra-6-server-gpu') or (platform_machine == 'arm64' and sys_platform == 'win32' and extra != 'extra-6-server-gpu') or (platform_machine == 'ppc64le' and sys_platform == 'win32' and extra != 'extra-6-server-gpu') or (platform_machine == 's390x' and sys_platform == 'win32' and extra != 'extra-6-server-gpu') or (platform_machine == 'x86_64' and sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a8/49/60a2a962ecbf780c8fbfd0d5548b208d654d5c4267df94d8d93883641431/vllm-0.19.1.tar.gz", hash = "sha256:9fb88ce6b50991eba41d183584f65f51d7f6015d86a42cdabf79c1c8bd5d66fa", size = 31105401, upload-time = "2026-04-18T05:50:15.143Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/28/4c/26c426103c58ac8d98435fe63c7758a2f289b5481a08be19e9c9fe29a4c2/vllm-0.19.1-cp38-abi3-manylinux_2_31_aarch64.whl", hash = "sha256:c8dde3c9af20f00a644e64a50ebe43948f2921bab3ffd5407d634c15836cb181", size = 385252556, upload-time = "2026-04-18T05:49:16.101Z" },
-    { url = "https://files.pythonhosted.org/packages/78/20/f41216b79c87372a9d03175f36fa1411ee61059ce8c557d2691722ea4aae/vllm-0.19.1-cp38-abi3-manylinux_2_31_x86_64.whl", hash = "sha256:71a87f46cafab4489c69a5c5c83b870d0235e5694d8222303d460576293dc719", size = 433132101, upload-time = "2026-04-18T05:49:54.202Z" },
+    { url = "https://wheels.vllm.ai/88d34c6409e9fb3c7b8ca0c04756f061d2099eb1/vllm-0.20.0%2Bcu129-cp38-abi3-manylinux_2_31_aarch64.whl" },
+    { url = "https://wheels.vllm.ai/88d34c6409e9fb3c7b8ca0c04756f061d2099eb1/vllm-0.20.0%2Bcu129-cp38-abi3-manylinux_2_31_x86_64.whl" },
 ]
 
 [[package]]
@@ -3118,7 +3177,7 @@ name = "watchfiles"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
+    { name = "anyio", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c2/c9/8869df9b2a2d6c59d79220a4db37679e74f807c559ffe5265e08b227a210/watchfiles-1.1.1.tar.gz", hash = "sha256:a173cb5c16c4f40ab19cecf48a534c409f7ea983ab8fed0741304a1c0a31b3f2", size = 94440, upload-time = "2025-10-14T15:06:21.08Z" }
 wheels = [
@@ -3189,13 +3248,13 @@ name = "xgrammar"
 version = "0.1.34"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "apache-tvm-ffi" },
-    { name = "numpy" },
-    { name = "pydantic" },
-    { name = "torch", version = "2.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" } },
-    { name = "transformers" },
+    { name = "apache-tvm-ffi", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "numpy", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "pydantic", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "torch", version = "2.11.0+cu129", source = { registry = "https://download.pytorch.org/whl/cu129" }, marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
+    { name = "transformers", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
     { name = "triton", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "(sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra != 'extra-6-server-gpu') or (sys_platform == 'win32' and extra != 'extra-6-server-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b5/16/4abfb0985ffdf050894cbdce583056cf1b367683c63150e1f9384c3c7619/xgrammar-0.1.34.tar.gz", hash = "sha256:ac72a4c3fdb56654bf904fce11cd7135d7cdba696e5d03039f90e1655b97ede4", size = 2411387, upload-time = "2026-04-29T04:11:24.852Z" }
 wheels = [
@@ -3238,9 +3297,9 @@ name = "yarl"
 version = "1.23.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "idna" },
-    { name = "multidict" },
-    { name = "propcache" },
+    { name = "idna", marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-vllm') or extra == 'extra-6-server-cpu' or extra == 'extra-6-server-gpu'" },
+    { name = "multidict", marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-vllm') or extra == 'extra-6-server-cpu' or extra == 'extra-6-server-gpu'" },
+    { name = "propcache", marker = "(sys_platform != 'darwin' and extra == 'extra-6-server-vllm') or extra == 'extra-6-server-cpu' or extra == 'extra-6-server-gpu'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/23/6e/beb1beec874a72f23815c1434518bfc4ed2175065173fb138c3705f658d4/yarl-1.23.0.tar.gz", hash = "sha256:53b1ea6ca88ebd4420379c330aea57e258408dd0df9af0992e5de2078dc9f5d5", size = 194676, upload-time = "2026-03-01T22:07:53.373Z" }
 wheels = [
@@ -3263,6 +3322,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f5/be/25216a49daeeb7af2bec0db22d5e7df08ed1d7c9f65d78b14f3b74fd72fc/yarl-1.23.0-cp312-cp312-win_amd64.whl", hash = "sha256:f69f57305656a4852f2a7203efc661d8c042e6cc67f7acd97d8667fb448a426e", size = 87674, upload-time = "2026-03-01T22:05:38.171Z" },
     { url = "https://files.pythonhosted.org/packages/d2/35/aeab955d6c425b227d5b7247eafb24f2653fedc32f95373a001af5dfeb9e/yarl-1.23.0-cp312-cp312-win_arm64.whl", hash = "sha256:6e87a6e8735b44816e7db0b2fbc9686932df473c826b0d9743148432e10bb9b9", size = 81879, upload-time = "2026-03-01T22:05:40.006Z" },
     { url = "https://files.pythonhosted.org/packages/69/68/c8739671f5699c7dc470580a4f821ef37c32c4cb0b047ce223a7f115757f/yarl-1.23.0-py3-none-any.whl", hash = "sha256:a2df6afe50dea8ae15fa34c9f824a3ee958d785fd5d089063d960bae1daa0a3f", size = 48288, upload-time = "2026-03-01T22:07:51.388Z" },
+]
+
+[[package]]
+name = "z3-solver"
+version = "4.15.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8a/8e/0c8f17309549d2e5cde9a3ccefa6365437f1e7bafe71878eaf9478e47b18/z3_solver-4.15.4.0.tar.gz", hash = "sha256:928c29b58c4eb62106da51c1914f6a4a55d0441f8f48a81b9da07950434a8946", size = 5018600, upload-time = "2025-10-29T18:12:03.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/33/a3d5d2eaeb0f7b3174d57d405437eabb2075d4d50bd9ea0957696c435c7b/z3_solver-4.15.4.0-py3-none-macosx_13_0_arm64.whl", hash = "sha256:407e825cc9211f95ef46bdc8d151bf630e7ab2d62a21d24cd74c09cc5b73f3aa", size = 37052538, upload-time = "2025-10-29T18:11:46.233Z" },
+    { url = "https://files.pythonhosted.org/packages/47/84/fd7ffac1551cd9f8d44fe41358f738be670fc4c24dfd514fab503f2cf3e7/z3_solver-4.15.4.0-py3-none-macosx_13_0_x86_64.whl", hash = "sha256:00bd10c5a6a5f6112d3a9a810d0799227e52f76caa860dafa5e00966bb47eb13", size = 39807925, upload-time = "2025-10-29T18:11:49.81Z" },
+    { url = "https://files.pythonhosted.org/packages/21/c9/bb51a96af0091324c81b803f16c49f719f9f6ea0b0bb52200f5c97ec4892/z3_solver-4.15.4.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e103a6f203f505b8b8b8e5c931cc407c95b61556512d4921c1ddc0b3f41b08e", size = 29268352, upload-time = "2025-10-29T18:11:53.032Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/2e/0b49f7e4e53817cfb09a0f6585012b782dfe0b666e8abefcb4fac0570606/z3_solver-4.15.4.0-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:62c7e9cbdd711932301f29919ad9158de9b2f58b4d281dd259bbcd0a2f408ba1", size = 27226534, upload-time = "2025-10-29T18:11:55.59Z" },
+    { url = "https://files.pythonhosted.org/packages/26/91/33de49538444d4aafbe47415c450c2f9abab1733e1226f276b496672f46c/z3_solver-4.15.4.0-py3-none-win32.whl", hash = "sha256:be3bc916545c96ffbf89e00d07104ff14f78336e55db069177a1bfbcc01b269d", size = 13191672, upload-time = "2025-10-29T18:11:58.424Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d6/a0b135e4419df475177ae78fc93c422430b0fd8875649486f9a5989772e6/z3_solver-4.15.4.0-py3-none-win_amd64.whl", hash = "sha256:00e35b02632ed085ea8199fb230f6015e6fc40554a6680c097bd5f060e827431", size = 16259597, upload-time = "2025-10-29T18:12:01.14Z" },
 ]
 
 [[package]]

--- a/src/server/vllm_sampler.py
+++ b/src/server/vllm_sampler.py
@@ -132,7 +132,7 @@ async def generate(req: Request):
       n=num_samples,
       temperature=temperature,
       max_tokens=max_tokens,
-      stop=stop,
+      stop_token_ids=stop,
       top_p=top_p,
       top_k=top_k,
       logprobs=1,  # return logprobs for TITO RL

--- a/tests/tinker_client_compat.py
+++ b/tests/tinker_client_compat.py
@@ -201,7 +201,6 @@ def probe_server(methods: list[str]) -> dict[str, str]:
       compat_model_path(),
       sampling_backend="torch",
       startup_timeout=STARTUP_TIMEOUT,
-      extra_env={"OPEN_RL_TARGET_MODULES": "all-linear"},
     ) as base_url,
   ):
     service, state_path, clients = make_clients(base_url)


### PR DESCRIPTION
The latest release of VLLM fixes a bunch of issues with gemma4 models. Though we still need to apply a patch for LoRA online serving to work