### PR TITLE
Replace watches with waits in README

### DIFF
--- a/k8s/deploy/text-to-sql-gke/README.md
+++ b/k8s/deploy/text-to-sql-gke/README.md
@@ -107,17 +107,13 @@ gcloud container clusters get-credentials "${CLUSTER}" --location="${REGION}"
 kubectl apply -k k8s/deploy/text-to-sql-gke
 ```
 
-Watch the PVC and pods:
+Wait for the shared storage (PVC) to be bound:
 
 ```bash
-kubectl get pvc open-rl-shared-pvc -w
+kubectl wait --for=jsonpath='{.status.phase}'=Bound pvc/open-rl-shared-pvc --timeout=5m
 ```
 
-```bash
-kubectl get pods -l app.kubernetes.io/part-of=text-to-sql -w
-```
-
-Wait for the deployments:
+Wait for the deployments to become ready:
 
 ```bash
 kubectl rollout status deploy/redis-store


### PR DESCRIPTION
- Replaced manual `kubectl get ... -w` commands in step 3 with `kubectl wait` for the PVC to improve usability. The manual watches did not terminate automatically, causing confusion about when the deployment step was complete.
- `kubectl rollout status` commands are retained as they appropriately block until the deployments are ready.
- The pod watch was removed as it was redundant with the rollout status checks.