### PR TITLE
fix: optimizer adapter isolation

### DIFF
--- a/src/server/trainer.py
+++ b/src/server/trainer.py
@@ -34,6 +34,14 @@ class Datum(BaseModel):
   model_input: list[int]
 
 
+def active_adapter_parameters(model: Any, adapter_id: str) -> list[torch.nn.Parameter]:
+  model.set_adapter(adapter_id)
+  params = [param for param in model.parameters() if param.requires_grad]
+  if not params:
+    raise ValueError(f"No trainable parameters found for adapter '{adapter_id}'")
+  return params
+
+
 class TrainerEngine:
   def __init__(self):
     # The raw pre-trained base model (e.g., Gemma, Qwen) loaded in VRAM
@@ -48,8 +56,9 @@ class TrainerEngine:
     # String identifier of the currently loaded base model
     self.base_model_name: str | None = None
 
-    # Store optimizers per model_id (adapter ID)
+    # Store per-adapter training state by model_id (adapter ID).
     self.optimizers: dict[str, torch.optim.Optimizer] = {}
+    self.adapter_params: dict[str, list[torch.nn.Parameter]] = {}
     self.lora_target_modules: dict[tuple[bool, bool, bool], list[str]] = {}
 
     # Decide device
@@ -99,12 +108,15 @@ class TrainerEngine:
     self.lora_target_modules[cache_key] = target_modules
     return target_modules
 
+  def clear_adapter_training_state(self, adapter_id: str) -> None:
+    self.optimizers.pop(adapter_id, None)
+    self.adapter_params.pop(adapter_id, None)
+
   def create_adapter(self, adapter_id: str, config: LoraConfig) -> None:
     """Create a new LoRA adapter on top of the loaded base model."""
     assert self.base_model is not None, "Base model is not loaded. Call load_base_model first."
 
-    if adapter_id in self.optimizers:
-      del self.optimizers[adapter_id]
+    self.clear_adapter_training_state(adapter_id)
 
     if not any([config.train_attn, config.train_mlp, config.train_unembed]):
       raise ValueError("At least one LoRA training target must be enabled.")
@@ -129,6 +141,7 @@ class TrainerEngine:
       self.peft_model.add_adapter(adapter_id, peft_config)
 
     self.peft_model.set_adapter(adapter_id)
+    self.adapter_params[adapter_id] = active_adapter_parameters(self.peft_model, adapter_id)
 
     self.peft_model.train()
     print(f"LoRA adapter '{adapter_id}' created and set to active.")
@@ -213,17 +226,18 @@ class TrainerEngine:
     else:
       if model_id in getattr(self.peft_model, "peft_config", {}):
         self.peft_model.delete_adapter(model_id)
-        self.optimizers.pop(model_id, None)
+        self.clear_adapter_training_state(model_id)
       self.peft_model.load_adapter(adapter_dir, adapter_name=model_id, is_trainable=True)
 
     self.peft_model.set_adapter(model_id)
+    params = active_adapter_parameters(self.peft_model, model_id)
+    self.adapter_params[model_id] = params
     self.peft_model.train()
 
     if restore_optimizer and metadata.get("has_optimizer"):
       optimizer_path = os.path.join(state_path, "optimizer.pt")
       if os.path.exists(optimizer_path):
         lr = 1e-4
-        params = [p for p in self.peft_model.parameters() if p.requires_grad]
         optimizer = torch.optim.AdamW(params, lr=lr)
         optimizer.load_state_dict(torch.load(optimizer_path, map_location=self.device))
         self.optimizers[model_id] = optimizer
@@ -235,6 +249,8 @@ class TrainerEngine:
   def forward_backward(self, data: list[Datum], loss_fn: str, loss_config: dict | None = None, model_id: str | None = None) -> dict[str, Any]:
     """Core training step: forward pass, loss computation, and backward pass."""
     assert self.peft_model is not None, "Model must be loaded first."
+    if model_id:
+      self.peft_model.set_adapter(model_id)
 
     total_loss = 0.0
     loss_fn_outputs = []
@@ -391,6 +407,12 @@ class TrainerEngine:
     if not model_id:
       raise ValueError("model_id is required for optim_step")
 
+    self.peft_model.set_adapter(model_id)
+    try:
+      params = self.adapter_params[model_id]
+    except KeyError as e:
+      raise ValueError(f"Adapter '{model_id}' has no cached trainable parameters") from e
+
     if model_id not in self.optimizers:
       lr = adam_params.get("learning_rate", 1e-4)
       beta1 = adam_params.get("beta1", 0.9)
@@ -399,7 +421,6 @@ class TrainerEngine:
       weight_decay = adam_params.get("weight_decay", 0.0)
 
       print(f"Initializing AdamW optimizer for '{model_id}' with lr={lr}")
-      params = [p for p in self.peft_model.parameters() if p.requires_grad]
       self.optimizers[model_id] = torch.optim.AdamW(
         params,
         lr=lr,
@@ -414,15 +435,14 @@ class TrainerEngine:
       for param_group in optimizer.param_groups:
         param_group["lr"] = learning_rate
 
-    total_norm = 0.0
-    for param in self.peft_model.parameters():
-      if param.grad is not None:
-        total_norm += param.grad.data.norm(2).item() ** 2
-    total_norm = total_norm**0.5
+    max_grad_norm = adam_params.get("grad_clip_norm") or math.inf
+    if max_grad_norm <= 0.0:
+      max_grad_norm = math.inf
 
-    clip_norm = adam_params.get("grad_clip_norm", 0.0)
-    if clip_norm and clip_norm > 0.0:
-      torch.nn.utils.clip_grad_norm_(self.peft_model.parameters(), clip_norm)
+    total_norm = torch.nn.utils.clip_grad_norm_(
+      params,
+      max_grad_norm,
+    )
 
     optimizer.step()
     optimizer.zero_grad()
@@ -431,7 +451,7 @@ class TrainerEngine:
 
     return {
       "metrics": {
-        "grad_norm:mean": self._sanitize_float(total_norm),
+        "grad_norm:mean": self._sanitize_float(total_norm.item()),
       },
     }
 

--- a/src/server/trainer.py
+++ b/src/server/trainer.py
@@ -57,8 +57,7 @@ class TrainerEngine:
     self.base_model_name: str | None = None
 
     # Store per-adapter training state by model_id (adapter ID).
-    self.optimizers: dict[str, torch.optim.Optimizer] = {}
-    self.adapter_params: dict[str, list[torch.nn.Parameter]] = {}
+    self.adapter_states: dict[str, dict[str, Any]] = {}
     self.lora_target_modules: dict[tuple[bool, bool, bool], list[str]] = {}
 
     # Decide device
@@ -109,8 +108,7 @@ class TrainerEngine:
     return target_modules
 
   def clear_adapter_training_state(self, adapter_id: str) -> None:
-    self.optimizers.pop(adapter_id, None)
-    self.adapter_params.pop(adapter_id, None)
+    self.adapter_states.pop(adapter_id, None)
 
   def create_adapter(self, adapter_id: str, config: LoraConfig) -> None:
     """Create a new LoRA adapter on top of the loaded base model."""
@@ -141,7 +139,7 @@ class TrainerEngine:
       self.peft_model.add_adapter(adapter_id, peft_config)
 
     self.peft_model.set_adapter(adapter_id)
-    self.adapter_params[adapter_id] = active_adapter_parameters(self.peft_model, adapter_id)
+    self.adapter_states[adapter_id] = {"trainable_params": active_adapter_parameters(self.peft_model, adapter_id), "optimizer": None}
 
     self.peft_model.train()
     print(f"LoRA adapter '{adapter_id}' created and set to active.")
@@ -178,7 +176,8 @@ class TrainerEngine:
     os.makedirs(state_path, exist_ok=True)
     self.peft_model.save_pretrained(state_path, selected_adapters=[model_id])
 
-    optimizer = self.optimizers.get(model_id)
+    adapter_state = self.adapter_states.get(model_id)
+    optimizer = adapter_state.get("optimizer") if adapter_state is not None else None
     if include_optimizer and optimizer is not None:
       torch.save(optimizer.state_dict(), os.path.join(state_path, "optimizer.pt"))
 
@@ -231,7 +230,8 @@ class TrainerEngine:
 
     self.peft_model.set_adapter(model_id)
     params = active_adapter_parameters(self.peft_model, model_id)
-    self.adapter_params[model_id] = params
+    adapter_state = {"trainable_params": params, "optimizer": None}
+    self.adapter_states[model_id] = adapter_state
     self.peft_model.train()
 
     if restore_optimizer and metadata.get("has_optimizer"):
@@ -240,7 +240,7 @@ class TrainerEngine:
         lr = 1e-4
         optimizer = torch.optim.AdamW(params, lr=lr)
         optimizer.load_state_dict(torch.load(optimizer_path, map_location=self.device))
-        self.optimizers[model_id] = optimizer
+        adapter_state["optimizer"] = optimizer
         print(f"Restored optimizer state for '{model_id}' from {optimizer_path}")
 
     print(f"Loaded state for '{model_id}' from {state_path}")
@@ -409,11 +409,12 @@ class TrainerEngine:
 
     self.peft_model.set_adapter(model_id)
     try:
-      params = self.adapter_params[model_id]
+      adapter_state = self.adapter_states[model_id]
     except KeyError as e:
       raise ValueError(f"Adapter '{model_id}' has no cached trainable parameters") from e
+    params = adapter_state["trainable_params"]
 
-    if model_id not in self.optimizers:
+    if adapter_state.get("optimizer") is None:
       lr = adam_params.get("learning_rate", 1e-4)
       beta1 = adam_params.get("beta1", 0.9)
       beta2 = adam_params.get("beta2", 0.95)
@@ -421,7 +422,7 @@ class TrainerEngine:
       weight_decay = adam_params.get("weight_decay", 0.0)
 
       print(f"Initializing AdamW optimizer for '{model_id}' with lr={lr}")
-      self.optimizers[model_id] = torch.optim.AdamW(
+      adapter_state["optimizer"] = torch.optim.AdamW(
         params,
         lr=lr,
         betas=(beta1, beta2),
@@ -429,7 +430,7 @@ class TrainerEngine:
         weight_decay=weight_decay,
       )
 
-    optimizer = self.optimizers[model_id]
+    optimizer = adapter_state["optimizer"]
     learning_rate = adam_params.get("learning_rate")
     if learning_rate is not None:
       for param_group in optimizer.param_groups:

--- a/src/server/trainer.py
+++ b/src/server/trainer.py
@@ -107,14 +107,12 @@ class TrainerEngine:
     self.lora_target_modules[cache_key] = target_modules
     return target_modules
 
-  def clear_adapter_training_state(self, adapter_id: str) -> None:
-    self.adapter_states.pop(adapter_id, None)
-
   def create_adapter(self, adapter_id: str, config: LoraConfig) -> None:
     """Create a new LoRA adapter on top of the loaded base model."""
     assert self.base_model is not None, "Base model is not loaded. Call load_base_model first."
 
-    self.clear_adapter_training_state(adapter_id)
+    if adapter_id in self.adapter_states:
+      del self.adapter_states[adapter_id]
 
     if not any([config.train_attn, config.train_mlp, config.train_unembed]):
       raise ValueError("At least one LoRA training target must be enabled.")
@@ -223,9 +221,10 @@ class TrainerEngine:
     if self.peft_model is None:
       self.peft_model = PeftModelForCausalLM.from_pretrained(self.base_model, adapter_dir, adapter_name=model_id, is_trainable=True)
     else:
-      if model_id in getattr(self.peft_model, "peft_config", {}):
+      if model_id in self.peft_model.peft_config:
         self.peft_model.delete_adapter(model_id)
-        self.clear_adapter_training_state(model_id)
+        if model_id in self.adapter_states:
+          del self.adapter_states[model_id]
       self.peft_model.load_adapter(adapter_dir, adapter_name=model_id, is_trainable=True)
 
     self.peft_model.set_adapter(model_id)

--- a/tests/test_trainer_optimizer_correctness.py
+++ b/tests/test_trainer_optimizer_correctness.py
@@ -70,8 +70,9 @@ class TestTrainerOptimizerCorrectness(unittest.TestCase):
         "adapter-b": [other_param],
       }
     )
-    engine.adapter_params = {"adapter-a": trainer_module.active_adapter_parameters(engine.peft_model, "adapter-a")}
-    engine.optimizers = {}
+    engine.adapter_states = {
+      "adapter-a": {"trainable_params": trainer_module.active_adapter_parameters(engine.peft_model, "adapter-a"), "optimizer": None}
+    }
     engine.save_adapter = lambda *_args, **_kwargs: None
 
     result = engine.optim_step(

--- a/tests/test_trainer_optimizer_correctness.py
+++ b/tests/test_trainer_optimizer_correctness.py
@@ -1,0 +1,98 @@
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import torch
+
+from tests._server_fixture import SERVER_DIR
+
+
+def _load_trainer_module():
+  stubs = {
+    "peft": types.SimpleNamespace(
+      LoraConfig=object,
+      PeftModelForCausalLM=object,
+      get_peft_model=lambda *_args, **_kwargs: None,
+    ),
+    "transformers": types.SimpleNamespace(
+      AutoModelForCausalLM=object,
+      AutoTokenizer=object,
+      PreTrainedModel=object,
+      PreTrainedTokenizerBase=object,
+    ),
+  }
+  spec = importlib.util.spec_from_file_location("trainer_under_test", Path(SERVER_DIR) / "trainer.py")
+  assert spec is not None and spec.loader is not None
+  module = importlib.util.module_from_spec(spec)
+  with patch.dict(sys.modules, stubs):
+    spec.loader.exec_module(module)
+  return module
+
+
+trainer_module = _load_trainer_module()
+TrainerEngine = trainer_module.TrainerEngine
+
+
+class _PeftModelStub:
+  def __init__(self, adapter_params):
+    self.adapter_params = adapter_params
+    self.active_adapter = None
+
+  def set_adapter(self, adapter_id):
+    self.active_adapter = adapter_id
+    for param in self.parameters():
+      param.requires_grad_(False)
+    for param in self.adapter_params[adapter_id]:
+      param.requires_grad_(True)
+
+  def parameters(self):
+    for params in self.adapter_params.values():
+      yield from params
+
+  def save_pretrained(self, *_args, **_kwargs):
+    return None
+
+
+class TestTrainerOptimizerCorrectness(unittest.TestCase):
+  def test_optim_step_only_updates_active_adapter_params(self) -> None:
+    active_param = torch.nn.Parameter(torch.tensor([1.0]))
+    other_param = torch.nn.Parameter(torch.tensor([1.0]))
+    active_param.grad = torch.tensor([1.0])
+    other_param.grad = torch.tensor([10.0])
+
+    engine = TrainerEngine()
+    engine.peft_model = _PeftModelStub(
+      {
+        "adapter-a": [active_param],
+        "adapter-b": [other_param],
+      }
+    )
+    engine.adapter_params = {"adapter-a": trainer_module.active_adapter_parameters(engine.peft_model, "adapter-a")}
+    engine.optimizers = {}
+    engine.save_adapter = lambda *_args, **_kwargs: None
+
+    result = engine.optim_step(
+      {
+        "learning_rate": 0.1,
+        "beta1": 0.0,
+        "beta2": 0.0,
+        "eps": 1e-8,
+        "weight_decay": 0.0,
+      },
+      "adapter-a",
+    )
+
+    self.assertEqual(engine.peft_model.active_adapter, "adapter-a")
+    self.assertAlmostEqual(result["metrics"]["grad_norm:mean"], 1.0)
+    self.assertFalse(torch.allclose(active_param.detach(), torch.tensor([1.0])))
+    self.assertTrue(torch.allclose(other_param.detach(), torch.tensor([1.0])))
+    if active_param.grad is not None:
+      self.assertTrue(torch.allclose(active_param.grad, torch.zeros_like(active_param.grad)))
+    self.assertIsNotNone(other_param.grad)
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
Noticed a bug while I was doing tinker's sl loops and rl loops at the same time. We keep one base model loaded, then add different LoRA adapters to it for different training runs. PEFT lets one model hold multiple adapters, and `set_adapter(...)` just switches which one is active.

  So requests can interleave like:

  ```text
  forward_backward(A)
  forward_backward(B)
  optim_step(A)
  ```
The bug was that optim_step(A) grabbed params with [p for p in self.peft_model.parameters() if p.requires_grad], but requires_grad depends on whichever adapter is currently active. So if B was active, A’s optimizer could accidentally get B’s params. That also meant grad norm / clipping could look at params from the wrong adapter.

The fix is to cache the params for each adapter id when we create or load it. Then during forward_backward(model_id)
and optim_step(model_id), we explicitly switch to that adapter and only use its cached params, so optim_step(A) only updates A.

