### PR TITLE
fix: update accelerator-types list command in README

### DIFF
--- a/k8s/deploy/text-to-sql-gke/README.md
+++ b/k8s/deploy/text-to-sql-gke/README.md
@@ -39,8 +39,7 @@ Optional quota/capacity sanity check:
 
 ```bash
 gcloud compute accelerator-types list \
-  --zones="${ZONE}" \
-  --filter="name=nvidia-l4"
+  --filter="zone:(${ZONE}) AND name:nvidia-l4"
 ```
 
 ## 2. Create the Cluster


### PR DESCRIPTION
The current command errors with `unrecognized arguments`.


```
❯ gcloud compute accelerator-types list \
  --zones="${ZONE}" \
  --filter="name=nvidia-l4"
ERROR: (gcloud.compute.accelerator-types.list) unrecognized arguments: --zones=us-central1-a

To search the help text of gcloud commands, run:
  gcloud help -- SEARCH_TERMS

```