### PR TITLE
feat: FFT v1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,171 @@
+# Full Fine-Tuning Scheduler Diff
+
+## What Changed
+
+This PR adds the minimal full fine-tuning path needed to prove that two SFT jobs can share one local GPU through explicit scheduler handoff.
+
+Before this change:
+
+- OpenRL had a single trainer worker style that could assume it owned CUDA.
+- Requests were drained from the shared queue.
+- There was no node-local process that coordinated GPU residency across multiple full-FT workers.
+- There was no process-level checkpoint/restore seam for evicting a trainer's CUDA state.
+
+After this change:
+
+- A full-FT run gets its own trainer worker process.
+- Each worker drains only its own run queue.
+- Workers talk to a node-local `TrainerScheduler` over a persistent Unix socket.
+- Only one worker can hold the scheduler's active CUDA slot at a time.
+- A worker must call `ACQUIRE` before CUDA work and `RELEASE` after its drain window.
+- `RELEASE` checkpoints the active worker with `cuda-checkpoint`.
+- A later `ACQUIRE` restores that same worker if it was checkpointed.
+
+The intended first milestone is narrow: two full fine-tuning SFT jobs, same base model, one OpenRL server, one GPU residency slot. This PR does not try to solve sampling, vLLM handoff, multi-base scheduling, placement, multi-GPU topology, or crash recovery.
+
+## Design Shape
+
+The scheduler uses the same basic shape as `accel-time-slicer`:
+
+- Jobs explicitly request GPU access instead of assuming CUDA ownership.
+- A scheduler grants one job at a time.
+- The job yields/releases when its current GPU work window is done.
+- The scheduler checkpoints the old job before another job can run.
+- Restoring happens before the job is granted CUDA again.
+
+## New Pieces
+
+- `CheckpointRestorer`
+  - Protocol with `checkpoint(pid)` and `restore(pid)`.
+  - Intentionally does not know about OpenRL queues, runs, fairness, or scheduler state.
+- `CudaCheckpointRestorer`
+  - Uses NVIDIA `cuda-checkpoint`.
+  - `checkpoint(pid)` runs `lock` then `checkpoint`.
+  - `restore(pid)` runs `restore` then `unlock`.
+- `TrainerScheduler`
+  - Owns registered workers, a FIFO waiter queue, the active run, and checkpointed/failed worker state.
+  - Grants one worker at a time.
+- `TrainerSchedulerClient`
+  - Worker-side socket client.
+  - Exposes `async with scheduler.acquire(run_id): ...`.
+- Worker launch and run-scoped queue draining
+  - The gateway can launch a per-run worker.
+  - Scheduled workers drain only requests for their run.
+
+## Scheduler Behavior
+
+`REGISTER(run_id, pid)`:
+
+- Records the worker PID and socket connection for the run.
+- Duplicate registration for a live run fails.
+
+`ACQUIRE(run_id)`:
+
+- Validates that the run is registered, not failed, and not already waiting or active.
+- Appends the run to the FIFO waiter queue.
+- Waits until no run is active and this run is at the head of the queue.
+- Marks the run active.
+- Restores the worker if it was checkpointed by a previous release.
+- Returns success only when the worker may touch CUDA.
+
+`RELEASE(run_id)`:
+
+- Validates that the run owns the active slot.
+- Checkpoints the worker.
+- Marks the worker checkpointed.
+- Clears the active slot and wakes waiters.
+
+`UNREGISTER(run_id)`:
+
+- Removes the worker.
+- Clears any waiting or active claim for the run.
+
+Socket close:
+
+- Means worker death.
+- Clears waiting/active state for that connection.
+- Marks the worker failed so future acquires cannot grant CUDA.
+
+## Lazy Residency Decision
+
+The first implementation tried to keep the single-worker fast path in mind: if a worker released while nobody else was waiting, leave it resident and avoid checkpointing.
+
+That optimization made the scheduler harder to reason about. It required extra state and pushed eviction into surprising places:
+
+- Track `resident_run_id` for a worker that is not active but may still occupy GPU memory.
+- Make `ACQUIRE` checkpoint a different idle-resident worker before granting the requester.
+- Handle the dynamic registration case where worker A is resident because it was alone, then worker B registers later.
+- Add socket-close and unregister handling for idle-resident workers.
+- Add tests for release/reacquire without checkpointing, second-worker eviction, and idle-resident failure cleanup.
+
+This PR deliberately does not include that optimization.
+
+Current invariant:
+
+- Every successful `RELEASE` checkpoints.
+- `RELEASE` is the only eviction point.
+- `ACQUIRE` never checkpoints another worker.
+- A worker outside an acquire window is either cold/not-yet-materialized or checkpointed.
+- There is no idle-resident state.
+
+This is less efficient because a single job pays checkpoint cost after every drain window. For this prototype, that is the right tradeoff: the goal is to prove the two-worker full-FT path with the smallest correct scheduler.
+
+The single-job edge case is therefore intentionally suboptimal: if only one full-FT worker exists, it still checkpoints on every `RELEASE` and restores on the next `ACQUIRE`. Correctness is simple because the worker never keeps hidden GPU residency outside the acquire window, but throughput is worse than the lazy-resident version would be.
+
+If checkpoint overhead becomes the bottleneck later, add lazy residency as a separate change with explicit `resident_run_id` state and tests.
+
+## CUDA Boundary
+
+The correctness boundary is strict:
+
+- No CUDA allocation before first successful `ACQUIRE`.
+- Model and optimizer materialization onto CUDA happens inside the acquire window.
+- After `RELEASE`, the worker may only do CPU work: queue waits, socket I/O, heartbeats, CPU logging.
+- After `RELEASE`, the worker must not touch CUDA until the next successful `ACQUIRE`.
+
+Risky paths include lazy model init, optimizer state moves, CUDA tensor `.item()`, CUDA metrics, save/load hooks, and `torch.cuda.empty_cache`.
+
+## Failure Policy
+
+- Worker socket close is handled gracefully as worker death.
+- Checkpoint or restore failure is not handled as a normal request error.
+- If checkpoint/restore fails, GPU state is unknown, so the scheduler fails closed instead of granting another worker.
+
+The important behavior is that a failed checkpoint or restore cannot be followed by another successful CUDA grant from the same scheduler instance.
+
+## Known Lifecycle Gap
+
+Socket close detects worker death, not normal client completion.
+
+If the client finishes but the worker keeps polling an empty queue, the scheduler still sees a live socket. The gateway should own cleanup because it launched the worker and sees client activity.
+
+Next cleanup step:
+
+- Add an idle reaper in the gateway.
+- Use the existing Tinker session heartbeat as the client liveness signal.
+- If a run queue is empty and the session heartbeat is stale past a timeout, terminate the worker.
+- Terminating the worker closes the scheduler socket and reuses existing cleanup.
+
+Later:
+
+- Tune heartbeat timeout behavior so long legitimate idle gaps do not kill active clients.
+- Add a max-hold/acquire deadline for hung-but-alive workers.
+
+## Tests
+
+The tests are meant to cover behavior, not tiny implementation details.
+
+Covered behavior:
+
+- Only one worker can be active.
+- A waiting acquire is not granted until release checkpoint completes.
+- A checkpointed worker is not granted until restore completes.
+- First acquire is cold; later acquire restores after checkpoint.
+- Release checkpoints even with no waiters.
+- Waiters are FIFO.
+- Unregistering a waiting worker prevents a later grant.
+- Socket clients alternate over the real Unix socket server.
+- Closing an active worker socket marks the run failed.
+- A worker drains only its own run queue.
+
+Avoid testing the exact local helper shape inside `CudaCheckpointRestorer`; the important contract is that scheduler handoff waits for checkpoint/restore completion.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,6 +151,32 @@ Later:
 - Tune heartbeat timeout behavior so long legitimate idle gaps do not kill active clients.
 - Add a max-hold/acquire deadline for hung-but-alive workers.
 
+## Full-FT Resume Compatibility
+
+This prototype treats full fine-tuning as a server-side mode selected by `OPEN_RL_TRAINING_MODE=full`.
+That keeps the stock Tinker client and cookbook training loop unchanged for creating a run.
+
+The resume path is different. `tinker_cookbook.supervised.train` checks `log_path/checkpoints.jsonl`
+on startup. If it finds a `state_path`, it calls the stock Tinker
+`create_training_client_from_state*` flow. That SDK flow asks `/api/v1/weights_info` for LoRA-shaped
+metadata, creates a LoRA training client, then calls `load_state`.
+
+OpenRL now records model-scoped checkpoint paths so aliases do not collide across runs, and the
+gateway can answer `weights_info` from checkpoint metadata. When `OPEN_RL_TRAINING_MODE=full`, a full
+checkpoint intentionally reports a LoRA-shaped `weights_info` response because the stock SDK asserts
+that `create_training_client_from_state*` is LoRA-shaped before it calls `load_state`.
+
+That response is a compatibility shim, not the source of truth. In full mode the gateway ignores the
+LoRA shape and creates a full-FT worker; `load_state` then loads the full HuggingFace checkpoint.
+
+Current user-facing behavior:
+
+- Start the gateway with `OPEN_RL_TRAINING_MODE=full` for both the original run and resume.
+- Use a fresh `log_path`, or delete the previous artifacts directory, when a clean run is desired.
+
+The cleaner long-term version is a client/helper that can create a full-FT training client from state
+without the `weights_info` lie.
+
 ## Tests
 
 The tests are meant to cover behavior, not tiny implementation details.

--- a/examples/sft/gsm8k/README.md
+++ b/examples/sft/gsm8k/README.md
@@ -26,7 +26,8 @@ python examples/sft/gsm8k/gsm8k_sft.py base_model=Qwen/Qwen2.5-0.5B epochs=1 lr=
 Training uses `tinker_cookbook.supervised.train`, so batching, LR scheduling, metric logging, and
 final checkpoint export are handled by the cookbook loop. The final checkpoint is recorded under
 `artifacts/gsm8k_sft/checkpoints.jsonl`; for full-FT the sampler checkpoint path points at a
-standard HF model directory.
+standard HF model directory. Since this prototype runs training and eval on the same machine, the
+script also prints `eval_model_path=<local_dir>` after training.
 
 ## Current resume behavior
 
@@ -51,7 +52,7 @@ Eval is decoupled (point a server at the saved dir). With vLLM:
 
 ```bash
 VLLM_USE_FLASHINFER_SAMPLER=0 python examples/sft/gsm8k/vllm_eval.py \
-  --path <saved_dir> --data gsm8k_test.json   # ~5s for 250 problems
+  --path <eval_model_path> --data gsm8k_test.json   # ~5s for 250 problems
 ```
 
 ## Results (Qwen2.5-0.5B, 1 epoch, lr 2e-5, 0-shot exact-match on 250 test problems)

--- a/examples/sft/gsm8k/README.md
+++ b/examples/sft/gsm8k/README.md
@@ -2,7 +2,7 @@
 
 Full-parameter SFT of a small model on [GSM8K](https://github.com/openai/grade-school-math)
 (7,473 grade-school math problems with chain-of-thought), driven through the open-rl gateway
-with the tinker SDK — the same client path as `../pig-latin`, but full fine-tuning instead of LoRA.
+with the tinker SDK.
 
 ## Why full-FT goes through an env var
 
@@ -11,48 +11,55 @@ full fine-tuning without changing the client, start the gateway with **`OPEN_RL_
 which makes every created model a full-FT model. (The eventual plan is a
 `create_fft_training_client()` client helper; until then this env var keeps the client unchanged.)
 
-## Run
+## Run (4-Pane Setup)
 
+This setup demonstrates multi-tenant full fine-tuning (FFT) SFT jobs sharing a single GPU through explicit scheduler handoff. 
+
+Assumes you start at the project root in all terminal panes:
+
+### Pane 1: Scheduler
 ```bash
-# Terminal 1 — gateway (single-process, in-memory store, torch sampling)
-cd src/server
-OPEN_RL_TRAINING_MODE=full BASE_MODEL=Qwen/Qwen2.5-0.5B \
-  python -m uvicorn gateway:app --host 127.0.0.1 --port 9003
-
-# Terminal 2 — train (chz config)
-python examples/sft/gsm8k/gsm8k_sft.py base_model=Qwen/Qwen2.5-0.5B epochs=1 lr=2e-5
+uv --project src/server run python src/server/trainer_scheduler.py
 ```
 
-Training uses `tinker_cookbook.supervised.train`, so batching, LR scheduling, metric logging, and
-final checkpoint export are handled by the cookbook loop. The final checkpoint is recorded under
-`artifacts/gsm8k_sft/checkpoints.jsonl`; for full-FT the sampler checkpoint path points at a
-standard HF model directory. Since this prototype runs training and eval on the same machine, the
-script also prints `eval_model_path=<local_dir>` after training.
-
-## Current resume behavior
-
-Full-FT resume from a saved `state_path` requires starting the gateway in full mode again.
-
-The cookbook trainer automatically checks `<log_path>/checkpoints.jsonl` on startup. If it finds a
-previous `state_path`, it tries to resume through the stock Tinker `create_training_client_from_state`
-path, which is still LoRA-shaped. This prototype uses `OPEN_RL_TRAINING_MODE=full` as a server-side
-knob so the normal client can create full-FT runs. The gateway also uses that same knob when answering
-the SDK's resume metadata request.
-
-If you want a clean run instead of resuming, rerun with a fresh `log_path` or let the cookbook
-helper delete the existing log dir before training starts:
-
+### Pane 2: Gateway
 ```bash
-python examples/sft/gsm8k/gsm8k_sft.py behavior_if_log_dir_exists=delete
+OPEN_RL_STORE_DIR=/tmp/open-rl/store \
+OPEN_RL_SCHEDULER_SOCKET=/tmp/open-rl/trainer-scheduler.sock \
+OPEN_RL_TRAINING_MODE=full \
+BASE_MODEL=Qwen/Qwen2.5-0.5B \
+uv --project src/server run uvicorn gateway:app --app-dir src/server --host 127.0.0.1 --port 9003
 ```
+
+### Pane 3: SFT Job A
+```bash
+uv --project examples run python examples/sft/gsm8k/gsm8k_sft.py \
+  --log-path=examples/sft/gsm8k/artifacts/job_a \
+  --max-steps=20 \
+  --base-model=Qwen/Qwen2.5-0.5B \
+  --behavior-if-log-dir-exists=delete
+```
+
+### Pane 4: SFT Job B
+```bash
+uv --project examples run python examples/sft/gsm8k/gsm8k_sft.py \
+  --log-path=examples/sft/gsm8k/artifacts/job_b \
+  --max-steps=20 \
+  --base-model=Qwen/Qwen2.5-0.5B \
+  --behavior-if-log-dir-exists=delete
+```
+
+---
+
+Training uses `tinker_cookbook.supervised.train`, so batching, LR scheduling, metric logging, and final checkpoint export are handled by the cookbook loop. The training script will print the directory where the final checkpoint is saved.
 
 ## Eval
 
-Eval is decoupled (point a server at the saved dir). With vLLM:
+Eval is decoupled (point a server at the saved dir). With vLLM (run from the project root):
 
 ```bash
-VLLM_USE_FLASHINFER_SAMPLER=0 python examples/sft/gsm8k/vllm_eval.py \
-  --path <eval_model_path> --data gsm8k_test.json   # ~5s for 250 problems
+python examples/sft/gsm8k/vllm_eval.py \
+  --path <saved_dir> --data gsm8k_test.json
 ```
 
 ## Results (Qwen2.5-0.5B, 1 epoch, lr 2e-5, 0-shot exact-match on 250 test problems)
@@ -61,10 +68,6 @@ VLLM_USE_FLASHINFER_SAMPLER=0 python examples/sft/gsm8k/vllm_eval.py \
 |---|---|
 | base (our 0-shot format) | ~1.5% |
 | **after full-FT SFT** | **~36%** |
-| Qwen2.5-0.5B base *(published, 4-shot)* | 41.6% |
-| Qwen2.5-0.5B-Instruct *(published)* | 49.6% |
 
-In the published ~0.5B band (and our number is the harder 0-shot vs their 4-shot). Qwen3-0.6B-Base
-under the same recipe reaches ~48%.
 
 Files: `gsm8k_sft.py` (training via tinker server), `vllm_eval.py` (fast eval of the saved dir).

--- a/examples/sft/gsm8k/README.md
+++ b/examples/sft/gsm8k/README.md
@@ -1,0 +1,52 @@
+# GSM8K full fine-tuning (via the tinker server)
+
+Full-parameter SFT of a small model on [GSM8K](https://github.com/openai/grade-school-math)
+(7,473 grade-school math problems with chain-of-thought), driven through the open-rl gateway
+with the tinker SDK — the same client path as `../pig-latin`, but full fine-tuning instead of LoRA.
+
+## Why full-FT goes through an env var
+
+The tinker SDK's `create_lora_training_client()` is LoRA-only (it rejects `training_mode`). To do
+full fine-tuning without changing the client, start the gateway with **`OPEN_RL_TRAINING_MODE=full`**,
+which makes every created model a full-FT model. (The eventual plan is a
+`create_fft_training_client()` client helper; until then this env var keeps the client unchanged.)
+
+## Run
+
+```bash
+# Terminal 1 — gateway (single-process, in-memory store, torch sampling)
+cd src/server
+OPEN_RL_TRAINING_MODE=full BASE_MODEL=Qwen/Qwen2.5-0.5B \
+  python -m uvicorn gateway:app --host 127.0.0.1 --port 9003
+
+# Terminal 2 — train (chz config)
+python examples/sft/gsm8k/gsm8k_sft.py base_model=Qwen/Qwen2.5-0.5B epochs=1 lr=2e-5
+```
+
+Training uses `tinker_cookbook.supervised.train`, so batching, LR scheduling, metric logging, and
+final checkpoint export are handled by the cookbook loop. The final checkpoint is recorded under
+`artifacts/gsm8k_sft/checkpoints.jsonl`; for full-FT the sampler checkpoint path points at a
+standard HF model directory.
+
+## Eval
+
+Eval is decoupled (point a server at the saved dir). With vLLM:
+
+```bash
+VLLM_USE_FLASHINFER_SAMPLER=0 python examples/sft/gsm8k/vllm_eval.py \
+  --path <saved_dir> --data gsm8k_test.json   # ~5s for 250 problems
+```
+
+## Results (Qwen2.5-0.5B, 1 epoch, lr 2e-5, 0-shot exact-match on 250 test problems)
+
+| | GSM8K |
+|---|---|
+| base (our 0-shot format) | ~1.5% |
+| **after full-FT SFT** | **~36%** |
+| Qwen2.5-0.5B base *(published, 4-shot)* | 41.6% |
+| Qwen2.5-0.5B-Instruct *(published)* | 49.6% |
+
+In the published ~0.5B band (and our number is the harder 0-shot vs their 4-shot). Qwen3-0.6B-Base
+under the same recipe reaches ~48%.
+
+Files: `gsm8k_sft.py` (training via tinker server), `vllm_eval.py` (fast eval of the saved dir).

--- a/examples/sft/gsm8k/README.md
+++ b/examples/sft/gsm8k/README.md
@@ -28,6 +28,23 @@ final checkpoint export are handled by the cookbook loop. The final checkpoint i
 `artifacts/gsm8k_sft/checkpoints.jsonl`; for full-FT the sampler checkpoint path points at a
 standard HF model directory.
 
+## Current resume behavior
+
+Full-FT resume from a saved `state_path` requires starting the gateway in full mode again.
+
+The cookbook trainer automatically checks `<log_path>/checkpoints.jsonl` on startup. If it finds a
+previous `state_path`, it tries to resume through the stock Tinker `create_training_client_from_state`
+path, which is still LoRA-shaped. This prototype uses `OPEN_RL_TRAINING_MODE=full` as a server-side
+knob so the normal client can create full-FT runs. The gateway also uses that same knob when answering
+the SDK's resume metadata request.
+
+If you want a clean run instead of resuming, rerun with a fresh `log_path` or let the cookbook
+helper delete the existing log dir before training starts:
+
+```bash
+python examples/sft/gsm8k/gsm8k_sft.py behavior_if_log_dir_exists=delete
+```
+
 ## Eval
 
 Eval is decoupled (point a server at the saved dir). With vLLM:

--- a/examples/sft/gsm8k/gsm8k_sft.py
+++ b/examples/sft/gsm8k/gsm8k_sft.py
@@ -6,7 +6,7 @@ import chz
 import tinker
 from datasets import load_dataset
 from tinker import types
-from tinker_cookbook import cli_utils
+from tinker_cookbook import checkpoint_utils, cli_utils
 from tinker_cookbook.supervised.data import SupervisedDatasetFromHFDataset
 from tinker_cookbook.supervised.train import Config as TrainConfig
 from tinker_cookbook.supervised.train import main as train
@@ -81,6 +81,12 @@ def main(config: Config) -> None:
       )
     )
   )
+  checkpoint = checkpoint_utils.get_last_checkpoint(config.log_path, required_key="sampler_path")
+  if checkpoint and checkpoint.sampler_path:
+    path = checkpoint.sampler_path
+    if path.startswith("tinker://"):
+      path = str(Path(os.getenv("OPEN_RL_TMP_DIR", "/tmp/open-rl")) / "sampler_full" / path.removeprefix("tinker://"))
+    print(f"eval_model_path={path}")
 
 
 if __name__ == "__main__":

--- a/examples/sft/gsm8k/gsm8k_sft.py
+++ b/examples/sft/gsm8k/gsm8k_sft.py
@@ -1,0 +1,84 @@
+import asyncio
+import os
+from pathlib import Path
+
+import chz
+import tinker
+from datasets import load_dataset
+from tinker import types
+from tinker_cookbook.supervised.data import SupervisedDatasetFromHFDataset
+from tinker_cookbook.supervised.train import Config as TrainConfig
+from tinker_cookbook.supervised.train import main as train
+from tinker_cookbook.supervised.types import SupervisedDatasetBuilder
+from tinker_cookbook.tokenizer_utils import get_tokenizer
+
+os.environ.setdefault("TINKER_API_KEY", "tml-dummy-key")
+
+
+@chz.chz
+class GSM8KDataset(SupervisedDatasetBuilder):
+  model_name: str
+  batch_size: int = 16
+  max_length: int = 640
+  seed: int = 0
+
+  def __call__(self):
+    tokenizer = get_tokenizer(self.model_name)
+    dataset = load_dataset("openai/gsm8k", "main", split="train").shuffle(seed=self.seed)
+
+    def make_datum(row: dict) -> tinker.Datum:
+      prompt = tokenizer.encode(f"Question: {row['question']}\nAnswer:", add_special_tokens=False)
+      completion = tokenizer.encode(" " + row["answer"].strip(), add_special_tokens=False) + [tokenizer.eos_token_id]
+      tokens = (prompt + completion)[: self.max_length]
+      weights = ([0] * len(prompt) + [1] * len(completion))[: self.max_length]
+      return types.Datum(
+        model_input=types.ModelInput.from_ints(tokens=tokens[:-1]),
+        loss_fn_inputs={"target_tokens": tokens[1:], "weights": [float(w) for w in weights[1:]]},
+      )
+
+    return SupervisedDatasetFromHFDataset(dataset, self.batch_size, map_fn=make_datum), None
+
+
+@chz.chz
+class Config:
+  base_model: str = "Qwen/Qwen2.5-0.5B"
+  base_url: str = os.getenv("TINKER_BASE_URL", os.getenv("BASE_URL", "http://127.0.0.1:9003"))
+  log_path: str = str(Path(__file__).with_name("artifacts") / "gsm8k_sft")
+  epochs: int = 1
+  batch: int = 16
+  lr: float = 2e-5
+  rank: int = 32
+  max_len: int = 640
+  seed: int = 0
+  max_steps: int | None = None
+  save_every: int = 0
+
+
+def main(config: Config) -> None:
+  asyncio.run(
+    train(
+      TrainConfig(
+        log_path=config.log_path,
+        model_name=config.base_model,
+        dataset_builder=GSM8KDataset(
+          model_name=config.base_model,
+          batch_size=config.batch,
+          max_length=config.max_len,
+          seed=config.seed,
+        ),
+        learning_rate=config.lr,
+        lr_schedule="cosine",
+        num_epochs=config.epochs,
+        lora_rank=config.rank,
+        base_url=config.base_url,
+        save_every=config.save_every,
+        eval_every=0,
+        infrequent_eval_every=0,
+        max_steps=config.max_steps,
+      )
+    )
+  )
+
+
+if __name__ == "__main__":
+  chz.nested_entrypoint(main, allow_hyphens=True)

--- a/examples/sft/gsm8k/gsm8k_sft.py
+++ b/examples/sft/gsm8k/gsm8k_sft.py
@@ -6,6 +6,7 @@ import chz
 import tinker
 from datasets import load_dataset
 from tinker import types
+from tinker_cookbook import cli_utils
 from tinker_cookbook.supervised.data import SupervisedDatasetFromHFDataset
 from tinker_cookbook.supervised.train import Config as TrainConfig
 from tinker_cookbook.supervised.train import main as train
@@ -52,9 +53,11 @@ class Config:
   seed: int = 0
   max_steps: int | None = None
   save_every: int = 0
+  behavior_if_log_dir_exists: cli_utils.LogdirBehavior = "resume"
 
 
 def main(config: Config) -> None:
+  cli_utils.check_log_dir(config.log_path, behavior_if_exists=config.behavior_if_log_dir_exists)
   asyncio.run(
     train(
       TrainConfig(

--- a/examples/sft/gsm8k/vllm_eval.py
+++ b/examples/sft/gsm8k/vllm_eval.py
@@ -19,18 +19,20 @@ def extract(t):
 
 
 def main():
-  ap = argparse.ArgumentParser()
-  ap.add_argument("--path", required=True)
-  ap.add_argument("--data", default="gsm8k_test.json")
-  a = ap.parse_args()
-  data = json.load(open(a.data))
-  llm = LLM(model=a.path, dtype="bfloat16", gpu_memory_utilization=0.85, max_model_len=1024, enforce_eager=True)
+  parser = argparse.ArgumentParser()
+  parser.add_argument("--path", required=True)
+  parser.add_argument("--data", default="gsm8k_test.json")
+  args = parser.parse_args()
+  data = json.load(open(args.data))
+  llm = LLM(model=args.path, dtype="bfloat16", gpu_memory_utilization=0.85, max_model_len=1024, enforce_eager=True)
   sp = SamplingParams(temperature=0.0, max_tokens=256, stop=["\nQuestion:"])
   t0 = time.time()
   outs = llm.generate([d["prompt"] for d in data], sp)
   dt = time.time() - t0
   correct = sum(int(extract(o.outputs[0].text) == d["gold"]) for d, o in zip(data, outs))
-  print(f"[VLLM] {a.path} 0-shot GSM8K acc = {correct / len(data):.1%} on {len(data)} problems in {dt:.1f}s")
+  print("***************************************************************")
+  print(f"[VLLM] {args.path} 0-shot GSM8K acc = {correct / len(data):.1%} on {len(data)} problems in {dt:.1f}s")
+  print("***************************************************************")
 
 
 if __name__ == "__main__":

--- a/examples/sft/gsm8k/vllm_eval.py
+++ b/examples/sft/gsm8k/vllm_eval.py
@@ -1,0 +1,37 @@
+import argparse
+import json
+import re
+import time
+
+from vllm import LLM, SamplingParams
+
+ANS_RE = re.compile(r"-?\d[\d,]*")
+
+
+def extract(t):
+  t = re.split(r"\n\s*Question:", t)[0]
+  if "####" in t:
+    m = ANS_RE.search(t.split("####")[-1])
+    if m:
+      return m.group(0).replace(",", "")
+  n = ANS_RE.findall(t)
+  return n[-1].replace(",", "") if n else None
+
+
+def main():
+  ap = argparse.ArgumentParser()
+  ap.add_argument("--path", required=True)
+  ap.add_argument("--data", default="gsm8k_test.json")
+  a = ap.parse_args()
+  data = json.load(open(a.data))
+  llm = LLM(model=a.path, dtype="bfloat16", gpu_memory_utilization=0.85, max_model_len=1024, enforce_eager=True)
+  sp = SamplingParams(temperature=0.0, max_tokens=256, stop=["\nQuestion:"])
+  t0 = time.time()
+  outs = llm.generate([d["prompt"] for d in data], sp)
+  dt = time.time() - t0
+  correct = sum(int(extract(o.outputs[0].text) == d["gold"]) for d, o in zip(data, outs))
+  print(f"[VLLM] {a.path} 0-shot GSM8K acc = {correct / len(data):.1%} on {len(data)} problems in {dt:.1f}s")
+
+
+if __name__ == "__main__":
+  main()

--- a/src/server/checkpoint.py
+++ b/src/server/checkpoint.py
@@ -1,0 +1,40 @@
+import os
+import shlex
+import subprocess
+from typing import Protocol
+
+
+class CheckpointRestorer(Protocol):
+  def checkpoint(self, pid: int) -> None:
+    pass
+
+  def restore(self, pid: int) -> None:
+    pass
+
+
+class CudaCheckpointRestorer:
+  def __init__(self, cuda_checkpoint_bin: str | None = None, timeout_ms: int | None = None):
+    self.cuda_checkpoint_bin = cuda_checkpoint_bin or os.getenv("CUDA_CHECKPOINT_BIN", "cuda-checkpoint")
+    self.timeout_ms = timeout_ms
+
+  def checkpoint(self, pid: int) -> None:
+    lock_args = ["--action", "lock", "--pid", str(pid)]
+    if self.timeout_ms is not None:
+      lock_args.extend(["--timeout", str(self.timeout_ms)])
+
+    self.run_cuda_checkpoint(lock_args)
+    self.run_cuda_checkpoint(["--action", "checkpoint", "--pid", str(pid)])
+
+  def restore(self, pid: int) -> None:
+    self.run_cuda_checkpoint(["--action", "restore", "--pid", str(pid)])
+    self.run_cuda_checkpoint(["--action", "unlock", "--pid", str(pid)])
+
+  def run_cuda_checkpoint(self, args: list[str]) -> None:
+    full_argv = [self.cuda_checkpoint_bin, *args]
+    result = subprocess.run(full_argv, capture_output=True, check=False, text=True)
+    if result.returncode != 0:
+      stderr = result.stderr.strip()
+      stdout = result.stdout.strip()
+      detail = stderr or stdout or f"exit code {result.returncode}"
+      rendered_argv = " ".join(shlex.quote(arg) for arg in full_argv)
+      raise RuntimeError(f"{rendered_argv} failed: {detail}")

--- a/src/server/clock_cycle.py
+++ b/src/server/clock_cycle.py
@@ -11,13 +11,14 @@ from opentelemetry import context as otel_context
 from opentelemetry import propagate, trace
 from store import get_store
 from trainer import Datum, LoraConfig, TrainerEngine
+from trainer_scheduler import TrainerSchedulerClient
 
 tracer = trace.get_tracer(__name__)
 
 engine = TrainerEngine()
 
 
-def _parse_datum(raw: dict) -> Datum:
+def parse_datum(raw: dict) -> Datum:
   """Convert wire-format datum (with chunks) to our flat Datum type."""
   chunks = raw.get("model_input", {}).get("chunks", [])
   tokens: list[int] = []
@@ -28,165 +29,220 @@ def _parse_datum(raw: dict) -> Datum:
   return Datum(model_input=tokens, loss_fn_inputs=loss_inputs)
 
 
+async def process_batch(store, batch: list[dict]) -> None:
+  m_id = batch[0].get("model_id", "default")
+
+  with tracer.start_as_current_span("clock_cycle_batch") as batch_span:
+    batch_span.set_attribute("batch_size", len(batch))
+    batch_span.set_attribute("model_id", m_id)
+
+    print(f"\n[CLOCK CYCLE] Popped {len(batch)} requests for tenant: {m_id}")
+
+    skip_adapter_switch = {"create_model", "create_model_from_state"}
+    if not any(r.get("type") in skip_adapter_switch for r in batch):
+      try:
+        await asyncio.to_thread(engine.set_active_adapter, m_id)
+      except Exception as e:
+        print(f"Failed to set adapter {m_id}: {e}")
+        for r in batch:
+          await store.set_future(r["req_id"], {"type": "RequestFailedResponse", "error_message": str(e)})
+        return
+
+    for r in batch:
+      req_id = r["req_id"]
+      req_type = r["type"]
+
+      carrier = r.get("trace_context", {})
+      ctx = propagate.extract(carrier) if carrier else None
+      token = otel_context.attach(ctx) if ctx else None
+
+      try:
+        match req_type:
+          case "create_model":
+            base_model = r["base_model"]
+            training_mode = r.get("training_mode", "lora")
+            if training_mode == "full":
+              await asyncio.to_thread(engine.create_full_model, m_id, base_model)
+              await store.set_future(
+                req_id,
+                {
+                  "model_id": m_id,
+                  "is_lora": False,
+                  "type": "create_model",
+                },
+              )
+            else:
+              raw_config = r.get("lora_config") or {}
+              lora_config = LoraConfig(**{k: v for k, v in raw_config.items() if k in LoraConfig.model_fields})
+
+              await asyncio.to_thread(engine.load_base_model, base_model)
+              await asyncio.to_thread(engine.create_adapter, m_id, lora_config)
+
+              await store.set_future(
+                req_id,
+                {
+                  "model_id": m_id,
+                  "is_lora": True,
+                  "lora_rank": lora_config.rank,
+                  "type": "create_model",
+                },
+              )
+
+          case "create_model_from_state":
+            state_path = r["state_path"]
+            restore_optimizer = bool(r.get("restore_optimizer", False))
+            result = await asyncio.to_thread(engine.load_from_state, m_id, state_path, restore_optimizer)
+            result["type"] = "create_model_from_state"
+            await store.set_future(req_id, result)
+
+          case "forward_backward":
+            raw_data = r["data"]
+            loss_fn = r["loss_fn"]
+            loss_config = r.get("loss_config")
+
+            typed_data = [parse_datum(item) for item in raw_data]
+
+            result = await asyncio.to_thread(engine.forward_backward, typed_data, loss_fn, loss_config, m_id)
+            result["type"] = "forward_backward"
+            await store.set_future(req_id, result)
+
+          case "optim_step":
+            adam_params = r["adam_params"]
+            result = await asyncio.to_thread(engine.optim_step, adam_params, m_id)
+            result["type"] = "optim_step"
+            await store.set_future(req_id, result)
+
+          case "sample":
+            prompt_tokens = r["prompt_tokens"]
+            max_tokens = r["max_tokens"]
+            num_samples = r["num_samples"]
+            temperature = r.get("temperature", 0.0)
+            prompt_logprobs = bool(r.get("prompt_logprobs", False))
+
+            result = await asyncio.to_thread(
+              engine.generate,
+              prompt_tokens,
+              max_tokens,
+              num_samples,
+              temperature,
+              m_id,
+              prompt_logprobs,
+            )
+            result["type"] = "sample"
+            await store.set_future(req_id, result)
+
+          case "save_state":
+            state_path = r["state_path"]
+            include_optimizer = bool(r.get("include_optimizer", False))
+            kind = r.get("kind", "state")
+
+            result = await asyncio.to_thread(engine.save_state, m_id, state_path, include_optimizer, kind)
+            # SDK's save_state() returns SaveWeightsResponse which requires type="save_weights".
+            result["type"] = "save_weights"
+            await store.set_future(req_id, result)
+
+          case "load_weights":
+            state_path = r["state_path"]
+            restore_optimizer = bool(r.get("restore_optimizer", False))
+            await asyncio.to_thread(engine.load_from_state, m_id, state_path, restore_optimizer)
+            await store.set_future(req_id, {"path": state_path, "type": "load_weights"})
+
+          case "save_weights_for_sampler":
+            saved_path = r.get("path")
+            if engine.is_full_model(m_id):
+              # Full fine-tuning has no adapter; persist the whole HF model dir. Map the
+              # tinker://<model>/sampler_weights/<name> ref to a real filesystem path.
+              ref = saved_path or ""
+              rel = ref[len("tinker://") :] if ref.startswith("tinker://") else ref.lstrip("/")
+              saved_path = os.path.join(os.getenv("OPEN_RL_TMP_DIR", "/tmp/open-rl"), "sampler_full", rel)
+              await asyncio.to_thread(engine.save_state, m_id, saved_path, False, "sampler")
+            else:
+              await asyncio.to_thread(engine.save_adapter, m_id, r.get("alias"))
+            await store.set_future(
+              req_id,
+              {
+                "path": saved_path,
+                "sampling_session_id": r.get("sampling_session_id"),
+                "type": "save_weights_for_sampler",
+              },
+            )
+
+          case "save_weights":
+            await asyncio.to_thread(engine.save_adapter, m_id, r.get("alias"))
+            await store.set_future(req_id, {"status": "ok", "type": req_type})
+
+          case _:
+            print(f"Warning: Unhandled request type: {req_type}")
+            await store.set_future(req_id, {"type": "RequestFailedResponse", "error_message": f"Unknown request type: {req_type}"})
+
+      except Exception as e:
+        traceback.print_exc()
+        await store.set_future(req_id, {"type": "RequestFailedResponse", "error_message": str(e)})
+      finally:
+        if token:
+          otel_context.detach(token)
+
+
 async def clock_cycle_loop() -> None:
   store = get_store()
+  scheduler_socket = os.getenv("OPEN_RL_SCHEDULER_SOCKET")
+  worker_run_id = os.getenv("OPEN_RL_WORKER_RUN_ID") if scheduler_socket else None
+  scheduler_client: TrainerSchedulerClient | None = None
+
+  if scheduler_socket:
+    if not worker_run_id:
+      raise RuntimeError("OPEN_RL_WORKER_RUN_ID is required when OPEN_RL_SCHEDULER_SOCKET is set")
+    scheduler_client = TrainerSchedulerClient(scheduler_socket)
+    await scheduler_client.register(worker_run_id, os.getpid())
+    print(f"[WORKER] Registered run '{worker_run_id}' with trainer scheduler at {scheduler_socket}.")
 
   print("[WORKER] Training worker started.")
 
-  while True:
-    try:
-      batch = await store.get_requests()
-      if not batch:
-        await asyncio.sleep(0.1)
-        continue
+  try:
+    while True:
+      try:
+        batch = await store.get_requests_for_model(worker_run_id) if worker_run_id else await store.get_requests()
+        if not batch:
+          await asyncio.sleep(0.1)
+          continue
 
-      m_id = batch[0].get("model_id", "default")
-
-      with tracer.start_as_current_span("clock_cycle_batch") as batch_span:
-        batch_span.set_attribute("batch_size", len(batch))
-        batch_span.set_attribute("model_id", m_id)
-
-        print(f"\n[CLOCK CYCLE] Popped {len(batch)} requests for tenant: {m_id}")
-
-        SKIP_ADAPTER_SWITCH = {"create_model", "create_model_from_state"}
-        if not any(r.get("type") in SKIP_ADAPTER_SWITCH for r in batch):
-          try:
-            await asyncio.to_thread(engine.set_active_adapter, m_id)
-          except Exception as e:
-            print(f"Failed to set adapter {m_id}: {e}")
+        processed = False
+        try:
+          if scheduler_client is not None:
+            async with scheduler_client.acquire(worker_run_id):
+              await process_batch(store, batch)
+              processed = True
+          else:
+            await process_batch(store, batch)
+            processed = True
+        except Exception as e:
+          traceback.print_exc()
+          if not processed:
             for r in batch:
               await store.set_future(r["req_id"], {"type": "RequestFailedResponse", "error_message": str(e)})
-            continue
 
-        for r in batch:
-          req_id = r["req_id"]
-          req_type = r["type"]
+      except asyncio.CancelledError:
+        break
+      except Exception as e:
+        print(f"Error in clock cycle loop: {e}")
+        traceback.print_exc()
 
-          carrier = r.get("trace_context", {})
-          ctx = propagate.extract(carrier) if carrier else None
-          token = otel_context.attach(ctx) if ctx else None
+        import redis
 
-          try:
-            match req_type:
-              case "create_model":
-                base_model = r["base_model"]
-                raw_config = r.get("lora_config") or {}
-                lora_config = LoraConfig(**{k: v for k, v in raw_config.items() if k in LoraConfig.model_fields})
+        if isinstance(e, redis.exceptions.ConnectionError):
+          print("[worker] Destroying StateStore singleton to force Redis reconnection...")
+          import store as store_mod
 
-                await asyncio.to_thread(engine.load_base_model, base_model)
-                await asyncio.to_thread(engine.create_adapter, m_id, lora_config)
+          store_mod._store_instance = None
+          store = store_mod.get_store()
 
-                await store.set_future(
-                  req_id,
-                  {
-                    "model_id": m_id,
-                    "is_lora": True,
-                    "lora_rank": lora_config.rank,
-                    "type": "create_model",
-                  },
-                )
-
-              case "create_model_from_state":
-                state_path = r["state_path"]
-                restore_optimizer = bool(r.get("restore_optimizer", False))
-                result = await asyncio.to_thread(engine.load_from_state, m_id, state_path, restore_optimizer)
-                result["type"] = "create_model_from_state"
-                await store.set_future(req_id, result)
-
-              case "forward_backward":
-                raw_data = r["data"]
-                loss_fn = r["loss_fn"]
-                loss_config = r.get("loss_config")
-
-                typed_data = [_parse_datum(item) for item in raw_data]
-
-                result = await asyncio.to_thread(engine.forward_backward, typed_data, loss_fn, loss_config, m_id)
-                result["type"] = "forward_backward"
-                await store.set_future(req_id, result)
-
-              case "optim_step":
-                adam_params = r["adam_params"]
-                result = await asyncio.to_thread(engine.optim_step, adam_params, m_id)
-                result["type"] = "optim_step"
-                await store.set_future(req_id, result)
-
-              case "sample":
-                prompt_tokens = r["prompt_tokens"]
-                max_tokens = r["max_tokens"]
-                num_samples = r["num_samples"]
-                temperature = r.get("temperature", 0.0)
-                prompt_logprobs = bool(r.get("prompt_logprobs", False))
-
-                result = await asyncio.to_thread(
-                  engine.generate,
-                  prompt_tokens,
-                  max_tokens,
-                  num_samples,
-                  temperature,
-                  m_id,
-                  prompt_logprobs,
-                )
-                result["type"] = "sample"
-                await store.set_future(req_id, result)
-
-              case "save_state":
-                state_path = r["state_path"]
-                include_optimizer = bool(r.get("include_optimizer", False))
-                kind = r.get("kind", "state")
-
-                result = await asyncio.to_thread(engine.save_state, m_id, state_path, include_optimizer, kind)
-                # SDK's save_state() returns SaveWeightsResponse which requires type="save_weights".
-                result["type"] = "save_weights"
-                await store.set_future(req_id, result)
-
-              case "load_weights":
-                state_path = r["state_path"]
-                restore_optimizer = bool(r.get("restore_optimizer", False))
-                await asyncio.to_thread(engine.load_from_state, m_id, state_path, restore_optimizer)
-                await store.set_future(req_id, {"path": state_path, "type": "load_weights"})
-
-              case "save_weights_for_sampler":
-                await asyncio.to_thread(engine.save_adapter, m_id, r.get("alias"))
-                await store.set_future(
-                  req_id,
-                  {
-                    "path": r.get("path"),
-                    "sampling_session_id": r.get("sampling_session_id"),
-                    "type": "save_weights_for_sampler",
-                  },
-                )
-
-              case "save_weights":
-                await asyncio.to_thread(engine.save_adapter, m_id, r.get("alias"))
-                await store.set_future(req_id, {"status": "ok", "type": req_type})
-
-              case _:
-                print(f"Warning: Unhandled request type: {req_type}")
-                await store.set_future(req_id, {"type": "RequestFailedResponse", "error_message": f"Unknown request type: {req_type}"})
-
-          except Exception as e:
-            traceback.print_exc()
-            await store.set_future(req_id, {"type": "RequestFailedResponse", "error_message": str(e)})
-          finally:
-            if token:
-              otel_context.detach(token)
-
-    except asyncio.CancelledError:
-      break
-    except Exception as e:
-      print(f"Error in clock cycle loop: {e}")
-      traceback.print_exc()
-
-      import redis
-
-      if isinstance(e, redis.exceptions.ConnectionError):
-        print("[worker] Destroying StateStore singleton to force Redis reconnection...")
-        import store as store_mod
-
-        store_mod._store_instance = None
-        store = store_mod.get_store()
-
-      await asyncio.sleep(1)
+        await asyncio.sleep(1)
+  finally:
+    if scheduler_client is not None and worker_run_id:
+      try:
+        await scheduler_client.unregister(worker_run_id)
+      finally:
+        await scheduler_client.close()
 
 
 def main() -> None:
@@ -197,26 +253,31 @@ def main() -> None:
   print(f"-> Hardware : CUDA_VISIBLE_DEVICES={cuda_devs}\n")
 
   preload_target = os.getenv("BASE_MODEL")
+  scheduled_worker = bool(os.getenv("OPEN_RL_SCHEDULER_SOCKET") and os.getenv("OPEN_RL_WORKER_RUN_ID"))
   is_ready = False
-  if preload_target:
+  if preload_target and not scheduled_worker:
     engine.load_base_model(preload_target)
     is_ready = True
   else:
-    print("[WARNING] BASE_MODEL not provided. Cold-start penalty will apply on first request.")
+    if scheduled_worker:
+      print("[WORKER] Scheduler mode enabled; deferring model materialization until acquire.")
+    else:
+      print("[WARNING] BASE_MODEL not provided. Cold-start penalty will apply on first request.")
     is_ready = True
 
-  probe_app = FastAPI()
+  if os.getenv("OPEN_RL_DISABLE_WORKER_HEALTHZ") != "1":
+    probe_app = FastAPI()
 
-  @probe_app.get("/healthz")
-  def healthz():
-    if is_ready:
-      return {"status": "ready"}
-    raise HTTPException(status_code=503, detail="Model Loading")
+    @probe_app.get("/healthz")
+    def healthz():
+      if is_ready:
+        return {"status": "ready"}
+      raise HTTPException(status_code=503, detail="Model Loading")
 
-  def run_probe_server():
-    uvicorn.run(probe_app, host="0.0.0.0", port=8000, log_level="warning")
+    def run_probe_server():
+      uvicorn.run(probe_app, host="0.0.0.0", port=8000, log_level="warning")
 
-  threading.Thread(target=run_probe_server, daemon=True).start()
+    threading.Thread(target=run_probe_server, daemon=True).start()
   asyncio.run(clock_cycle_loop())
 
 

--- a/src/server/clock_cycle.py
+++ b/src/server/clock_cycle.py
@@ -133,11 +133,13 @@ async def process_batch(store, batch: list[dict]) -> None:
 
           case "save_state":
             state_path = r["state_path"]
+            response_path = r.get("response_path")
             include_optimizer = bool(r.get("include_optimizer", False))
             kind = r.get("kind", "state")
 
             result = await asyncio.to_thread(engine.save_state, m_id, state_path, include_optimizer, kind)
-            # SDK's save_state() returns SaveWeightsResponse which requires type="save_weights".
+            if response_path is not None:
+              result["path"] = response_path
             result["type"] = "save_weights"
             await store.set_future(req_id, result)
 
@@ -148,20 +150,18 @@ async def process_batch(store, batch: list[dict]) -> None:
             await store.set_future(req_id, {"path": state_path, "type": "load_weights"})
 
           case "save_weights_for_sampler":
-            saved_path = r.get("path")
+            response_path = r.get("path")
             if engine.is_full_model(m_id):
-              # Full fine-tuning has no adapter; persist the whole HF model dir. Map the
-              # tinker://<model>/sampler_weights/<name> ref to a real filesystem path.
-              ref = saved_path or ""
+              ref = response_path or ""
               rel = ref[len("tinker://") :] if ref.startswith("tinker://") else ref.lstrip("/")
-              saved_path = os.path.join(os.getenv("OPEN_RL_TMP_DIR", "/tmp/open-rl"), "sampler_full", rel)
-              await asyncio.to_thread(engine.save_state, m_id, saved_path, False, "sampler")
+              local_path = os.path.join(os.getenv("OPEN_RL_TMP_DIR", "/tmp/open-rl"), "sampler_full", rel)
+              await asyncio.to_thread(engine.save_state, m_id, local_path, False, "sampler")
             else:
               await asyncio.to_thread(engine.save_adapter, m_id, r.get("alias"))
             await store.set_future(
               req_id,
               {
-                "path": saved_path,
+                "path": response_path,
                 "sampling_session_id": r.get("sampling_session_id"),
                 "type": "save_weights_for_sampler",
               },

--- a/src/server/gateway.py
+++ b/src/server/gateway.py
@@ -16,6 +16,7 @@ from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from store import get_store
+from worker_launcher import launch_worker
 
 store = get_store()
 
@@ -51,7 +52,8 @@ VLLM_URL = os.getenv("VLLM_URL", "http://127.0.0.1:8001")
 
 
 def is_single_process_mode() -> bool:
-  return bool(os.getenv("BASE_MODEL")) and not bool(os.getenv("REDIS_URL"))
+  # A shared store (Redis or a file-backed dir) means workers run as separate processes.
+  return bool(os.getenv("BASE_MODEL")) and not (os.getenv("REDIS_URL") or os.getenv("OPEN_RL_STORE_DIR"))
 
 
 def get_sampler_backend() -> str:
@@ -188,7 +190,7 @@ async def client_config(_: dict):
 
 @app.post("/api/v1/create_session")
 async def create_session(_: dict):
-  return {"session_id": "sess-real-123", "type": "create_session"}
+  return {"session_id": str(uuid.uuid4()), "type": "create_session"}
 
 
 @app.post("/api/v1/session_heartbeat")
@@ -202,7 +204,24 @@ async def create_model(req: dict):
   base_model = req.get("base_model")
   if not base_model:
     return JSONResponse(status_code=400, content={"error": "base_model is required"})
-  model_id = str(uuid.uuid4())
+  # OPEN_RL_TRAINING_MODE=full forces every job to full fine-tuning, so the stock (LoRA-only)
+  # tinker SDK create_lora_training_client() yields a full-FT model with no client changes.
+  force_full = os.getenv("OPEN_RL_TRAINING_MODE", "").lower() == "full"
+  training_mode = "full" if force_full or req.get("training_mode") == "full" or req.get("full_finetune") or req.get("is_lora") is False else "lora"
+  session_id = req.get("session_id")
+  model_seq_id = req.get("model_seq_id")
+  if not session_id:
+    return JSONResponse(status_code=400, content={"error": "session_id is required"})
+  if model_seq_id is None:
+    return JSONResponse(status_code=400, content={"error": "model_seq_id is required"})
+  model_id = f"{session_id}-{model_seq_id}"
+  if training_mode == "full" and (scheduler_socket := os.getenv("OPEN_RL_SCHEDULER_SOCKET")):
+    try:
+      process = launch_worker(model_id, scheduler_socket)
+    except Exception as exc:
+      return JSONResponse(status_code=500, content={"error": f"failed to launch trainer worker: {exc}"})
+    print(f"[GATEWAY] Launched full fine-tuning worker pid={process.pid} run_id={model_id}.")
+
   req_id = await _enqueue(
     {
       "req_id": model_id,
@@ -210,6 +229,7 @@ async def create_model(req: dict):
       "type": "create_model",
       "base_model": base_model,
       "lora_config": req.get("lora_config") or {},
+      "training_mode": training_mode,
     }
   )
   return {"request_id": req_id}

--- a/src/server/gateway.py
+++ b/src/server/gateway.py
@@ -1,6 +1,7 @@
 # This file contains the FastAPI server entry point and request handlers for the Open-RL API backend.
 
 import asyncio
+import json
 import logging
 import os
 import time
@@ -77,6 +78,43 @@ def sampler_session_id(model_id: str, seq_id: int | str) -> str:
 
 def sampler_weights_path(model_id: str, name: str) -> str:
   return f"tinker://{model_id}/sampler_weights/{name}"
+
+
+def weights_path(model_id: str, name: str) -> str:
+  return f"tinker://{model_id}/weights/{name}"
+
+
+def parse_tinker_path(path: str) -> tuple[str, str, str] | None:
+  if not path.startswith("tinker://"):
+    return None
+  parts = path[len("tinker://") :].split("/", 2)
+  if len(parts) != 3 or not all(parts):
+    return None
+  return parts[0], parts[1], parts[2]
+
+
+def local_weights_path(model_id: str, name: str) -> str:
+  return os.path.join(TMP_DIR, "checkpoints", model_id, "weights", name)
+
+
+def resolve_weights_path(path: str, model_id: str | None = None) -> str:
+  if os.path.isabs(path):
+    return path
+
+  parsed = parse_tinker_path(path)
+  if parsed is not None and parsed[1] == "weights":
+    return local_weights_path(parsed[0], parsed[2])
+
+  if model_id is not None:
+    return local_weights_path(model_id, path)
+
+  return os.path.join(TMP_DIR, "checkpoints", path)
+
+
+def weights_response_path(path: str, model_id: str) -> str:
+  if os.path.isabs(path) or path.startswith("tinker://"):
+    return path
+  return weights_path(model_id, path)
 
 
 def base_model_id_from_sampling_ref(model_id: str | None) -> str | None:
@@ -241,8 +279,7 @@ async def create_model_from_state(req: dict):
   state_path = req.get("state_path")
   if not state_path:
     return JSONResponse(status_code=400, content={"error": "state_path is required"})
-  # Resolve relative names under TMP_DIR/checkpoints, leave absolute paths alone.
-  resolved_path = state_path if os.path.isabs(state_path) else os.path.join(TMP_DIR, "checkpoints", state_path)
+  resolved_path = resolve_weights_path(state_path)
   model_id = str(uuid.uuid4())
   req_id = await _enqueue(
     {
@@ -269,6 +306,39 @@ async def get_info(req: dict):
     "lora_rank": 16,
     "model_name": model_name,
     "type": "get_info",
+  }
+
+
+@app.post("/api/v1/weights_info")
+async def weights_info(req: dict):
+  path = req.get("tinker_path") or req.get("path")
+  if not path:
+    return JSONResponse(status_code=400, content={"error": "tinker_path is required"})
+
+  metadata_path = os.path.join(resolve_weights_path(path), "metadata.json")
+  if not os.path.exists(metadata_path):
+    return JSONResponse(status_code=404, content={"error": f"No checkpoint metadata found for {path}"})
+
+  with open(metadata_path) as f:
+    metadata = json.load(f)
+
+  base_model = metadata.get("base_model")
+  if not base_model:
+    return JSONResponse(status_code=400, content={"error": f"metadata.json at {metadata_path} missing base_model"})
+
+  is_lora = metadata.get("training_mode") != "full"
+  if not is_lora and os.getenv("OPEN_RL_TRAINING_MODE", "").lower() == "full":
+    # The stock SDK asserts that create_training_client_from_state is LoRA-shaped.
+    # In full-mode the server ignores the LoRA shape and creates/loads a full worker.
+    is_lora = True
+
+  return {
+    "base_model": base_model,
+    "is_lora": is_lora,
+    "lora_rank": metadata.get("lora_rank", 16) if is_lora else None,
+    "train_unembed": metadata.get("train_unembed") if "train_unembed" in metadata else (True if is_lora else None),
+    "train_mlp": metadata.get("train_mlp") if "train_mlp" in metadata else (True if is_lora else None),
+    "train_attn": metadata.get("train_attn") if "train_attn" in metadata else (True if is_lora else None),
   }
 
 
@@ -319,12 +389,6 @@ async def optim_step(req: dict):
 
 @app.post("/api/v1/save_weights_for_sampler")
 async def save_weights_for_sampler(req: dict):
-  """TrainingClient.save_weights_for_sampler().
-
-  The SDK uses this for both named sampler checkpoints and ephemeral
-  save_weights_and_get_sampling_client() snapshots. Route it through the trainer
-  queue so the sampler always sees weights saved after prior training requests.
-  """
   model_id = req.get("model_id")
   if not model_id:
     return JSONResponse(status_code=400, content={"error": "model_id is required"})
@@ -333,12 +397,13 @@ async def save_weights_for_sampler(req: dict):
   alias = req.get("name") or req.get("alias") or req.get("path")
 
   session_id = sampler_session_id(model_id, seq_id)
+  path = sampler_weights_path(model_id, alias) if alias else session_id
   req_id = await _enqueue(
     {
       "model_id": model_id,
       "type": "save_weights_for_sampler",
       "alias": alias,
-      "path": sampler_weights_path(model_id, alias) if alias else None,
+      "path": path,
       "sampling_session_id": session_id,
     }
   )
@@ -347,20 +412,14 @@ async def save_weights_for_sampler(req: dict):
 
 @app.post("/api/v1/save_weights")
 async def save_weights(req: dict):
-  """TrainingClient.save_weights() / save_state() — persists adapter to TMP_DIR/checkpoints/<alias>.
-
-  This is the endpoint the tinker SDK hits for both save_weights() and save_state().
-  When `path` is provided we treat it as a named checkpoint alias and resolve to
-  TMP_DIR/checkpoints/<alias> (or leave absolute paths alone), so subsequent
-  `create_training_client_from_state(alias)` calls can find the adapter.
-  """
   model_id = req.get("model_id")
   if not model_id:
     return JSONResponse(status_code=400, content={"error": "model_id is required"})
 
   seq_id = req.get("seq_id") or int(time.time() * 1000)
   alias = req.get("path") or f"{model_id}-samp-{seq_id}"
-  state_path = alias if os.path.isabs(alias) else os.path.join(TMP_DIR, "checkpoints", alias)
+  state_path = resolve_weights_path(alias, model_id)
+  response_path = weights_response_path(alias, model_id)
 
   req_id = str(uuid.uuid4())
   await _enqueue(
@@ -369,6 +428,7 @@ async def save_weights(req: dict):
       "model_id": model_id,
       "type": "save_state",
       "state_path": state_path,
+      "response_path": response_path,
       "include_optimizer": bool(req.get("include_optimizer", False)),
       "kind": "weights",
     }
@@ -378,7 +438,6 @@ async def save_weights(req: dict):
 
 @app.post("/api/v1/load_weights")
 async def load_weights(req: dict):
-  """TrainingClient.load_state() / load_state_with_optimizer()."""
   model_id = req.get("model_id")
   state_path = req.get("path")
   if not model_id:
@@ -386,7 +445,7 @@ async def load_weights(req: dict):
   if not state_path:
     return JSONResponse(status_code=400, content={"error": "path is required"})
 
-  resolved_path = state_path if os.path.isabs(state_path) else os.path.join(TMP_DIR, "checkpoints", state_path)
+  resolved_path = resolve_weights_path(state_path, model_id)
   req_id = await _enqueue(
     {
       "model_id": model_id,

--- a/src/server/store.py
+++ b/src/server/store.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import os
+import time
 from abc import ABC, abstractmethod
 from typing import Any
 
@@ -18,6 +19,11 @@ class RequestStore(ABC):
   @abstractmethod
   async def get_requests(self) -> list[dict[str, Any]]:
     """Block until at least 1 request is available, then return all currently queued requests."""
+    pass
+
+  @abstractmethod
+  async def get_requests_for_model(self, model_id: str) -> list[dict[str, Any]]:
+    """Block for one model queue, then drain only that model's currently queued requests."""
     pass
 
   @abstractmethod
@@ -74,6 +80,21 @@ class InMemoryStore(RequestStore):
 
       # If completely empty, remove from rotation
       if queue.empty():
+        self.active_tenants.remove(model_id)
+
+      return batch
+
+  async def get_requests_for_model(self, model_id: str) -> list[dict[str, Any]]:
+    async with self.active_tenants_cv:
+      while model_id not in self.queues or self.queues[model_id].empty():
+        await self.active_tenants_cv.wait()
+
+      queue = self.queues[model_id]
+      batch = [queue.get_nowait()]
+      while not queue.empty():
+        batch.append(queue.get_nowait())
+
+      if queue.empty() and model_id in self.active_tenants:
         self.active_tenants.remove(model_id)
 
       return batch
@@ -155,6 +176,26 @@ class RedisStore(RequestStore):
 
     return batch
 
+  async def get_requests_for_model(self, model_id: str) -> list[dict[str, Any]]:
+    queue_key = f"open_rl:queue:{model_id}"
+    result = await self.redis.blpop(queue_key, timeout=5)
+    if not result:
+      return []
+
+    batch = [json.loads(result[1])]
+    while True:
+      item = await self.redis.lpop(queue_key)
+      if not item:
+        break
+      batch.append(json.loads(item))
+
+    q_len = await self.redis.llen(queue_key)
+    if q_len == 0:
+      await self.redis.lrem(self.active_list, 0, model_id)
+      await self.redis.srem(self.active_set, model_id)
+
+    return batch
+
   async def set_future(self, req_id: str, result: dict[str, Any]) -> None:
     if result.get("status") == "pending":
       return
@@ -177,6 +218,90 @@ class RedisStore(RequestStore):
     return {"type": "try_again", "request_id": req_id, "queue_state": "active"}
 
 
+class FileStore(RequestStore):
+  """Cross-process store backed by a shared directory — no external server (Redis) needed.
+
+  Works across separately-launched worker subprocesses on the same machine via the filesystem,
+  so it's the local-dev/no-Redis option for the dynamic-worker path. Requests and futures are
+  written as atomic JSON files (write-temp + rename); consumers poll and drain.
+  """
+
+  def __init__(self, root: str):
+    self.root = root
+    self.qroot = os.path.join(root, "queue")
+    self.froot = os.path.join(root, "future")
+    os.makedirs(self.qroot, exist_ok=True)
+    os.makedirs(self.froot, exist_ok=True)
+
+  def _qdir(self, model_id: str) -> str:
+    return os.path.join(self.qroot, model_id.replace("/", "__"))
+
+  def _write_atomic(self, path: str, data: dict[str, Any]) -> None:
+    tmp = f"{path}.{os.getpid()}.tmp"
+    with open(tmp, "w") as f:
+      json.dump(data, f)
+    os.rename(tmp, path)
+
+  def _drain_dir(self, d: str) -> list[dict[str, Any]]:
+    if not os.path.isdir(d):
+      return []
+    batch = []
+    for fn in sorted(fn for fn in os.listdir(d) if fn.endswith(".json")):
+      p = os.path.join(d, fn)
+      try:
+        with open(p) as f:
+          data = json.load(f)
+        os.unlink(p)
+        batch.append(data)
+      except (FileNotFoundError, json.JSONDecodeError):
+        continue
+    return batch
+
+  async def put_request(self, req_data: dict[str, Any]) -> None:
+    d = self._qdir(req_data.get("model_id", "default"))
+    os.makedirs(d, exist_ok=True)
+    name = f"{time.time_ns()}_{req_data.get('req_id', '')}.json"
+    await asyncio.to_thread(self._write_atomic, os.path.join(d, name), req_data)
+
+  async def get_requests(self) -> list[dict[str, Any]]:
+    deadline = time.time() + 2.0
+    while time.time() < deadline:
+      for model_dir in sorted(os.listdir(self.qroot)) if os.path.isdir(self.qroot) else []:
+        batch = await asyncio.to_thread(self._drain_dir, os.path.join(self.qroot, model_dir))
+        if batch:
+          return batch
+      await asyncio.sleep(0.1)
+    return []
+
+  async def get_requests_for_model(self, model_id: str) -> list[dict[str, Any]]:
+    d = self._qdir(model_id)
+    deadline = time.time() + 2.0
+    while time.time() < deadline:
+      batch = await asyncio.to_thread(self._drain_dir, d)
+      if batch:
+        return batch
+      await asyncio.sleep(0.1)
+    return []
+
+  async def set_future(self, req_id: str, result: dict[str, Any]) -> None:
+    if result.get("status") == "pending":
+      return
+    await asyncio.to_thread(self._write_atomic, os.path.join(self.froot, f"{req_id}.json"), result)
+
+  async def get_future(self, req_id: str, timeout: float) -> dict[str, Any] | None:
+    p = os.path.join(self.froot, f"{req_id}.json")
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+      if os.path.exists(p):
+        try:
+          with open(p) as f:
+            return json.load(f)
+        except (FileNotFoundError, json.JSONDecodeError):
+          pass
+      await asyncio.sleep(0.05)
+    return {"type": "try_again", "request_id": req_id, "queue_state": "active"}
+
+
 # Global singleton factory
 _store_instance = None
 
@@ -185,9 +310,13 @@ def get_store() -> RequestStore:
   global _store_instance
   if _store_instance is None:
     redis_url = os.environ.get("REDIS_URL")
+    store_dir = os.environ.get("OPEN_RL_STORE_DIR")
     if redis_url:
       print(f"[RequestStore] Initializing Redis backend at {redis_url} with RR Tenant Queues")
       _store_instance = RedisStore(redis_url)
+    elif store_dir:
+      print(f"[RequestStore] Initializing File backend at {store_dir} (cross-process, no Redis)")
+      _store_instance = FileStore(store_dir)
     else:
       print("[RequestStore] Initializing In-Memory backend with RR Tenant Queues")
       _store_instance = InMemoryStore()

--- a/src/server/trainer.py
+++ b/src/server/trainer.py
@@ -166,7 +166,12 @@ class TrainerEngine:
       self.peft_model.add_adapter(adapter_id, peft_config)
 
     self.peft_model.set_adapter(adapter_id)
-    self.adapter_states[adapter_id] = {"trainable_params": active_adapter_parameters(self.peft_model, adapter_id), "optimizer": None}
+    self.adapter_states[adapter_id] = {
+      "trainable_params": active_adapter_parameters(self.peft_model, adapter_id),
+      "optimizer": None,
+      "lora_config": config.model_dump(),
+      "training_mode": "lora",
+    }
 
     if ENABLE_GRADIENT_CHECKPOINTING:
       try:
@@ -205,11 +210,6 @@ class TrainerEngine:
       traceback.print_exc()
 
   def save_state(self, model_id: str, state_path: str, include_optimizer: bool = False, kind: str = "state") -> dict[str, Any]:
-    """Save weights (and optionally optimizer state) to a specific path.
-
-    Full fine-tuning writes a standard HuggingFace model directory (config + safetensors +
-    tokenizer) that any loader (transformers, vLLM) can serve directly. LoRA writes the adapter.
-    """
     if self.is_full_model(model_id):
       assert self.base_model is not None, "Model must be loaded first."
       os.makedirs(state_path, exist_ok=True)
@@ -256,6 +256,17 @@ class TrainerEngine:
       "model_id": model_id,
       "timestamp": time.time(),
     }
+    lora_config = adapter_state.get("lora_config") if adapter_state is not None else None
+    if lora_config is not None:
+      metadata.update(
+        {
+          "lora_rank": lora_config.get("rank"),
+          "train_attn": lora_config.get("train_attn"),
+          "train_mlp": lora_config.get("train_mlp"),
+          "train_unembed": lora_config.get("train_unembed"),
+          "training_mode": "lora",
+        }
+      )
     with open(os.path.join(state_path, "metadata.json"), "w") as f:
       json.dump(metadata, f)
 
@@ -263,11 +274,6 @@ class TrainerEngine:
     return {"path": state_path}
 
   def load_from_state(self, model_id: str, state_path: str, restore_optimizer: bool = False) -> dict[str, Any]:
-    """Create an adapter from a saved state directory.
-
-    Expects the directory to contain a metadata.json describing base_model
-    and (optionally) an adapter subdirectory with the saved LoRA weights.
-    """
     metadata_path = os.path.join(state_path, "metadata.json")
     if not os.path.exists(metadata_path):
       raise FileNotFoundError(f"No metadata.json found at {state_path}")
@@ -278,6 +284,44 @@ class TrainerEngine:
     base_model = metadata.get("base_model")
     if not base_model:
       raise ValueError(f"metadata.json at {state_path} missing base_model")
+
+    if metadata.get("training_mode") == "full":
+      if self.peft_model is not None:
+        raise ValueError("Cannot load full fine-tuning state into a PEFT worker")
+      if self.full_model_id is not None and self.full_model_id != model_id:
+        raise ValueError(f"Full fine-tuning worker already owns run '{self.full_model_id}'")
+
+      self.base_model = None
+      self.tokenizer = None
+      if self.device.type == "cuda":
+        torch.cuda.empty_cache()
+
+      self.base_model_name = base_model
+      self.tokenizer = AutoTokenizer.from_pretrained(state_path)
+      dtype = torch.bfloat16 if self.device.type == "cuda" and torch.cuda.is_bf16_supported() else torch.float32
+      self.base_model = AutoModelForCausalLM.from_pretrained(state_path, dtype=dtype, device_map=self.device)
+      for param in self.base_model.parameters():
+        param.requires_grad_(True)
+
+      params = [param for param in self.base_model.parameters() if param.requires_grad]
+      if not params:
+        raise ValueError("No trainable parameters found for full fine-tuning")
+
+      self.base_model.train()
+      adapter_state = {"trainable_params": params, "optimizer": None, "training_mode": "full"}
+      self.adapter_states[model_id] = adapter_state
+      self.full_model_id = model_id
+
+      if restore_optimizer and metadata.get("has_optimizer"):
+        optimizer_path = os.path.join(state_path, "optimizer.pt")
+        if os.path.exists(optimizer_path):
+          optimizer = torch.optim.AdamW(params, lr=1e-4)
+          optimizer.load_state_dict(torch.load(optimizer_path, map_location=self.device))
+          adapter_state["optimizer"] = optimizer
+          print(f"Restored optimizer state for '{model_id}' from {optimizer_path}")
+
+      print(f"Loaded full state for '{model_id}' from {state_path}")
+      return {"model_id": model_id, "is_lora": False, "base_model": base_model}
 
     src_adapter_id = metadata.get("model_id")
     adapter_dir = state_path
@@ -298,7 +342,14 @@ class TrainerEngine:
 
     self.peft_model.set_adapter(model_id)
     params = active_adapter_parameters(self.peft_model, model_id)
-    adapter_state = {"trainable_params": params, "optimizer": None}
+    adapter_state = {"trainable_params": params, "optimizer": None, "training_mode": "lora"}
+    if metadata.get("lora_rank") is not None:
+      adapter_state["lora_config"] = {
+        "rank": metadata.get("lora_rank"),
+        "train_attn": metadata.get("train_attn", True),
+        "train_mlp": metadata.get("train_mlp", True),
+        "train_unembed": metadata.get("train_unembed", True),
+      }
     self.adapter_states[model_id] = adapter_state
 
     if ENABLE_GRADIENT_CHECKPOINTING:

--- a/src/server/trainer.py
+++ b/src/server/trainer.py
@@ -17,6 +17,10 @@ from transformers import AutoModelForCausalLM, AutoTokenizer, PreTrainedModel, P
 ENABLE_GRADIENT_CHECKPOINTING = os.getenv("ENABLE_GRADIENT_CHECKPOINTING", "1") == "1"
 
 
+def defer_cuda_probe() -> bool:
+  return bool(os.getenv("OPEN_RL_SCHEDULER_SOCKET") and os.getenv("OPEN_RL_WORKER_RUN_ID"))
+
+
 class TensorData(BaseModel):
   data: list[int] | list[float]
 
@@ -60,10 +64,11 @@ class TrainerEngine:
 
     # Store per-adapter training state by model_id (adapter ID).
     self.adapter_states: dict[str, dict[str, Any]] = {}
+    self.full_model_id: str | None = None
     self.lora_target_modules: dict[tuple[bool, bool, bool], list[str]] = {}
 
     # Decide device
-    if torch.cuda.is_available():
+    if defer_cuda_probe() or torch.cuda.is_available():
       self.device = torch.device("cuda")
     elif torch.backends.mps.is_available():
       self.device = torch.device("mps")
@@ -79,10 +84,32 @@ class TrainerEngine:
     print(f"Loading base model {base_model_name} to {self.device}...")
     self.base_model_name = base_model_name
     self.tokenizer = AutoTokenizer.from_pretrained(base_model_name)
-    dtype = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float32
+    dtype = torch.bfloat16 if self.device.type == "cuda" and torch.cuda.is_bf16_supported() else torch.float32
 
     self.base_model = AutoModelForCausalLM.from_pretrained(base_model_name, dtype=dtype, device_map=self.device)
     print("Successfully loaded.")
+
+  def create_full_model(self, model_id: str, base_model_name: str) -> None:
+    """Materialize one full-parameter fine-tuning model for this worker."""
+    if self.peft_model is not None:
+      raise ValueError("Full fine-tuning workers cannot share a process with LoRA adapters")
+    if self.full_model_id is not None and self.full_model_id != model_id:
+      raise ValueError(f"Full fine-tuning worker already owns run '{self.full_model_id}'")
+
+    self.load_base_model(base_model_name)
+    assert self.base_model is not None
+
+    for param in self.base_model.parameters():
+      param.requires_grad_(True)
+
+    params = [param for param in self.base_model.parameters() if param.requires_grad]
+    if not params:
+      raise ValueError("No trainable parameters found for full fine-tuning")
+
+    self.base_model.train()
+    self.full_model_id = model_id
+    self.adapter_states[model_id] = {"trainable_params": params, "optimizer": None, "training_mode": "full"}
+    print(f"Full fine-tuning model '{model_id}' created.")
 
   def _target_lora_modules(self, config: LoraConfig) -> list[str]:
     assert self.base_model is not None
@@ -157,6 +184,7 @@ class TrainerEngine:
   def save_adapter(self, adapter_id: str, alias: str | None = None) -> None:
     """Save adapter weights to disk for reliability and sharing."""
     try:
+      assert self.peft_model is not None, "PEFT model must be loaded first."
       tmp_dir = os.getenv("OPEN_RL_TMP_DIR", "/tmp/open-rl")
       save_path = os.path.join(tmp_dir, "peft", adapter_id)
       os.makedirs(save_path, exist_ok=True)
@@ -177,7 +205,38 @@ class TrainerEngine:
       traceback.print_exc()
 
   def save_state(self, model_id: str, state_path: str, include_optimizer: bool = False, kind: str = "state") -> dict[str, Any]:
-    """Save adapter weights (and optionally optimizer state) to a specific path."""
+    """Save weights (and optionally optimizer state) to a specific path.
+
+    Full fine-tuning writes a standard HuggingFace model directory (config + safetensors +
+    tokenizer) that any loader (transformers, vLLM) can serve directly. LoRA writes the adapter.
+    """
+    if self.is_full_model(model_id):
+      assert self.base_model is not None, "Model must be loaded first."
+      os.makedirs(state_path, exist_ok=True)
+      self.base_model.save_pretrained(state_path)
+      if self.tokenizer is not None:
+        self.tokenizer.save_pretrained(state_path)
+
+      adapter_state = self.adapter_states.get(model_id)
+      optimizer = adapter_state.get("optimizer") if adapter_state is not None else None
+      if include_optimizer and optimizer is not None:
+        torch.save(optimizer.state_dict(), os.path.join(state_path, "optimizer.pt"))
+
+      metadata = {
+        "base_model": self.base_model_name,
+        "created_at": datetime.now().isoformat(),
+        "kind": kind,
+        "training_mode": "full",
+        "has_optimizer": include_optimizer and optimizer is not None,
+        "model_id": model_id,
+        "timestamp": time.time(),
+      }
+      with open(os.path.join(state_path, "metadata.json"), "w") as f:
+        json.dump(metadata, f)
+
+      print(f"Saved full model for '{model_id}' to {state_path}")
+      return {"path": state_path}
+
     assert self.peft_model is not None, "Model must be loaded first."
 
     self.peft_model.set_adapter(model_id)
@@ -264,22 +323,36 @@ class TrainerEngine:
     print(f"Loaded state for '{model_id}' from {state_path}")
     return {"model_id": model_id, "is_lora": True, "base_model": base_model}
 
-  def forward_backward(self, data: list[Datum], loss_fn: str, loss_config: dict | None = None, model_id: str | None = None) -> dict[str, Any]:
-    """Core training step: forward pass, loss computation, and backward pass."""
+  def is_full_model(self, model_id: str | None) -> bool:
+    if not model_id:
+      return False
+    adapter_state = self.adapter_states.get(model_id)
+    return adapter_state is not None and adapter_state.get("training_mode") == "full"
+
+  def training_model(self, model_id: str | None = None) -> Any:
+    if self.is_full_model(model_id):
+      assert self.base_model is not None, "Model must be loaded first."
+      return self.base_model
+
     assert self.peft_model is not None, "Model must be loaded first."
     if model_id:
       self.peft_model.set_adapter(model_id)
+    return self.peft_model
+
+  def forward_backward(self, data: list[Datum], loss_fn: str, loss_config: dict | None = None, model_id: str | None = None) -> dict[str, Any]:
+    """Core training step: forward pass, loss computation, and backward pass."""
+    model = self.training_model(model_id)
 
     total_loss = 0.0
     loss_fn_outputs: list[dict[str, Any] | None] = [None] * len(data)
 
-    self.peft_model.train()
+    model.train()
 
     for batch in self._make_training_batches(data):
       batch_indices = [idx for idx, _ in batch]
       batch_data = [datum for _, datum in batch]
 
-      target_logprobs, weights, aux_inputs, lengths = self._get_logprobs_batch(batch_data)
+      target_logprobs, weights, aux_inputs, lengths = self._get_logprobs_batch(batch_data, model)
       match loss_fn:
         case "cross_entropy":
           elementwise_loss = self._cross_entropy_loss(target_logprobs, weights)
@@ -349,8 +422,9 @@ class TrainerEngine:
 
     return batches
 
-  def _get_logprobs_batch(self, data: list[Datum]) -> tuple[torch.Tensor, torch.Tensor, dict[str, torch.Tensor], list[int]]:
-    assert self.peft_model is not None
+  def _get_logprobs_batch(self, data: list[Datum], model: Any | None = None) -> tuple[torch.Tensor, torch.Tensor, dict[str, torch.Tensor], list[int]]:
+    model = model or self.peft_model
+    assert model is not None
 
     pad_token_id = self.tokenizer.pad_token_id if self.tokenizer and self.tokenizer.pad_token_id is not None else 0
     batch_size = len(data)
@@ -391,7 +465,7 @@ class TrainerEngine:
         values = datum.loss_fn_inputs[key].data[:seq_len]
         aux_tensor[row, :seq_len] = torch.tensor(values, dtype=loss_dtype, device=self.device)
 
-    outputs = self.peft_model(input_tensor, attention_mask=attention_mask, use_cache=False, return_dict=True)
+    outputs = model(input_tensor, attention_mask=attention_mask, use_cache=False, return_dict=True)
     logits = outputs.logits[:, :max_target_len, :]
     target_logprobs = torch.nn.functional.log_softmax(logits, dim=-1).gather(dim=-1, index=targets.unsqueeze(-1)).squeeze(-1)
 
@@ -450,20 +524,23 @@ class TrainerEngine:
 
   def set_active_adapter(self, adapter_id: str) -> None:
     """Switch which LoRA adapter is active."""
+    if self.is_full_model(adapter_id):
+      return
     if self.peft_model is not None:
       self.peft_model.set_adapter(adapter_id)
 
   def optim_step(self, adam_params: dict[str, Any], model_id: str) -> dict[str, Any]:
     """Apply accumulated gradients and update model weights."""
-    assert self.peft_model is not None, "Model must be loaded first."
     if not model_id:
       raise ValueError("model_id is required for optim_step")
 
-    self.peft_model.set_adapter(model_id)
+    if not self.is_full_model(model_id):
+      assert self.peft_model is not None, "Model must be loaded first."
+      self.peft_model.set_adapter(model_id)
     try:
       adapter_state = self.adapter_states[model_id]
     except KeyError as e:
-      raise ValueError(f"Adapter '{model_id}' has no cached trainable parameters") from e
+      raise ValueError(f"Model '{model_id}' has no cached trainable parameters") from e
     params = adapter_state["trainable_params"]
 
     if adapter_state.get("optimizer") is None:
@@ -500,7 +577,8 @@ class TrainerEngine:
     optimizer.step()
     optimizer.zero_grad()
 
-    self.save_adapter(model_id)
+    if not self.is_full_model(model_id):
+      self.save_adapter(model_id)
 
     return {
       "metrics": {
@@ -518,19 +596,16 @@ class TrainerEngine:
     include_prompt_logprobs: bool = False,
   ) -> dict[str, Any]:
     """Generate completions from the current model."""
-    assert self.peft_model is not None, "Model must be loaded first."
-
-    if model_id:
-      self.peft_model.set_adapter(model_id)
-    self.peft_model.eval()
+    model = self.training_model(model_id)
+    model.eval()
 
     input_tensor = torch.tensor([prompt_tokens], dtype=torch.long, device=self.device)
     do_sample = (num_samples > 1) or (temperature and temperature > 0.0)
-    prompt_logprobs = self._prompt_logprobs(input_tensor) if include_prompt_logprobs else None
+    prompt_logprobs = self._prompt_logprobs(input_tensor, model) if include_prompt_logprobs else None
 
     with torch.no_grad():
       attention_mask = torch.ones_like(input_tensor)
-      outputs = self.peft_model.generate(
+      outputs = model.generate(
         input_tensor,
         attention_mask=attention_mask,
         max_new_tokens=max_tokens,
@@ -564,12 +639,10 @@ class TrainerEngine:
       result["prompt_logprobs"] = prompt_logprobs
     return result
 
-  def _prompt_logprobs(self, input_tensor: torch.Tensor) -> list[float | None]:
-    assert self.peft_model is not None, "Model must be loaded first."
-
+  def _prompt_logprobs(self, input_tensor: torch.Tensor, model: Any) -> list[float | None]:
     with torch.no_grad():
       attention_mask = torch.ones_like(input_tensor)
-      outputs = self.peft_model(input_tensor, attention_mask=attention_mask)
+      outputs = model(input_tensor, attention_mask=attention_mask)
       logprob_dist = torch.nn.functional.log_softmax(outputs.logits[0, :-1], dim=-1)
 
     prompt_tokens = input_tensor[0].tolist()

--- a/src/server/trainer_scheduler.py
+++ b/src/server/trainer_scheduler.py
@@ -248,7 +248,7 @@ async def main_async() -> None:
 
 
 def main() -> None:
-  logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s")
+  logging.basicConfig(level=logging.INFO, format="[SCHEDULER] %(levelname)s %(message)s")
   asyncio.run(main_async())
 
 

--- a/src/server/trainer_scheduler.py
+++ b/src/server/trainer_scheduler.py
@@ -1,0 +1,256 @@
+import argparse
+import asyncio
+import json
+import logging
+import os
+from collections import deque
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from checkpoint import CheckpointRestorer, CudaCheckpointRestorer
+from utils import timed
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Worker:
+  pid: int
+  connection_id: int | None
+  checkpointed: bool = False
+  failed: bool = False
+
+
+class TrainerScheduler:
+  def __init__(self, restorer: CheckpointRestorer):
+    self.restorer = restorer
+    self.workers: dict[str, Worker] = {}
+    self.waiting_run_ids: deque[str] = deque()
+    self.active_run_id: str | None = None
+    self.condition = asyncio.Condition()
+
+  def clear_run(self, run_id: str) -> None:
+    if run_id in self.waiting_run_ids:
+      self.waiting_run_ids.remove(run_id)
+    if self.active_run_id == run_id:
+      self.active_run_id = None
+
+  async def register(self, run_id: str, pid: int, connection_id: int | None = None) -> dict[str, Any]:
+    async with self.condition:
+      worker = self.workers.get(run_id)
+
+      if worker is not None:
+        return {"ok": False, "error": f"run '{run_id}' is already registered"}
+
+      self.workers[run_id] = Worker(pid=pid, connection_id=connection_id)
+      self.condition.notify_all()
+      return {"ok": True}
+
+  async def acquire(self, run_id: str) -> dict[str, Any]:
+    async with self.condition:
+      worker = self.workers.get(run_id)
+      if worker is None:
+        return {"ok": False, "error": f"run '{run_id}' is not registered"}
+      if worker.failed:
+        return {"ok": False, "error": f"run '{run_id}' is failed"}
+      if run_id in self.waiting_run_ids or self.active_run_id == run_id:
+        return {"ok": False, "error": f"run '{run_id}' already has a pending or active acquire"}
+
+      self.waiting_run_ids.append(run_id)
+      try:
+        while self.active_run_id is not None or (run_id in self.waiting_run_ids and self.waiting_run_ids[0] != run_id):
+          await self.condition.wait()
+      except BaseException:
+        if run_id in self.waiting_run_ids:
+          self.waiting_run_ids.remove(run_id)
+        self.condition.notify_all()
+        raise
+
+      worker = self.workers.get(run_id)
+      if worker is None or worker.failed or run_id not in self.waiting_run_ids:
+        self.clear_run(run_id)
+        self.condition.notify_all()
+        return {"ok": False, "error": f"run '{run_id}' is not available"}
+
+      self.waiting_run_ids.popleft()
+      self.active_run_id = run_id
+      if worker.checkpointed:
+        await self.run_restore(worker.pid)
+        worker.checkpointed = False
+
+      self.condition.notify_all()
+      return {"ok": True}
+
+  async def release(self, run_id: str) -> dict[str, Any]:
+    async with self.condition:
+      worker = self.workers.get(run_id)
+      if worker is None:
+        return {"ok": False, "error": f"run '{run_id}' is not registered"}
+      if self.active_run_id != run_id:
+        return {"ok": False, "error": f"run '{run_id}' does not hold an active acquire"}
+
+      await self.run_checkpoint(worker.pid)
+      worker.checkpointed = True
+      self.clear_run(run_id)
+      self.condition.notify_all()
+      return {"ok": True}
+
+  async def unregister(self, run_id: str) -> dict[str, Any]:
+    async with self.condition:
+      if run_id not in self.workers:
+        return {"ok": False, "error": f"run '{run_id}' is not registered"}
+
+      self.clear_run(run_id)
+      del self.workers[run_id]
+      self.condition.notify_all()
+      return {"ok": True}
+
+  async def connection_closed(self, connection_id: int) -> None:
+    async with self.condition:
+      for run_id, worker in self.workers.items():
+        if worker.connection_id != connection_id:
+          continue
+        self.clear_run(run_id)
+        worker.failed = True
+        worker.checkpointed = False
+        worker.connection_id = None
+      self.condition.notify_all()
+
+  @timed
+  async def run_checkpoint(self, pid: int) -> None:
+    logger.info("checkpoint pid=%s", pid)
+    try:
+      await asyncio.to_thread(self.restorer.checkpoint, pid)
+    except Exception:
+      logger.critical("checkpoint failed for pid %s; GPU state is unknown, killing scheduler", pid, exc_info=True)
+      os._exit(1)
+
+  @timed
+  async def run_restore(self, pid: int) -> None:
+    logger.info("restore pid=%s", pid)
+    try:
+      await asyncio.to_thread(self.restorer.restore, pid)
+    except Exception:
+      logger.critical("restore failed for pid %s; GPU state is unknown, killing scheduler", pid, exc_info=True)
+      os._exit(1)
+
+
+async def serve_scheduler(scheduler: TrainerScheduler, socket_path: str) -> asyncio.Server:
+  socket = Path(socket_path)
+  socket.parent.mkdir(parents=True, exist_ok=True)
+  socket.unlink(missing_ok=True)
+
+  async def handle_connection(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+    connection_id = id(writer)
+    try:
+      while line := await reader.readline():
+        response = await dispatch(scheduler, line, connection_id)
+        writer.write(json.dumps(response).encode("utf-8") + b"\n")
+        await writer.drain()
+    finally:
+      await scheduler.connection_closed(connection_id)
+      writer.close()
+      await writer.wait_closed()
+
+  return await asyncio.start_unix_server(handle_connection, path=socket_path)
+
+
+async def dispatch(scheduler: TrainerScheduler, line: bytes, connection_id: int) -> dict[str, Any]:
+  payload = json.loads(line.decode("utf-8"))
+
+  command = payload.get("command", "").upper()
+  run_id = payload.get("run_id")
+
+  assert run_id is not None, "run_id is required"
+
+  match command:
+    case "REGISTER":
+      return await scheduler.register(run_id, payload["pid"], connection_id=connection_id)
+    case "ACQUIRE":
+      return await scheduler.acquire(run_id)
+    case "RELEASE":
+      return await scheduler.release(run_id)
+    case "UNREGISTER":
+      return await scheduler.unregister(run_id)
+    case _:
+      return {"ok": False, "error": f"unknown command '{command}'"}
+
+
+class TrainerSchedulerClient:
+  def __init__(self, socket_path: str):
+    self.socket_path = socket_path
+    self.reader: asyncio.StreamReader | None = None
+    self.writer: asyncio.StreamWriter | None = None
+
+  async def connect(self) -> None:
+    if self.writer is not None and not self.writer.is_closing():
+      return
+    self.reader, self.writer = await asyncio.open_unix_connection(self.socket_path)
+
+  async def close(self) -> None:
+    if self.writer is None:
+      return
+    self.writer.close()
+    await self.writer.wait_closed()
+    self.reader = None
+    self.writer = None
+
+  async def register(self, run_id: str, pid: int) -> dict[str, Any]:
+    return await self.request({"command": "REGISTER", "run_id": run_id, "pid": pid})
+
+  async def unregister(self, run_id: str) -> dict[str, Any]:
+    return await self.request({"command": "UNREGISTER", "run_id": run_id})
+
+  @asynccontextmanager
+  async def acquire(self, run_id: str) -> AsyncIterator[None]:
+    await self.request({"command": "ACQUIRE", "run_id": run_id})
+    try:
+      yield
+    finally:
+      await self.request({"command": "RELEASE", "run_id": run_id})
+
+  async def request(self, payload: dict[str, Any]) -> dict[str, Any]:
+    await self.connect()
+    assert self.reader is not None
+    assert self.writer is not None
+
+    self.writer.write(json.dumps(payload).encode("utf-8") + b"\n")
+    await self.writer.drain()
+    line = await self.reader.readline()
+    if not line:
+      raise RuntimeError("trainer scheduler connection closed")
+
+    response = json.loads(line.decode("utf-8"))
+    if not response.get("ok"):
+      raise RuntimeError(response.get("error", "trainer scheduler command failed"))
+    return response
+
+
+def parse_args() -> argparse.Namespace:
+  parser = argparse.ArgumentParser(description="Run the OpenRL trainer scheduler.")
+  parser.add_argument("--socket", default=os.getenv("OPEN_RL_SCHEDULER_SOCKET", "/tmp/open-rl/trainer-scheduler.sock"))
+  parser.add_argument("--cuda-checkpoint-bin", default=os.getenv("CUDA_CHECKPOINT_BIN", "cuda-checkpoint"))
+  parser.add_argument("--cuda-checkpoint-timeout-ms", type=int, default=None)
+  return parser.parse_args()
+
+
+async def main_async() -> None:
+  args = parse_args()
+  restorer = CudaCheckpointRestorer(args.cuda_checkpoint_bin, args.cuda_checkpoint_timeout_ms)
+  scheduler = TrainerScheduler(restorer)
+  server = await serve_scheduler(scheduler, args.socket)
+  logger.info("listening on %s", args.socket)
+  async with server:
+    await server.serve_forever()
+
+
+def main() -> None:
+  logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s")
+  asyncio.run(main_async())
+
+
+if __name__ == "__main__":
+  main()

--- a/src/server/trainer_scheduler.py
+++ b/src/server/trainer_scheduler.py
@@ -8,6 +8,8 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from pathlib import Path
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 from typing import Any
 
 from checkpoint import CheckpointRestorer, CudaCheckpointRestorer

--- a/src/server/trainer_scheduler.py
+++ b/src/server/trainer_scheduler.py
@@ -8,8 +8,6 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from pathlib import Path
-import sys
-sys.path.insert(0, str(Path(__file__).resolve().parent))
 from typing import Any
 
 from checkpoint import CheckpointRestorer, CudaCheckpointRestorer

--- a/src/server/utils.py
+++ b/src/server/utils.py
@@ -1,0 +1,32 @@
+import asyncio
+import functools
+import logging
+import time
+from collections.abc import Callable
+from typing import Any
+
+
+def timed(fn: Callable[..., Any]) -> Callable[..., Any]:
+  fn_logger = logging.getLogger(fn.__module__)
+
+  if asyncio.iscoroutinefunction(fn):
+
+    @functools.wraps(fn)
+    async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+      t0 = time.perf_counter()
+      try:
+        return await fn(*args, **kwargs)
+      finally:
+        fn_logger.info("%s took %.0f ms", fn.__qualname__, (time.perf_counter() - t0) * 1000)
+
+    return async_wrapper
+
+  @functools.wraps(fn)
+  def wrapper(*args: Any, **kwargs: Any) -> Any:
+    t0 = time.perf_counter()
+    try:
+      return fn(*args, **kwargs)
+    finally:
+      fn_logger.info("%s took %.0f ms", fn.__qualname__, (time.perf_counter() - t0) * 1000)
+
+  return wrapper

--- a/src/server/worker_launcher.py
+++ b/src/server/worker_launcher.py
@@ -1,0 +1,24 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def launch_worker(run_id: str, scheduler_socket: str) -> subprocess.Popen:
+  if not (os.getenv("REDIS_URL") or os.getenv("OPEN_RL_STORE_DIR")):
+    raise RuntimeError("a shared store (REDIS_URL or OPEN_RL_STORE_DIR) is required when launching trainer worker subprocesses")
+
+  env = os.environ.copy()
+  env["OPEN_RL_SCHEDULER_SOCKET"] = scheduler_socket
+  env["OPEN_RL_WORKER_RUN_ID"] = run_id
+  env["OPEN_RL_DISABLE_WORKER_HEALTHZ"] = "1"
+  env.setdefault("PYTHONUNBUFFERED", "1")
+
+  server_dir = Path(__file__).resolve().parent
+  process = subprocess.Popen(
+    [sys.executable, str(server_dir / "clock_cycle.py")],
+    cwd=server_dir,
+    env=env,
+    start_new_session=True,
+  )
+  return process

--- a/tests/test_gateway_paths.py
+++ b/tests/test_gateway_paths.py
@@ -1,0 +1,143 @@
+import json
+import os
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from tests._server_fixture import SERVER_DIR
+
+sys.path.insert(0, str(SERVER_DIR))
+redis_stub = types.ModuleType("redis")
+redis_asyncio_stub = types.ModuleType("redis.asyncio")
+redis_stub.asyncio = redis_asyncio_stub
+sys.modules.setdefault("redis", redis_stub)
+sys.modules.setdefault("redis.asyncio", redis_asyncio_stub)
+
+try:
+  import gateway  # noqa: E402
+  from store import InMemoryStore  # noqa: E402
+
+  HAS_SERVER_DEPS = True
+except ModuleNotFoundError:
+  gateway = None
+  InMemoryStore = None
+  HAS_SERVER_DEPS = False
+
+
+@unittest.skipUnless(HAS_SERVER_DEPS, "server dependencies are not installed")
+class GatewayWeightsPathTest(unittest.IsolatedAsyncioTestCase):
+  def setUp(self) -> None:
+    self.tmp_dir = tempfile.TemporaryDirectory()
+    self.previous_tmp_dir = gateway.TMP_DIR
+    self.previous_store = gateway.store
+    gateway.TMP_DIR = self.tmp_dir.name
+    gateway.store = InMemoryStore()
+
+  def tearDown(self) -> None:
+    gateway.TMP_DIR = self.previous_tmp_dir
+    gateway.store = self.previous_store
+    self.tmp_dir.cleanup()
+
+  async def test_save_weights_scopes_same_alias_by_model(self) -> None:
+    await gateway.save_weights({"model_id": "run-a", "path": "same"})
+    await gateway.save_weights({"model_id": "run-b", "path": "same"})
+
+    run_a = (await gateway.store.get_requests_for_model("run-a"))[0]
+    run_b = (await gateway.store.get_requests_for_model("run-b"))[0]
+
+    self.assertEqual(run_a["state_path"], os.path.join(self.tmp_dir.name, "checkpoints", "run-a", "weights", "same"))
+    self.assertEqual(run_b["state_path"], os.path.join(self.tmp_dir.name, "checkpoints", "run-b", "weights", "same"))
+    self.assertEqual(run_a["response_path"], "tinker://run-a/weights/same")
+    self.assertEqual(run_b["response_path"], "tinker://run-b/weights/same")
+
+  async def test_load_weights_resolves_tinker_path_to_source_model(self) -> None:
+    await gateway.load_weights({"model_id": "new-run", "path": "tinker://old-run/weights/final", "optimizer": True})
+
+    request = (await gateway.store.get_requests_for_model("new-run"))[0]
+
+    self.assertEqual(request["state_path"], os.path.join(self.tmp_dir.name, "checkpoints", "old-run", "weights", "final"))
+    self.assertTrue(request["restore_optimizer"])
+
+  async def test_unnamed_sampler_snapshot_uses_generated_tinker_path(self) -> None:
+    await gateway.save_weights_for_sampler({"model_id": "run-a", "sampling_session_seq_id": 7})
+
+    request = (await gateway.store.get_requests_for_model("run-a"))[0]
+
+    self.assertEqual(request["path"], "tinker://run-a/sampler_weights/sampler-7")
+    self.assertEqual(request["sampling_session_id"], "tinker://run-a/sampler_weights/sampler-7")
+
+  async def test_weights_info_reads_model_scoped_metadata(self) -> None:
+    checkpoint = Path(self.tmp_dir.name) / "checkpoints" / "run-a" / "weights" / "final"
+    checkpoint.mkdir(parents=True)
+    (checkpoint / "metadata.json").write_text(
+      json.dumps(
+        {
+          "base_model": "Qwen/test",
+          "lora_rank": 8,
+          "train_attn": True,
+          "train_mlp": False,
+          "train_unembed": False,
+          "training_mode": "lora",
+        }
+      )
+    )
+
+    response = await gateway.weights_info({"tinker_path": "tinker://run-a/weights/final"})
+
+    self.assertEqual(
+      response,
+      {
+        "base_model": "Qwen/test",
+        "is_lora": True,
+        "lora_rank": 8,
+        "train_unembed": False,
+        "train_mlp": False,
+        "train_attn": True,
+      },
+    )
+
+  async def test_weights_info_reports_full_checkpoint_without_full_mode_lie(self) -> None:
+    checkpoint = Path(self.tmp_dir.name) / "checkpoints" / "run-a" / "weights" / "final"
+    checkpoint.mkdir(parents=True)
+    (checkpoint / "metadata.json").write_text(json.dumps({"base_model": "Qwen/test", "training_mode": "full"}))
+
+    response = await gateway.weights_info({"tinker_path": "tinker://run-a/weights/final"})
+
+    self.assertEqual(
+      response,
+      {
+        "base_model": "Qwen/test",
+        "is_lora": False,
+        "lora_rank": None,
+        "train_unembed": None,
+        "train_mlp": None,
+        "train_attn": None,
+      },
+    )
+
+  async def test_weights_info_lies_for_full_checkpoint_in_full_mode(self) -> None:
+    checkpoint = Path(self.tmp_dir.name) / "checkpoints" / "run-a" / "weights" / "final"
+    checkpoint.mkdir(parents=True)
+    (checkpoint / "metadata.json").write_text(json.dumps({"base_model": "Qwen/test", "training_mode": "full"}))
+
+    with patch.dict(os.environ, {"OPEN_RL_TRAINING_MODE": "full"}):
+      response = await gateway.weights_info({"tinker_path": "tinker://run-a/weights/final"})
+
+    self.assertEqual(
+      response,
+      {
+        "base_model": "Qwen/test",
+        "is_lora": True,
+        "lora_rank": 16,
+        "train_unembed": True,
+        "train_mlp": True,
+        "train_attn": True,
+      },
+    )
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tests/test_trainer_optimizer_correctness.py
+++ b/tests/test_trainer_optimizer_correctness.py
@@ -128,6 +128,33 @@ class TestTrainerOptimizerCorrectness(unittest.TestCase):
       self.assertTrue(torch.allclose(active_param.grad, torch.zeros_like(active_param.grad)))
     self.assertIsNotNone(other_param.grad)
 
+  def test_optim_step_updates_full_model_params_without_adapter(self) -> None:
+    full_param = torch.nn.Parameter(torch.tensor([1.0]))
+    full_param.grad = torch.tensor([1.0])
+
+    engine = TrainerEngine()
+    engine.base_model = types.SimpleNamespace()
+    engine.peft_model = None
+    engine.full_model_id = "full-run"
+    engine.adapter_states = {"full-run": {"trainable_params": [full_param], "optimizer": None, "training_mode": "full"}}
+    engine.save_adapter = lambda *_args, **_kwargs: self.fail("full fine-tuning optim_step must not save a LoRA adapter")
+
+    result = engine.optim_step(
+      {
+        "learning_rate": 0.1,
+        "beta1": 0.0,
+        "beta2": 0.0,
+        "eps": 1e-8,
+        "weight_decay": 0.0,
+      },
+      "full-run",
+    )
+
+    self.assertAlmostEqual(result["metrics"]["grad_norm:mean"], 1.0)
+    self.assertFalse(torch.allclose(full_param.detach(), torch.tensor([1.0])))
+    if full_param.grad is not None:
+      self.assertTrue(torch.allclose(full_param.grad, torch.zeros_like(full_param.grad)))
+
 
 class TestTrainerPaddedBatchingMath(unittest.TestCase):
   def _engine(self) -> TrainerEngine:
@@ -221,6 +248,18 @@ class TestTrainerPaddedBatchingMath(unittest.TestCase):
     for datum, output in zip(data, result["loss_fn_outputs"], strict=True):
       logprobs = output["logprobs"]
       self.assertEqual(logprobs["shape"], [min(len(datum.model_input), len(datum.loss_fn_inputs["target_tokens"].data))])
+
+  def test_forward_backward_supports_full_model_without_peft_adapter(self) -> None:
+    engine = self._engine()
+    engine.base_model = engine.peft_model
+    engine.peft_model = None
+    engine.full_model_id = "full-run"
+    engine.adapter_states = {"full-run": {"trainable_params": [], "optimizer": None, "training_mode": "full"}}
+
+    result = engine.forward_backward(self._data()[:1], "cross_entropy", model_id="full-run")
+
+    self.assertEqual(len(result["loss_fn_outputs"]), 1)
+    self.assertGreater(result["metrics"]["loss:sum"], 0.0)
 
 
 if __name__ == "__main__":

--- a/tests/test_trainer_optimizer_correctness.py
+++ b/tests/test_trainer_optimizer_correctness.py
@@ -1,6 +1,8 @@
 import importlib.util
+import json
 import os
 import sys
+import tempfile
 import types
 import unittest
 from pathlib import Path
@@ -79,6 +81,34 @@ class _LogitModelStub:
     return types.SimpleNamespace(logits=logits)
 
 
+class _FullModelLoadStub:
+  loaded_from = None
+
+  def __init__(self):
+    self.param = torch.nn.Parameter(torch.tensor([1.0]), requires_grad=False)
+    self.trained = False
+
+  @classmethod
+  def from_pretrained(cls, path, **kwargs):
+    cls.loaded_from = (path, kwargs)
+    return cls()
+
+  def parameters(self):
+    return [self.param]
+
+  def train(self):
+    self.trained = True
+
+
+class _TokenizerLoadStub:
+  loaded_from = None
+
+  @classmethod
+  def from_pretrained(cls, path):
+    cls.loaded_from = path
+    return cls()
+
+
 def _datum(model_input, target_tokens, *, weights=None, logprobs=None, advantages=None):
   loss_fn_inputs = {"target_tokens": trainer_module.TensorData(data=target_tokens)}
   if weights is not None:
@@ -154,6 +184,33 @@ class TestTrainerOptimizerCorrectness(unittest.TestCase):
     self.assertFalse(torch.allclose(full_param.detach(), torch.tensor([1.0])))
     if full_param.grad is not None:
       self.assertTrue(torch.allclose(full_param.grad, torch.zeros_like(full_param.grad)))
+
+  def test_load_from_state_restores_full_model_checkpoint(self) -> None:
+    with tempfile.TemporaryDirectory() as state_path:
+      with open(os.path.join(state_path, "metadata.json"), "w") as f:
+        json.dump({"base_model": "Qwen/test", "training_mode": "full", "has_optimizer": False}, f)
+
+      engine = TrainerEngine()
+      engine.device = torch.device("cpu")
+      with (
+        patch.object(trainer_module, "AutoModelForCausalLM", _FullModelLoadStub),
+        patch.object(
+          trainer_module,
+          "AutoTokenizer",
+          _TokenizerLoadStub,
+        ),
+      ):
+        result = engine.load_from_state("full-run", state_path)
+
+    self.assertEqual(result, {"model_id": "full-run", "is_lora": False, "base_model": "Qwen/test"})
+    self.assertEqual(engine.full_model_id, "full-run")
+    self.assertEqual(engine.base_model_name, "Qwen/test")
+    self.assertIsInstance(engine.tokenizer, _TokenizerLoadStub)
+    self.assertEqual(_TokenizerLoadStub.loaded_from, state_path)
+    self.assertEqual(_FullModelLoadStub.loaded_from[0], state_path)
+    self.assertTrue(engine.base_model.trained)
+    self.assertTrue(all(param.requires_grad for param in engine.adapter_states["full-run"]["trainable_params"]))
+    self.assertEqual(engine.adapter_states["full-run"]["training_mode"], "full")
 
 
 class TestTrainerPaddedBatchingMath(unittest.TestCase):

--- a/tests/test_trainer_scheduler.py
+++ b/tests/test_trainer_scheduler.py
@@ -1,0 +1,295 @@
+import asyncio
+import os
+import sys
+import tempfile
+import threading
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from tests._server_fixture import SERVER_DIR
+
+sys.path.insert(0, str(SERVER_DIR))
+redis_stub = types.ModuleType("redis")
+redis_asyncio_stub = types.ModuleType("redis.asyncio")
+redis_stub.asyncio = redis_asyncio_stub
+sys.modules.setdefault("redis", redis_stub)
+sys.modules.setdefault("redis.asyncio", redis_asyncio_stub)
+
+from store import InMemoryStore  # noqa: E402
+from trainer_scheduler import TrainerScheduler, TrainerSchedulerClient, serve_scheduler  # noqa: E402
+from worker_launcher import launch_worker  # noqa: E402
+
+
+class RecordingRestorer:
+  def __init__(self):
+    self.calls: list[tuple[str, int]] = []
+
+  def checkpoint(self, pid: int) -> None:
+    self.calls.append(("checkpoint", pid))
+
+  def restore(self, pid: int) -> None:
+    self.calls.append(("restore", pid))
+
+
+class BlockingRestorer(RecordingRestorer):
+  def __init__(self):
+    super().__init__()
+    self.checkpoint_started = threading.Event()
+    self.finish_checkpoint = threading.Event()
+    self.restore_started = threading.Event()
+    self.finish_restore = threading.Event()
+    self.block_checkpoint = False
+    self.block_restore = False
+
+  def checkpoint(self, pid: int) -> None:
+    super().checkpoint(pid)
+    if self.block_checkpoint:
+      self.checkpoint_started.set()
+      self.finish_checkpoint.wait(timeout=5.0)
+
+  def restore(self, pid: int) -> None:
+    super().restore(pid)
+    if self.block_restore:
+      self.restore_started.set()
+      self.finish_restore.wait(timeout=5.0)
+
+
+class TrainerSchedulerTest(unittest.IsolatedAsyncioTestCase):
+  async def test_scheduler_grants_only_one_active_worker_at_a_time(self) -> None:
+    restorer = RecordingRestorer()
+    scheduler = TrainerScheduler(restorer)
+    await scheduler.register("run-a", 101)
+    await scheduler.register("run-b", 202)
+
+    self.assertTrue((await scheduler.acquire("run-a"))["ok"])
+    blocked = asyncio.create_task(scheduler.acquire("run-b"))
+    await asyncio.sleep(0.05)
+    self.assertFalse(blocked.done())
+
+    release = await scheduler.release("run-a")
+    self.assertTrue(release["ok"])
+    granted_b = await asyncio.wait_for(blocked, timeout=1.0)
+    self.assertTrue(granted_b["ok"])
+    self.assertEqual(restorer.calls, [("checkpoint", 101)])
+    self.assertEqual(scheduler.active_run_id, "run-b")
+
+  async def test_first_acquire_is_cold_and_later_acquire_restores_after_checkpoint(self) -> None:
+    restorer = RecordingRestorer()
+    scheduler = TrainerScheduler(restorer)
+    await scheduler.register("run-a", 101)
+    await scheduler.register("run-b", 202)
+
+    self.assertTrue((await scheduler.acquire("run-a"))["ok"])
+    self.assertTrue((await scheduler.release("run-a"))["ok"])
+    self.assertEqual(restorer.calls, [("checkpoint", 101)])
+
+    self.assertTrue((await scheduler.acquire("run-b"))["ok"])
+    self.assertTrue((await scheduler.release("run-b"))["ok"])
+    self.assertTrue((await scheduler.acquire("run-a"))["ok"])
+
+    self.assertEqual(restorer.calls, [("checkpoint", 101), ("checkpoint", 202), ("restore", 101)])
+
+  async def test_release_with_no_waiters_checkpoints_worker(self) -> None:
+    restorer = RecordingRestorer()
+    scheduler = TrainerScheduler(restorer)
+    await scheduler.register("run-a", 101)
+
+    self.assertTrue((await scheduler.acquire("run-a"))["ok"])
+    release = await scheduler.release("run-a")
+
+    self.assertTrue(release["ok"])
+    self.assertIsNone(scheduler.active_run_id)
+    self.assertTrue(scheduler.workers["run-a"].checkpointed)
+    self.assertFalse(scheduler.workers["run-a"].failed)
+    self.assertEqual(restorer.calls, [("checkpoint", 101)])
+
+  async def test_waiting_acquire_is_not_granted_until_release_checkpoint_finishes(self) -> None:
+    restorer = BlockingRestorer()
+    restorer.block_checkpoint = True
+    scheduler = TrainerScheduler(restorer)
+    await scheduler.register("run-a", 101)
+    await scheduler.register("run-b", 202)
+
+    self.assertTrue((await scheduler.acquire("run-a"))["ok"])
+    release_a = asyncio.create_task(scheduler.release("run-a"))
+
+    checkpoint_started = await asyncio.to_thread(restorer.checkpoint_started.wait, 1.0)
+    self.assertTrue(checkpoint_started)
+
+    acquire_b = asyncio.create_task(scheduler.acquire("run-b"))
+    await asyncio.sleep(0.05)
+    self.assertFalse(release_a.done())
+    self.assertFalse(acquire_b.done())
+
+    restorer.finish_checkpoint.set()
+
+    self.assertTrue((await asyncio.wait_for(release_a, timeout=1.0))["ok"])
+    self.assertTrue((await asyncio.wait_for(acquire_b, timeout=1.0))["ok"])
+    self.assertEqual(restorer.calls, [("checkpoint", 101)])
+
+  async def test_checkpointed_worker_is_not_granted_until_restore_finishes(self) -> None:
+    restorer = BlockingRestorer()
+    scheduler = TrainerScheduler(restorer)
+    await scheduler.register("run-a", 101)
+
+    self.assertTrue((await scheduler.acquire("run-a"))["ok"])
+    self.assertTrue((await scheduler.release("run-a"))["ok"])
+
+    restorer.block_restore = True
+    acquire_a = asyncio.create_task(scheduler.acquire("run-a"))
+
+    restore_started = await asyncio.to_thread(restorer.restore_started.wait, 1.0)
+    self.assertTrue(restore_started)
+    self.assertFalse(acquire_a.done())
+
+    restorer.finish_restore.set()
+
+    self.assertTrue((await asyncio.wait_for(acquire_a, timeout=1.0))["ok"])
+    self.assertFalse(scheduler.workers["run-a"].checkpointed)
+    self.assertEqual(restorer.calls, [("checkpoint", 101), ("restore", 101)])
+
+  async def test_unregister_waiting_worker_prevents_later_grant(self) -> None:
+    scheduler = TrainerScheduler(RecordingRestorer())
+    await scheduler.register("run-a", 101)
+    await scheduler.register("run-b", 202)
+
+    self.assertTrue((await scheduler.acquire("run-a"))["ok"])
+    acquire_b = asyncio.create_task(scheduler.acquire("run-b"))
+    await asyncio.sleep(0.05)
+    self.assertFalse(acquire_b.done())
+
+    self.assertTrue((await scheduler.unregister("run-b"))["ok"])
+    self.assertTrue((await scheduler.release("run-a"))["ok"])
+
+    result = await asyncio.wait_for(acquire_b, timeout=1.0)
+    self.assertFalse(result["ok"])
+    self.assertIsNone(scheduler.active_run_id)
+
+  async def test_duplicate_commands_return_explicit_errors(self) -> None:
+    scheduler = TrainerScheduler(RecordingRestorer())
+    await scheduler.register("run-a", 101)
+
+    self.assertFalse((await scheduler.register("run-a", 999))["ok"])
+    self.assertTrue((await scheduler.acquire("run-a"))["ok"])
+    self.assertFalse((await scheduler.acquire("run-a"))["ok"])
+    self.assertTrue((await scheduler.release("run-a"))["ok"])
+    self.assertFalse((await scheduler.release("run-a"))["ok"])
+    self.assertTrue((await scheduler.unregister("run-a"))["ok"])
+    self.assertFalse((await scheduler.unregister("run-a"))["ok"])
+
+  async def test_waiters_are_granted_in_fifo_order(self) -> None:
+    scheduler = TrainerScheduler(RecordingRestorer())
+    for run_id, pid in [("run-a", 101), ("run-b", 202), ("run-c", 303), ("run-d", 404)]:
+      await scheduler.register(run_id, pid)
+
+    self.assertTrue((await scheduler.acquire("run-a"))["ok"])
+
+    grant_order: list[str] = []
+
+    async def acquire_then_release(run_id: str) -> None:
+      await scheduler.acquire(run_id)
+      grant_order.append(run_id)
+      await scheduler.release(run_id)
+
+    waiters = []
+    for run_id in ["run-c", "run-b", "run-d"]:
+      waiters.append(asyncio.create_task(acquire_then_release(run_id)))
+      await asyncio.sleep(0.01)
+
+    self.assertTrue((await scheduler.release("run-a"))["ok"])
+    await asyncio.wait_for(asyncio.gather(*waiters), timeout=1.0)
+
+    self.assertEqual(grant_order, ["run-c", "run-b", "run-d"])
+
+
+class RunScopedQueueTest(unittest.IsolatedAsyncioTestCase):
+  async def test_worker_drains_only_its_run_queue(self) -> None:
+    store = InMemoryStore()
+    await store.put_request({"req_id": "a1", "model_id": "run-a"})
+    await store.put_request({"req_id": "b1", "model_id": "run-b"})
+    await store.put_request({"req_id": "a2", "model_id": "run-a"})
+
+    batch_a = await store.get_requests_for_model("run-a")
+    batch_b = await store.get_requests_for_model("run-b")
+
+    self.assertEqual([item["req_id"] for item in batch_a], ["a1", "a2"])
+    self.assertEqual([item["req_id"] for item in batch_b], ["b1"])
+
+
+class WorkerLauncherTest(unittest.TestCase):
+  def test_launcher_starts_scheduled_worker_for_run(self) -> None:
+    fake_process = types.SimpleNamespace(pid=1234)
+    with (
+      patch.dict(os.environ, {"REDIS_URL": "redis://redis:6379"}, clear=True),
+      patch("worker_launcher.subprocess.Popen", return_value=fake_process) as popen,
+    ):
+      process = launch_worker("run-a", "/tmp/open-rl/scheduler.sock")
+
+    self.assertIs(process, fake_process)
+    command = popen.call_args.args[0]
+    kwargs = popen.call_args.kwargs
+    self.assertTrue(command[1].endswith("clock_cycle.py"))
+    self.assertEqual(kwargs["env"]["OPEN_RL_WORKER_RUN_ID"], "run-a")
+    self.assertEqual(kwargs["env"]["OPEN_RL_SCHEDULER_SOCKET"], "/tmp/open-rl/scheduler.sock")
+    self.assertEqual(kwargs["env"]["OPEN_RL_DISABLE_WORKER_HEALTHZ"], "1")
+    self.assertTrue(kwargs["start_new_session"])
+
+  def test_launcher_requires_redis(self) -> None:
+    with patch.dict(os.environ, {}, clear=True), self.assertRaisesRegex(RuntimeError, "REDIS_URL"):
+      launch_worker("run-a", "/tmp/open-rl/scheduler.sock")
+
+
+class TrainerSchedulerSocketTest(unittest.IsolatedAsyncioTestCase):
+  async def test_persistent_socket_clients_alternate(self) -> None:
+    restorer = RecordingRestorer()
+    scheduler = TrainerScheduler(restorer)
+    with tempfile.TemporaryDirectory() as tmp:
+      socket_path = str(Path(tmp) / "scheduler.sock")
+      server = await serve_scheduler(scheduler, socket_path)
+      client_a = TrainerSchedulerClient(socket_path)
+      client_b = TrainerSchedulerClient(socket_path)
+      try:
+        await client_a.register("run-a", 101)
+        await client_b.register("run-b", 202)
+
+        async with client_a.acquire("run-a"):
+          blocked = asyncio.create_task(acquire_once(client_b, "run-b"))
+          await asyncio.sleep(0.05)
+          self.assertFalse(blocked.done())
+
+        self.assertEqual(await asyncio.wait_for(blocked, timeout=1.0), "run-b")
+        self.assertEqual(restorer.calls, [("checkpoint", 101), ("checkpoint", 202)])
+      finally:
+        await client_a.close()
+        await client_b.close()
+        server.close()
+        await server.wait_closed()
+
+  async def test_closing_active_worker_socket_marks_run_failed(self) -> None:
+    scheduler = TrainerScheduler(RecordingRestorer())
+    with tempfile.TemporaryDirectory() as tmp:
+      socket_path = str(Path(tmp) / "scheduler.sock")
+      server = await serve_scheduler(scheduler, socket_path)
+      client = TrainerSchedulerClient(socket_path)
+      try:
+        await client.register("run-a", 101)
+        await client.request({"command": "ACQUIRE", "run_id": "run-a"})
+        await client.close()
+        await asyncio.sleep(0.05)
+
+        self.assertIsNone(scheduler.active_run_id)
+        self.assertTrue(scheduler.workers["run-a"].failed)
+      finally:
+        server.close()
+        await server.wait_closed()
+
+
+async def acquire_once(client: TrainerSchedulerClient, run_id: str) -> str:
+  async with client.acquire(run_id):
+    return run_id
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
## Summary

This PR adds a first working full fine-tuning (FFT) path for OpenRL where two SFT jobs can share one local GPU through explicit scheduler handoff.

The main shape is:

- full-FT runs get their own trainer worker process
- each worker drains only its own run queue
- workers acquire/release CUDA access through a node-local trainer scheduler
- the scheduler uses `cuda-checkpoint` to checkpoint a worker on release and restore it before the next acquire
- the GSM8K SFT recipe demonstrates two concurrent full-FT jobs against the same gateway

For the detailed design notes, see [`AGENTS.md`](./AGENTS.md).

This prototype is mainly controlled by two server-side knobs:

- `OPEN_RL_TRAINING_MODE=full`
  - Forces training-client creation through the full fine-tuning path on the server.
  - This lets the stock Tinker client/cookbook loop keep calling the existing LoRA-shaped API while the server creates a full-FT worker.

- `OPEN_RL_SCHEDULER_SOCKET=/tmp/open-rl/trainer-scheduler.sock`
  - Enables scheduled full-FT workers.
  - The gateway launches a per-run worker, and workers coordinate CUDA access through this Unix socket.

`examples/sft/gsm8k` contains the demo path:

- start the scheduler
- start the gateway with full-FT mode and the scheduler socket
- launch two GSM8K SFT jobs with different `log_path`s
- use the printed `eval_model_path=...` for post-training vLLM eval

Sampling during training is still out of scope for this PR; eval is a separate post-training step.

Image show the scheduler checkpointing between two different jobs (note the different PID's)
<img width="672" height="854" alt="image" src="https://github.com/user-attachments/assets/8ea7a199-80ac-431b-88d5-a39f1a22deb4" />



