### PR TITLE
feat(server): support base model sampling requests without LoRA

### DIFF
--- a/src/server/gateway.py
+++ b/src/server/gateway.py
@@ -424,7 +424,14 @@ async def asample(req: dict):
   req_id = str(uuid.uuid4())
   await store.set_future(req_id, {"status": "pending"})
 
-  lora_path = os.path.join(TMP_DIR, "peft", base_model_id, base_model_id) if base_model_id else None
+  # A request is for LoRA if the ID is not the base model or the default session fallback
+  default_model = get_default_model_name()
+  is_lora = (
+    base_model_id is not None
+    and base_model_id != default_model
+    and base_model_id != "samp-session-live-123"
+  )
+  lora_path = os.path.join(TMP_DIR, "peft", base_model_id, base_model_id) if is_lora else None
   headers: dict[str, str] = {"Content-Type": "application/json"}
   propagate.inject(headers)
 


### PR DESCRIPTION
*   **Context**: In `openclaw-rl`, the [Teacher/Judge model](https://github.com/Gen-Verse/OpenClaw-RL/blob/ffdebf1d46883394308fb4d8659a62794c38d43b/openclaw-tinker/trainer.py#L13-L15) (used by the scorers to evaluate turns and extract hints) is deployed as a base-model `SamplingClient` without any LoRA adapters to serve as a frozen reference.
*   **Problem**: The `/asample` endpoint in `gateway.py` always assumed requests required a LoRA adapter. When the Teacher client was queried, the server tried to load a LoRA path for the default session fallback (`"samp-session-live-123"`), causing a `LoRAAdapterNotFoundError` and crashing vLLM.
*   **Solution**: Added a check to verify if the request is actually for a LoRA session. If the ID matches the base model name or the default fallback session, `lora_path` resolves to `None`, enabling vLLM to serve the base model correctly.