### PR TITLE
Enable gradient checkpointing to prevent OOM on long training sequences

### DIFF
--- a/src/server/trainer.py
+++ b/src/server/trainer.py
@@ -14,6 +14,8 @@ from peft import PeftModelForCausalLM, get_peft_model
 from pydantic import BaseModel
 from transformers import AutoModelForCausalLM, AutoTokenizer, PreTrainedModel, PreTrainedTokenizerBase
 
+ENABLE_GRADIENT_CHECKPOINTING = os.getenv("ENABLE_GRADIENT_CHECKPOINTING", "1") == "1"
+
 
 class TensorData(BaseModel):
   data: list[int] | list[float]
@@ -139,6 +141,14 @@ class TrainerEngine:
     self.peft_model.set_adapter(adapter_id)
     self.adapter_states[adapter_id] = {"trainable_params": active_adapter_parameters(self.peft_model, adapter_id), "optimizer": None}
 
+    if ENABLE_GRADIENT_CHECKPOINTING:
+      try:
+        self.peft_model.gradient_checkpointing_enable()
+        self.peft_model.enable_input_require_grads()
+        print("Gradient checkpointing and input require grads enabled on PEFT model.")
+      except Exception as e:
+        print(f"Failed to enable gradient checkpointing: {e}")
+
     self.peft_model.train()
     print(f"LoRA adapter '{adapter_id}' created and set to active.")
 
@@ -231,6 +241,15 @@ class TrainerEngine:
     params = active_adapter_parameters(self.peft_model, model_id)
     adapter_state = {"trainable_params": params, "optimizer": None}
     self.adapter_states[model_id] = adapter_state
+
+    if ENABLE_GRADIENT_CHECKPOINTING:
+      try:
+        self.peft_model.gradient_checkpointing_enable()
+        self.peft_model.enable_input_require_grads()
+        print("Gradient checkpointing and input require grads enabled on PEFT model.")
+      except Exception as e:
+        print(f"Failed to enable gradient checkpointing: {e}")
+
     self.peft_model.train()
 
     if restore_optimizer and metadata.get("has_optimizer"):


### PR DESCRIPTION
### Context

We are using openrl as part of a self-hosted continuous learning stack (OpenRL -> OpenClaw-RL -> OpenClaw) where an AI agent (OpenClaw) learns from live user interactions in real time. Each user turn is intercepted, scored, and submitted by OpenClaw-RL to the open-rl training server as an RL training datum — a full prompt + response sequence. The system prompt carries a large tool list, so prompts reach **12,000–13,000 tokens** by the third conversational turn.

Once a batch is collected, OpenClaw-RL triggers the open-rl server to run a forward and backward pass through the full prompt + response sequences on a LoRA-wrapped Qwen3-4B model.

### Problem

Training crashes with CUDA OOM on A100 80GB when the first batch triggers `forward_backward`.

Without gradient checkpointing, the backward pass requires retaining **all intermediate activation tensors across all 36 layers** of Qwen3-4B simultaneously. For 13k-token sequences this accumulates to ~70 GiB of activations — exceeding the GPU before the backward pass even begins.

### Solution

Enable gradient checkpointing on the PEFT model in `create_adapter`, reducing activation memory from ~70 GiB to a few GiB by recomputing layer activations on demand during backward instead of storing them all. The trade-off is ~30% slower training steps due to the recomputation.

Two calls are required together:
- `gradient_checkpointing_enable()` — stops storing all intermediate activations
- `enable_input_require_grads()` — PEFT/LoRA compatibility fix: without it, checkpointing silently no-ops because frozen base model inputs have `requires_grad=False`

Togglable via `ENABLE_GRADIENT_CHECKPOINTING` env var (default: on).