### PR TITLE
feat: add trainer padded batching

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -66,6 +66,7 @@ make server BASE_MODEL=google/gemma-4-e2b SAMPLING_BACKEND=vllm
 | Env var | Default | What it does |
 | --- | --- | --- |
 | `OPEN_RL_TMP_DIR` | `/tmp/open-rl` | Root directory for adapter snapshots under `peft/` and saved states under `checkpoints/`. |
+| `OPEN_RL_TRAIN_TOKEN_BUDGET` | `0` | Maximum `batch_size * max_sequence_length` for padded trainer chunks inside one `forward_backward` request. `0` keeps the previous one-datum-at-a-time execution path. |
 | `CUDA_VISIBLE_DEVICES` | unset | Standard PyTorch GPU selector. Use different devices when the vLLM worker and trainer run on separate GPUs. |
 
 ## vLLM variables

--- a/src/server/trainer.py
+++ b/src/server/trainer.py
@@ -252,141 +252,170 @@ class TrainerEngine:
       self.peft_model.set_adapter(model_id)
 
     total_loss = 0.0
-    loss_fn_outputs = []
+    loss_fn_outputs: list[dict[str, Any] | None] = [None] * len(data)
 
-    # Ensure model is in train mode
     self.peft_model.train()
 
-    for datum in data:
-      # 1. Common Setup: Extract tokens and get logprobs
-      target_logprobs, targets_tensor, weights_tensor = self._get_logprobs(datum)
+    for batch in self._make_training_batches(data):
+      batch_indices = [idx for idx, _ in batch]
+      batch_data = [datum for _, datum in batch]
 
-      # 2. Specialized Loss Calculation
+      target_logprobs, weights, aux_inputs, lengths = self._get_logprobs_batch(batch_data)
       match loss_fn:
         case "cross_entropy":
-          loss = self._compute_cross_entropy_loss(target_logprobs, weights_tensor)
+          elementwise_loss = self._cross_entropy_loss(target_logprobs, weights)
         case "importance_sampling":
-          loss = self._compute_importance_sampling_loss(target_logprobs, weights_tensor, datum)
+          elementwise_loss = self._importance_sampling_loss(target_logprobs, weights, aux_inputs)
         case "ppo":
-          loss = self._compute_ppo_loss(target_logprobs, weights_tensor, datum, loss_config)
+          elementwise_loss = self._ppo_loss(target_logprobs, weights, aux_inputs, loss_config)
         case _:
           raise NotImplementedError(f"Loss {loss_fn} not supported")
 
-      # 3. Common Cleanup: Backward pass
+      per_datum_loss = elementwise_loss.sum(dim=1)
+      loss = per_datum_loss.sum()
       loss.backward()
       total_loss += loss.item()
 
-      # Save logprobs for return
-      logprobs_list = target_logprobs.detach().cpu().tolist()
-      logprobs_list = [max(l, -9999.0) if not math.isinf(l) else (-9999.0 if l < 0 else 9999.0) for l in logprobs_list]
-
-      loss_fn_outputs.append({"logprobs": {"data": logprobs_list, "dtype": "float32", "shape": [len(logprobs_list)]}})
+      detached_logprobs = target_logprobs.detach().cpu()
+      for row, original_idx in enumerate(batch_indices):
+        row_len = lengths[row]
+        logprobs_list = detached_logprobs[row, :row_len].tolist()
+        logprobs_list = [max(l, -9999.0) if not math.isinf(l) else (-9999.0 if l < 0 else 9999.0) for l in logprobs_list]
+        loss_fn_outputs[original_idx] = {"logprobs": {"data": logprobs_list, "dtype": "float32", "shape": [len(logprobs_list)]}}
 
     mean_loss = total_loss / max(1, len(data))
 
     return {
       "metrics": {"loss:mean": self._sanitize_float(mean_loss), "loss:sum": self._sanitize_float(total_loss)},
-      "loss_fn_outputs": loss_fn_outputs,
+      "loss_fn_outputs": [output for output in loss_fn_outputs if output is not None],
       "loss_fn_output_type": "ArrayRecord",
     }
 
-  def _get_logprobs(self, datum: Datum) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Returns (target_logprobs, targets_tensor, weights_tensor)."""
-    # model_input is now just a flat list of tokens!
-    inputs_tensor = torch.tensor([datum.model_input], dtype=torch.long, device=self.device)
+  def _make_training_batches(self, data: list[Datum]) -> list[list[tuple[int, Datum]]]:
+    """Group examples for the single padded forward/backward path."""
+    if len(data) <= 1:
+      return [[(idx, datum)] for idx, datum in enumerate(data)]
 
-    # Extract targets
-    targets_data = datum.loss_fn_inputs["target_tokens"].data
-    targets_tensor = torch.tensor(targets_data, dtype=torch.long, device=self.device)
+    token_budget = int(os.getenv("OPEN_RL_TRAIN_TOKEN_BUDGET", "0"))
 
-    # Extract weights with default fallback to 1.0
-    if "weights" in datum.loss_fn_inputs:
-      weights_data = datum.loss_fn_inputs["weights"].data
-    else:
-      weights_data = [1.0] * len(targets_data)
+    if token_budget <= 0:
+      return [[(idx, datum)] for idx, datum in enumerate(data)]
 
-    weights_tensor = torch.tensor(weights_data, dtype=torch.float32, device=self.device)
+    ordered_data = sorted(enumerate(data), key=lambda item: len(item[1].model_input))
+    batches: list[list[tuple[int, Datum]]] = []
+    batch: list[tuple[int, Datum]] = []
+    batch_max_len = 0
 
-    outputs = self.peft_model(inputs_tensor, use_cache=False)
-    logits = outputs.logits[0]  # Shape: (SeqLen, VocabSize)
+    for item in ordered_data:
+      length = len(item[1].model_input)
+      next_max_len = max(batch_max_len, length)
+      next_size = len(batch) + 1
+      over_token_budget = next_max_len * next_size > token_budget
 
-    seq_len = min(logits.size(0), targets_tensor.size(0))
-    sliced_logits = logits[:seq_len]
-    sliced_targets = targets_tensor[:seq_len]
+      if batch and over_token_budget:
+        batches.append(batch)
+        batch = []
+        batch_max_len = 0
 
-    target_logprobs = torch.nn.functional.log_softmax(sliced_logits, dim=-1).gather(dim=-1, index=sliced_targets.unsqueeze(-1)).squeeze(-1)
+      batch.append(item)
+      batch_max_len = max(batch_max_len, length)
 
-    if weights_tensor.numel() > 0:
-      weights_tensor = weights_tensor[:seq_len]
+    if batch:
+      batches.append(batch)
 
-    return target_logprobs, targets_tensor, weights_tensor
+    return batches
 
-  def _compute_cross_entropy_loss(self, target_logprobs: torch.Tensor, weights_tensor: torch.Tensor) -> torch.Tensor:
-    """Simple cross entropy loss."""
-    elementwise_loss = -target_logprobs * weights_tensor
-    return elementwise_loss.sum()
+  def _get_logprobs_batch(self, data: list[Datum]) -> tuple[torch.Tensor, torch.Tensor, dict[str, torch.Tensor], list[int]]:
+    assert self.peft_model is not None
 
-  def _compute_importance_sampling_loss(self, target_logprobs: torch.Tensor, weights_tensor: torch.Tensor, datum: Datum) -> torch.Tensor:
-    """Importance sampling loss for RL."""
-    if "logprobs" not in datum.loss_fn_inputs or "advantages" not in datum.loss_fn_inputs:
-      raise ValueError("importance_sampling requires 'logprobs' and 'advantages' in loss_fn_inputs")
+    pad_token_id = self.tokenizer.pad_token_id if self.tokenizer and self.tokenizer.pad_token_id is not None else 0
+    batch_size = len(data)
+    input_lengths = [len(datum.model_input) for datum in data]
+    max_input_len = max(input_lengths)
 
-    ref_logprobs = datum.loss_fn_inputs["logprobs"].data
-    advantages = datum.loss_fn_inputs["advantages"].data
-    ref_tensor = torch.tensor(ref_logprobs, dtype=target_logprobs.dtype, device=self.device)
-    advantages_tensor = torch.tensor(advantages, dtype=target_logprobs.dtype, device=self.device)
+    input_tensor = torch.full((batch_size, max_input_len), pad_token_id, dtype=torch.long, device=self.device)
+    attention_mask = torch.zeros((batch_size, max_input_len), dtype=torch.long, device=self.device)
+    for row, datum in enumerate(data):
+      input_len = input_lengths[row]
+      input_tensor[row, :input_len] = torch.tensor(datum.model_input, dtype=torch.long, device=self.device)
+      attention_mask[row, :input_len] = 1
 
-    seq_len = min(target_logprobs.size(0), ref_tensor.size(0), advantages_tensor.size(0), weights_tensor.size(0))
-    target_logprobs = target_logprobs[:seq_len]
-    ref_tensor = ref_tensor[:seq_len]
-    advantages_tensor = advantages_tensor[:seq_len]
-    weights_tensor = weights_tensor[:seq_len]
+    target_lengths = [len(datum.loss_fn_inputs["target_tokens"].data) for datum in data]
+    lengths = [min(input_lengths[row], target_lengths[row]) for row in range(batch_size)]
+    max_target_len = max(lengths)
+    loss_dtype = torch.float32
 
-    diff = target_logprobs - ref_tensor
-    diff = torch.clamp(diff, min=-20.0, max=20.0)
+    targets = torch.zeros((batch_size, max_target_len), dtype=torch.long, device=self.device)
+    weights = torch.zeros((batch_size, max_target_len), dtype=loss_dtype, device=self.device)
+    aux_inputs: dict[str, torch.Tensor] = {}
+
+    aux_keys = set().union(*(datum.loss_fn_inputs.keys() for datum in data)) - {"target_tokens", "weights"}
+    for key in aux_keys:
+      aux_inputs[key] = torch.zeros((batch_size, max_target_len), dtype=loss_dtype, device=self.device)
+
+    for row, datum in enumerate(data):
+      seq_len = lengths[row]
+      targets_data = datum.loss_fn_inputs["target_tokens"].data[:seq_len]
+      targets[row, :seq_len] = torch.tensor(targets_data, dtype=torch.long, device=self.device)
+
+      weights_data = datum.loss_fn_inputs["weights"].data if "weights" in datum.loss_fn_inputs else [1.0] * target_lengths[row]
+      weights[row, :seq_len] = torch.tensor(weights_data[:seq_len], dtype=loss_dtype, device=self.device)
+
+      for key, aux_tensor in aux_inputs.items():
+        if key not in datum.loss_fn_inputs:
+          continue
+        values = datum.loss_fn_inputs[key].data[:seq_len]
+        aux_tensor[row, :seq_len] = torch.tensor(values, dtype=loss_dtype, device=self.device)
+
+    outputs = self.peft_model(input_tensor, attention_mask=attention_mask, use_cache=False, return_dict=True)
+    logits = outputs.logits[:, :max_target_len, :]
+    target_logprobs = torch.nn.functional.log_softmax(logits, dim=-1).gather(dim=-1, index=targets.unsqueeze(-1)).squeeze(-1)
+
+    return target_logprobs, weights, aux_inputs, lengths
+
+  def _cross_entropy_loss(self, target_logprobs: torch.Tensor, weights: torch.Tensor) -> torch.Tensor:
+    return -target_logprobs * weights
+
+  def _importance_sampling_loss(
+    self,
+    target_logprobs: torch.Tensor,
+    weights: torch.Tensor,
+    aux_inputs: dict[str, torch.Tensor],
+  ) -> torch.Tensor:
+    ref, advantages = self._reference_logprobs_and_advantages(aux_inputs, "importance_sampling")
+    ratio = self._policy_ratio(target_logprobs, ref)
+    elementwise_loss = -(ratio * advantages) * weights
+    return torch.nan_to_num(elementwise_loss, nan=0.0, posinf=0.0, neginf=0.0)
+
+  def _ppo_loss(
+    self,
+    target_logprobs: torch.Tensor,
+    weights: torch.Tensor,
+    aux_inputs: dict[str, torch.Tensor],
+    loss_config: dict | None,
+  ) -> torch.Tensor:
+    ref, advantages = self._reference_logprobs_and_advantages(aux_inputs, "ppo")
+    diff = torch.clamp(target_logprobs - ref, min=-20.0, max=20.0)
     ratio = torch.exp(diff)
-
-    elementwise_loss = -(ratio * advantages_tensor) * weights_tensor
-    elementwise_loss = torch.nan_to_num(elementwise_loss, nan=0.0, posinf=0.0, neginf=0.0)
-    return elementwise_loss.sum()
-
-  def _compute_ppo_loss(self, target_logprobs: torch.Tensor, weights_tensor: torch.Tensor, datum: Datum, loss_config: dict | None) -> torch.Tensor:
-    """PPO loss for RL."""
-    if "logprobs" not in datum.loss_fn_inputs or "advantages" not in datum.loss_fn_inputs:
-      raise ValueError("ppo requires 'logprobs' and 'advantages' in loss_fn_inputs")
-
-    ref_logprobs = datum.loss_fn_inputs["logprobs"].data
-    advantages = datum.loss_fn_inputs["advantages"].data
-
-    ref_tensor = torch.tensor(ref_logprobs, dtype=target_logprobs.dtype, device=self.device)
-    advantages_tensor = torch.tensor(advantages, dtype=target_logprobs.dtype, device=self.device)
-
-    seq_len = min(target_logprobs.size(0), ref_tensor.size(0), advantages_tensor.size(0), weights_tensor.size(0))
-    target_logprobs = target_logprobs[:seq_len]
-    ref_tensor = ref_tensor[:seq_len]
-    advantages_tensor = advantages_tensor[:seq_len]
-    weights_tensor = weights_tensor[:seq_len]
-
-    diff = target_logprobs - ref_tensor
-    diff = torch.clamp(diff, min=-20.0, max=20.0)
-    ratio = torch.exp(diff)
-
     epsilon = loss_config.get("clip_range", 0.2) if loss_config else 0.2
-
-    surr1 = ratio * advantages_tensor
-    surr2 = torch.clamp(ratio, 1.0 - epsilon, 1.0 + epsilon) * advantages_tensor
-
+    surr1 = ratio * advantages
+    surr2 = torch.clamp(ratio, 1.0 - epsilon, 1.0 + epsilon) * advantages
     elementwise_objective = torch.min(surr1, surr2)
-
-    # Optional KL penalty against the reference policy.
-    # Uses the unbiased estimator (ratio - 1) - log(ratio), which is
-    # non-negative and zero when the policy matches the reference.
     kl_coeff = loss_config.get("kl_coeff", 0.0) if loss_config else 0.0
     if kl_coeff > 0:
       kl = (ratio - 1) - diff
       elementwise_objective = elementwise_objective - kl_coeff * kl
+    return -(elementwise_objective * weights)
 
-    return -(elementwise_objective * weights_tensor).sum()
+  def _reference_logprobs_and_advantages(self, aux_inputs: dict[str, torch.Tensor], loss_fn: str) -> tuple[torch.Tensor, torch.Tensor]:
+    ref = aux_inputs.get("logprobs")
+    advantages = aux_inputs.get("advantages")
+    if ref is None or advantages is None:
+      raise ValueError(f"{loss_fn} requires 'logprobs' and 'advantages' in loss_fn_inputs")
+    return ref, advantages
+
+  def _policy_ratio(self, target_logprobs: torch.Tensor, ref_logprobs: torch.Tensor) -> torch.Tensor:
+    return torch.exp(torch.clamp(target_logprobs - ref_logprobs, min=-20.0, max=20.0))
 
   def _sanitize_float(self, val: float) -> float:
     if math.isinf(val):

--- a/src/server/trainer.py
+++ b/src/server/trainer.py
@@ -284,10 +284,15 @@ class TrainerEngine:
         loss_fn_outputs[original_idx] = {"logprobs": {"data": logprobs_list, "dtype": "float32", "shape": [len(logprobs_list)]}}
 
     mean_loss = total_loss / max(1, len(data))
+    completed_loss_fn_outputs = []
+    for output in loss_fn_outputs:
+      if output is None:
+        raise RuntimeError("forward_backward did not produce one loss_fn_output per input datum")
+      completed_loss_fn_outputs.append(output)
 
     return {
       "metrics": {"loss:mean": self._sanitize_float(mean_loss), "loss:sum": self._sanitize_float(total_loss)},
-      "loss_fn_outputs": [output for output in loss_fn_outputs if output is not None],
+      "loss_fn_outputs": completed_loss_fn_outputs,
       "loss_fn_output_type": "ArrayRecord",
     }
 

--- a/tests/test_trainer_optimizer_correctness.py
+++ b/tests/test_trainer_optimizer_correctness.py
@@ -75,6 +75,7 @@ class _LogitModelStub:
     vocab = torch.arange(self.vocab_size, dtype=torch.float32, device=input_tensor.device).view(1, 1, -1)
     positions = torch.arange(input_tensor.shape[1], dtype=torch.float32, device=input_tensor.device).view(1, -1, 1)
     logits = torch.cos(input_tensor.float().unsqueeze(-1) * 0.11 + positions * 0.07 + vocab * 0.13)
+    logits.requires_grad_()
     return types.SimpleNamespace(logits=logits)
 
 
@@ -206,6 +207,20 @@ class TestTrainerPaddedBatchingMath(unittest.TestCase):
     for batch in batches:
       padded_tokens = max(len(datum.model_input) for _idx, datum in batch) * len(batch)
       self.assertTrue(len(batch) == 1 or padded_tokens <= 6)
+
+  def test_forward_backward_padded_batches_preserve_client_output_shape(self) -> None:
+    engine = self._engine()
+    data = self._data()
+
+    with patch.dict(os.environ, {"OPEN_RL_TRAIN_TOKEN_BUDGET": "12"}):
+      result = engine.forward_backward(data, "cross_entropy")
+
+    self.assertEqual(len(result["loss_fn_outputs"]), len(data))
+    self.assertGreater(len(engine.peft_model.calls), 0)
+    self.assertTrue(any(call[0].shape[0] > 1 for call in engine.peft_model.calls))
+    for datum, output in zip(data, result["loss_fn_outputs"], strict=True):
+      logprobs = output["logprobs"]
+      self.assertEqual(logprobs["shape"], [min(len(datum.model_input), len(datum.loss_fn_inputs["target_tokens"].data))])
 
 
 if __name__ == "__main__":

--- a/tests/test_trainer_optimizer_correctness.py
+++ b/tests/test_trainer_optimizer_correctness.py
@@ -1,4 +1,5 @@
 import importlib.util
+import os
 import sys
 import types
 import unittest
@@ -56,6 +57,38 @@ class _PeftModelStub:
     return None
 
 
+class _TokenizerStub:
+  pad_token_id = 0
+
+
+class _LogitModelStub:
+  def __init__(self, vocab_size: int = 17):
+    self.vocab_size = vocab_size
+    self.calls = []
+
+  def train(self):
+    return None
+
+  def __call__(self, input_tensor, attention_mask=None, **_kwargs):
+    if attention_mask is not None:
+      self.calls.append((input_tensor.detach().clone(), attention_mask.detach().clone()))
+    vocab = torch.arange(self.vocab_size, dtype=torch.float32, device=input_tensor.device).view(1, 1, -1)
+    positions = torch.arange(input_tensor.shape[1], dtype=torch.float32, device=input_tensor.device).view(1, -1, 1)
+    logits = torch.cos(input_tensor.float().unsqueeze(-1) * 0.11 + positions * 0.07 + vocab * 0.13)
+    return types.SimpleNamespace(logits=logits)
+
+
+def _datum(model_input, target_tokens, *, weights=None, logprobs=None, advantages=None):
+  loss_fn_inputs = {"target_tokens": trainer_module.TensorData(data=target_tokens)}
+  if weights is not None:
+    loss_fn_inputs["weights"] = trainer_module.TensorData(data=weights)
+  if logprobs is not None:
+    loss_fn_inputs["logprobs"] = trainer_module.TensorData(data=logprobs)
+  if advantages is not None:
+    loss_fn_inputs["advantages"] = trainer_module.TensorData(data=advantages)
+  return trainer_module.Datum(model_input=model_input, loss_fn_inputs=loss_fn_inputs)
+
+
 class TestTrainerOptimizerCorrectness(unittest.TestCase):
   def test_optim_step_only_updates_active_adapter_params(self) -> None:
     active_param = torch.nn.Parameter(torch.tensor([1.0]))
@@ -93,6 +126,86 @@ class TestTrainerOptimizerCorrectness(unittest.TestCase):
     if active_param.grad is not None:
       self.assertTrue(torch.allclose(active_param.grad, torch.zeros_like(active_param.grad)))
     self.assertIsNotNone(other_param.grad)
+
+
+class TestTrainerPaddedBatchingMath(unittest.TestCase):
+  def _engine(self) -> TrainerEngine:
+    engine = TrainerEngine()
+    engine.device = torch.device("cpu")
+    engine.tokenizer = _TokenizerStub()
+    engine.peft_model = _LogitModelStub()
+    return engine
+
+  def _data(self):
+    return [
+      _datum(
+        [3, 4, 5, 6],
+        [1, 2, 3, 4],
+        weights=[1.0, 0.5, 0.25, 2.0],
+        logprobs=[-0.1, -0.2, -0.3, -0.4],
+        advantages=[1.0, -0.5, 2.0, 0.25],
+      ),
+      _datum(
+        [7, 8],
+        [2, 3],
+        logprobs=[-0.7, -0.8],
+        advantages=[0.75, 1.25],
+      ),
+      _datum(
+        [9, 10, 11],
+        [5, 6, 7, 8],
+        weights=[0.2, 0.4, 0.6, 0.8],
+        logprobs=[-0.9, -1.0, -1.1, -1.2],
+        advantages=[-1.0, 0.3, 0.9, 1.7],
+      ),
+    ]
+
+  def test_padded_batch_logprobs_and_losses_match_per_example_math(self) -> None:
+    engine = self._engine()
+    data = self._data()
+
+    batch_logprobs, batch_weights, batch_aux, batch_lengths = engine._get_logprobs_batch(data)
+    single_results = [engine._get_logprobs_batch([datum]) for datum in data]
+
+    for row, (single_logprobs, single_weights, single_aux, single_lengths) in enumerate(single_results):
+      length = batch_lengths[row]
+      self.assertEqual(length, single_lengths[0])
+      torch.testing.assert_close(batch_logprobs[row, :length], single_logprobs[0, :length])
+      torch.testing.assert_close(batch_weights[row, :length], single_weights[0, :length])
+      torch.testing.assert_close(batch_weights[row, length:], torch.zeros_like(batch_weights[row, length:]))
+      for key in ("logprobs", "advantages"):
+        torch.testing.assert_close(batch_aux[key][row, :length], single_aux[key][0, :length])
+        torch.testing.assert_close(batch_aux[key][row, length:], torch.zeros_like(batch_aux[key][row, length:]))
+
+    def single_sum(fn):
+      losses = [fn(logprobs, weights, aux).sum() for logprobs, weights, aux, _lengths in single_results]
+      return torch.stack(losses).sum()
+
+    torch.testing.assert_close(
+      engine._cross_entropy_loss(batch_logprobs, batch_weights).sum(),
+      single_sum(lambda logprobs, weights, _aux: engine._cross_entropy_loss(logprobs, weights)),
+    )
+    torch.testing.assert_close(
+      engine._importance_sampling_loss(batch_logprobs, batch_weights, batch_aux).sum(),
+      single_sum(lambda logprobs, weights, aux: engine._importance_sampling_loss(logprobs, weights, aux)),
+    )
+    ppo_config = {"clip_range": 0.2, "kl_coeff": 0.03}
+    torch.testing.assert_close(
+      engine._ppo_loss(batch_logprobs, batch_weights, batch_aux, ppo_config).sum(),
+      single_sum(lambda logprobs, weights, aux: engine._ppo_loss(logprobs, weights, aux, ppo_config)),
+    )
+
+  def test_token_budget_batches_preserve_examples(self) -> None:
+    engine = self._engine()
+    data = self._data()
+    with patch.dict(os.environ, {"OPEN_RL_TRAIN_TOKEN_BUDGET": "6"}):
+      batches = engine._make_training_batches(data)
+
+    seen = [idx for batch in batches for idx, _datum in batch]
+    self.assertCountEqual(seen, range(len(data)))
+    for batch in batches:
+      padded_tokens = max(len(datum.model_input) for _idx, datum in batch) * len(batch)
+      self.assertTrue(len(batch) == 1 or padded_tokens <= 6)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds server side padded batching for forward_backward passes. Before we had code that looked like this: 

```python
for datum in data:
    loss = compute_loss(datum)
    loss.backward()

optimizer.step()
```
This means every datum does it's own small forward backward. To increase GPU utilization we can put multiple datums together in padded chunks and submit them all at once. To avoid OOMing, We can control how big an individual chunk can be with a new environment variable called ```OPEN_RL_TRAIN_TOKEN_BUDGET```. By default it's set 0 so we preserve the old behavior and make it opt-in.