### PR TITLE
feat: add FFT trainer worker class

### DIFF
--- a/src/server/clock_cycle.py
+++ b/src/server/clock_cycle.py
@@ -10,14 +10,15 @@ from fastapi import FastAPI, HTTPException
 from opentelemetry import context as otel_context
 from opentelemetry import propagate, trace
 from store import get_store
-from training.trainer import Datum, LoraConfig, TrainerEngine
+from training.lora_trainer_worker import LoraConfig, LoraTrainingWorker
+from training.trainer_worker import Datum
 
 tracer = trace.get_tracer(__name__)
 
-engine = TrainerEngine()
+engine = LoraTrainingWorker()
 
 
-def _parse_datum(raw: dict) -> Datum:
+def parse_datum(raw: dict) -> Datum:
   """Convert wire-format datum (with chunks) to our flat Datum type."""
   chunks = raw.get("model_input", {}).get("chunks", [])
   tokens: list[int] = []
@@ -98,7 +99,7 @@ async def clock_cycle_loop() -> None:
                 loss_fn = r["loss_fn"]
                 loss_config = r.get("loss_config")
 
-                typed_data = [_parse_datum(item) for item in raw_data]
+                typed_data = [parse_datum(item) for item in raw_data]
 
                 result = await asyncio.to_thread(engine.forward_backward, typed_data, loss_fn, loss_config, m_id)
                 result["type"] = "forward_backward"

--- a/src/server/clock_cycle.py
+++ b/src/server/clock_cycle.py
@@ -10,7 +10,7 @@ from fastapi import FastAPI, HTTPException
 from opentelemetry import context as otel_context
 from opentelemetry import propagate, trace
 from store import get_store
-from trainer import Datum, LoraConfig, TrainerEngine
+from training.trainer import Datum, LoraConfig, TrainerEngine
 
 tracer = trace.get_tracer(__name__)
 

--- a/src/server/training/__init__.py
+++ b/src/server/training/__init__.py
@@ -1,0 +1,1 @@
+"""Training engine package."""

--- a/src/server/training/fft_trainer_worker.py
+++ b/src/server/training/fft_trainer_worker.py
@@ -1,0 +1,211 @@
+# Full fine-tuning trainer worker lifecycle.
+
+import json
+import math
+import os
+import time
+from datetime import datetime
+from typing import Any
+
+import torch
+from pydantic import BaseModel
+from transformers import AutoModelForCausalLM, AutoTokenizer, PreTrainedModel
+
+from training.trainer_worker import BaseTrainerWorker, Datum
+
+ENABLE_GRADIENT_CHECKPOINTING = os.getenv("ENABLE_GRADIENT_CHECKPOINTING", "1") == "1"
+
+
+class FFTConfig(BaseModel):
+  seed: int | None = None
+
+
+def trainable_model_parameters(model: PreTrainedModel) -> list[torch.nn.Parameter]:
+  params = [param for param in model.parameters() if param.requires_grad]
+  if not params:
+    raise ValueError("No trainable parameters found for full fine-tuning model")
+  return params
+
+
+class FFTTrainingWorker(BaseTrainerWorker):
+  def __init__(self):
+    super().__init__()
+    self.model: PreTrainedModel | None = None
+    self.base_model_name: str | None = None
+    self.trainable_params: list[torch.nn.Parameter] = []
+    self.optimizer: torch.optim.Optimizer | None = None
+
+  def load_base_model(self, base_model_name: str) -> None:
+    """Load one full model for one fine-tuning job process."""
+    if self.model is not None and self.base_model_name == base_model_name:
+      print(f"Full fine-tuning model {base_model_name} already loaded.")
+      return
+
+    print(f"Loading full fine-tuning model {base_model_name} to {self.device}...")
+    self.base_model_name = base_model_name
+    self.tokenizer = AutoTokenizer.from_pretrained(base_model_name)
+    dtype = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float32
+
+    self.model = AutoModelForCausalLM.from_pretrained(base_model_name, dtype=dtype, device_map=self.device)
+    self.prepare_model_for_training()
+    print("Successfully loaded full fine-tuning model.")
+
+  def create_model(self, model_id: str | None = None, config: FFTConfig | None = None) -> None:
+    """Prepare the loaded model for full fine-tuning."""
+    if config is not None and config.seed is not None:
+      torch.manual_seed(config.seed)
+    self.prepare_model_for_training()
+
+  def prepare_model_for_training(self) -> None:
+    assert self.model is not None, "Model is not loaded. Call load_base_model first."
+
+    for param in self.model.parameters():
+      param.requires_grad_(True)
+    self.trainable_params = trainable_model_parameters(self.model)
+
+    if ENABLE_GRADIENT_CHECKPOINTING:
+      try:
+        self.model.gradient_checkpointing_enable()
+        self.model.enable_input_require_grads()
+        print("Gradient checkpointing and input require grads enabled on full fine-tuning model.")
+      except Exception as e:
+        print(f"Failed to enable gradient checkpointing: {e}")
+
+    self.model.train()
+
+  def save_model(self, alias: str | None = None) -> dict[str, Any]:
+    assert self.model is not None, "Model must be loaded first."
+
+    tmp_dir = os.getenv("OPEN_RL_TMP_DIR", "/tmp/open-rl")
+    name = alias or "fft-model"
+    save_path = name if os.path.isabs(name) else os.path.join(tmp_dir, "fft", name)
+    os.makedirs(save_path, exist_ok=True)
+
+    self.model.save_pretrained(save_path)
+    if self.tokenizer is not None:
+      self.tokenizer.save_pretrained(save_path)
+
+    metadata = {
+      "base_model": self.base_model_name,
+      "created_at": datetime.now().isoformat(),
+      "kind": "weights",
+      "model_id": alias,
+      "timestamp": time.time(),
+    }
+    with open(os.path.join(save_path, "metadata.json"), "w") as f:
+      json.dump(metadata, f)
+
+    print(f"Saved full fine-tuning model to {save_path}")
+    return {"path": save_path}
+
+  def save_state(self, model_id: str, state_path: str, include_optimizer: bool = False, kind: str = "state") -> dict[str, Any]:
+    assert self.model is not None, "Model must be loaded first."
+
+    os.makedirs(state_path, exist_ok=True)
+    self.model.save_pretrained(state_path)
+    if self.tokenizer is not None:
+      self.tokenizer.save_pretrained(state_path)
+
+    if include_optimizer and self.optimizer is not None:
+      torch.save(self.optimizer.state_dict(), os.path.join(state_path, "optimizer.pt"))
+
+    metadata = {
+      "base_model": self.base_model_name,
+      "created_at": datetime.now().isoformat(),
+      "kind": kind,
+      "has_optimizer": include_optimizer and self.optimizer is not None,
+      "model_id": model_id,
+      "timestamp": time.time(),
+    }
+    with open(os.path.join(state_path, "metadata.json"), "w") as f:
+      json.dump(metadata, f)
+
+    print(f"Saved full fine-tuning state to {state_path}")
+    return {"path": state_path}
+
+  def load_from_state(self, model_id: str, state_path: str, restore_optimizer: bool = False) -> dict[str, Any]:
+    metadata_path = os.path.join(state_path, "metadata.json")
+    if not os.path.exists(metadata_path):
+      raise FileNotFoundError(f"No metadata.json found at {state_path}")
+
+    with open(metadata_path) as f:
+      metadata = json.load(f)
+
+    base_model = metadata.get("base_model")
+    if not base_model:
+      raise ValueError(f"metadata.json at {state_path} missing base_model")
+
+    self.base_model_name = base_model
+    self.tokenizer = AutoTokenizer.from_pretrained(state_path)
+    dtype = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float32
+    self.model = AutoModelForCausalLM.from_pretrained(state_path, dtype=dtype, device_map=self.device)
+    self.prepare_model_for_training()
+
+    if restore_optimizer and metadata.get("has_optimizer"):
+      optimizer_path = os.path.join(state_path, "optimizer.pt")
+      if os.path.exists(optimizer_path):
+        self.optimizer = torch.optim.AdamW(self.trainable_params, lr=1e-4)
+        self.optimizer.load_state_dict(torch.load(optimizer_path, map_location=self.device))
+        print(f"Restored optimizer state from {optimizer_path}")
+
+    print(f"Loaded full fine-tuning state from {state_path}")
+    return {"model_id": model_id, "is_lora": False, "base_model": base_model}
+
+  def forward_backward(self, data: list[Datum], loss_fn: str, loss_config: dict | None = None, model_id: str | None = None) -> dict[str, Any]:
+    assert self.model is not None, "Model must be loaded first."
+    return super().forward_backward(self.model, data, loss_fn, loss_config)
+
+  def optim_step(self, adam_params: dict[str, Any], model_id: str | None = None) -> dict[str, Any]:
+    assert self.model is not None, "Model must be loaded first."
+    if not self.trainable_params:
+      self.trainable_params = trainable_model_parameters(self.model)
+
+    if self.optimizer is None:
+      lr = adam_params.get("learning_rate", 1e-4)
+      beta1 = adam_params.get("beta1", 0.9)
+      beta2 = adam_params.get("beta2", 0.95)
+      eps = adam_params.get("eps", 1e-12)
+      weight_decay = adam_params.get("weight_decay", 0.0)
+
+      print(f"Initializing AdamW optimizer for full fine-tuning model with lr={lr}")
+      self.optimizer = torch.optim.AdamW(
+        self.trainable_params,
+        lr=lr,
+        betas=(beta1, beta2),
+        eps=eps,
+        weight_decay=weight_decay,
+      )
+
+    learning_rate = adam_params.get("learning_rate")
+    if learning_rate is not None:
+      for param_group in self.optimizer.param_groups:
+        param_group["lr"] = learning_rate
+
+    max_grad_norm = adam_params.get("grad_clip_norm") or math.inf
+    if max_grad_norm <= 0.0:
+      max_grad_norm = math.inf
+
+    total_norm = torch.nn.utils.clip_grad_norm_(
+      self.trainable_params,
+      max_grad_norm,
+    )
+
+    self.optimizer.step()
+    self.optimizer.zero_grad()
+
+    return {
+      "metrics": {
+        "grad_norm:mean": self.sanitize_float(total_norm.item()),
+      },
+    }
+
+  def generate(
+    self,
+    prompt_tokens: list[int],
+    max_tokens: int,
+    num_samples: int = 1,
+    temperature: float = 0.0,
+    model_id: str | None = None,
+    include_prompt_logprobs: bool = False,
+  ) -> dict[str, Any]:
+    return super().generate(self.model, prompt_tokens, max_tokens, num_samples, temperature, include_prompt_logprobs)

--- a/src/server/training/lora_trainer_worker.py
+++ b/src/server/training/lora_trainer_worker.py
@@ -1,4 +1,4 @@
-# This file contains the core training engine logic for Open-RL, handling forward/backward passes and optimization steps.
+# LoRA trainer worker lifecycle and adapter management.
 
 import json
 import math
@@ -12,15 +12,11 @@ import torch
 from peft import LoraConfig as PeftLoraConfig
 from peft import PeftModelForCausalLM, get_peft_model
 from pydantic import BaseModel
-from transformers import AutoModelForCausalLM, AutoTokenizer, PreTrainedModel, PreTrainedTokenizerBase
+from transformers import AutoModelForCausalLM, AutoTokenizer, PreTrainedModel
 
-from training import losses
+from training.trainer_worker import BaseTrainerWorker, Datum
 
 ENABLE_GRADIENT_CHECKPOINTING = os.getenv("ENABLE_GRADIENT_CHECKPOINTING", "1") == "1"
-
-
-class TensorData(BaseModel):
-  data: list[int] | list[float]
 
 
 class LoraConfig(BaseModel):
@@ -33,12 +29,7 @@ class LoraConfig(BaseModel):
   train_unembed: bool = False
 
 
-class Datum(BaseModel):
-  loss_fn_inputs: dict[str, TensorData]
-  model_input: list[int]
-
-
-def active_adapter_parameters(model: Any, adapter_id: str) -> list[torch.nn.Parameter]:
+def active_adapter_parameters(model: PeftModelForCausalLM, adapter_id: str) -> list[torch.nn.Parameter]:
   model.set_adapter(adapter_id)
   params = [param for param in model.parameters() if param.requires_grad]
   if not params:
@@ -46,31 +37,14 @@ def active_adapter_parameters(model: Any, adapter_id: str) -> list[torch.nn.Para
   return params
 
 
-class TrainerEngine:
+class LoraTrainingWorker(BaseTrainerWorker):
   def __init__(self):
-    # The raw pre-trained base model (e.g., Gemma, Qwen) loaded in VRAM
+    super().__init__()
     self.base_model: PreTrainedModel | None = None
-
-    # The model wrapped with PEFT/LoRA adapters that we actually train
     self.peft_model: PeftModelForCausalLM | None = None
-
-    # The tokenizer associated with the base model
-    self.tokenizer: PreTrainedTokenizerBase | None = None
-
-    # String identifier of the currently loaded base model
     self.base_model_name: str | None = None
-
-    # Store per-adapter training state by model_id (adapter ID).
     self.adapter_states: dict[str, dict[str, Any]] = {}
     self.lora_target_modules: dict[tuple[bool, bool, bool], list[str]] = {}
-
-    # Decide device
-    if torch.cuda.is_available():
-      self.device = torch.device("cuda")
-    elif torch.backends.mps.is_available():
-      self.device = torch.device("mps")
-    else:
-      self.device = torch.device("cpu")
 
   def load_base_model(self, base_model_name: str) -> None:
     """Eagerly load the massive base model tensors into VRAM."""
@@ -86,7 +60,7 @@ class TrainerEngine:
     self.base_model = AutoModelForCausalLM.from_pretrained(base_model_name, dtype=dtype, device_map=self.device)
     print("Successfully loaded.")
 
-  def _target_lora_modules(self, config: LoraConfig) -> list[str]:
+  def target_lora_modules(self, config: LoraConfig) -> list[str]:
     assert self.base_model is not None
 
     cache_key = (config.train_attn, config.train_mlp, config.train_unembed)
@@ -129,7 +103,7 @@ class TrainerEngine:
       lora_alpha=config.lora_alpha,
       lora_dropout=config.lora_dropout,
       bias="none",
-      target_modules=self._target_lora_modules(config),
+      target_modules=self.target_lora_modules(config),
       modules_to_save=None,
     )
 
@@ -267,175 +241,10 @@ class TrainerEngine:
     return {"model_id": model_id, "is_lora": True, "base_model": base_model}
 
   def forward_backward(self, data: list[Datum], loss_fn: str, loss_config: dict | None = None, model_id: str | None = None) -> dict[str, Any]:
-    """Core training step: forward pass, loss computation, and backward pass."""
     assert self.peft_model is not None, "Model must be loaded first."
     if model_id:
       self.peft_model.set_adapter(model_id)
-
-    total_loss = 0.0
-    loss_fn_outputs: list[dict[str, Any] | None] = [None] * len(data)
-
-    self.peft_model.train()
-
-    for batch in self.make_training_batches(data):
-      batch_indices = [idx for idx, _ in batch]
-      batch_data = [datum for _, datum in batch]
-
-      input_ids, attention_mask, input_lengths = self.pad_model_inputs(batch_data)
-      target_token_ids, weights, lengths = self.pad_targets_and_weights(batch_data, input_lengths)
-      target_logprobs = self.compute_target_logprobs(input_ids, attention_mask, target_token_ids)
-
-      match loss_fn:
-        case "cross_entropy":
-          elementwise_loss = losses.cross_entropy_loss(target_logprobs, weights)
-        case "importance_sampling":
-          old_logprobs = self.pad_sequences([datum.loss_fn_inputs["logprobs"].data for datum in batch_data], lengths, torch.float32)
-          advantages = self.pad_sequences([datum.loss_fn_inputs["advantages"].data for datum in batch_data], lengths, torch.float32)
-          elementwise_loss = losses.importance_sampling_loss(
-            target_logprobs,
-            weights,
-            old_logprobs,
-            advantages,
-          )
-        case "ppo":
-          old_logprobs = self.pad_sequences([datum.loss_fn_inputs["logprobs"].data for datum in batch_data], lengths, torch.float32)
-          advantages = self.pad_sequences([datum.loss_fn_inputs["advantages"].data for datum in batch_data], lengths, torch.float32)
-          elementwise_loss = losses.ppo_loss(
-            target_logprobs,
-            weights,
-            old_logprobs,
-            advantages,
-            loss_config,
-          )
-        case _:
-          raise NotImplementedError(f"Loss {loss_fn} not supported")
-
-      per_datum_loss = elementwise_loss.sum(dim=1)
-      loss = per_datum_loss.sum()
-      loss.backward()
-      total_loss += loss.item()
-
-      detached_logprobs = target_logprobs.detach().cpu()
-      for row, original_idx in enumerate(batch_indices):
-        row_len = lengths[row]
-        logprobs_list = detached_logprobs[row, :row_len].tolist()
-        logprobs_list = [max(l, -9999.0) if not math.isinf(l) else (-9999.0 if l < 0 else 9999.0) for l in logprobs_list]
-        loss_fn_outputs[original_idx] = {"logprobs": {"data": logprobs_list, "dtype": "float32", "shape": [len(logprobs_list)]}}
-
-    mean_loss = total_loss / max(1, len(data))
-    completed_loss_fn_outputs = []
-    for output in loss_fn_outputs:
-      if output is None:
-        raise RuntimeError("forward_backward did not produce one loss_fn_output per input datum")
-      completed_loss_fn_outputs.append(output)
-
-    return {
-      "metrics": {"loss:mean": self._sanitize_float(mean_loss), "loss:sum": self._sanitize_float(total_loss)},
-      "loss_fn_outputs": completed_loss_fn_outputs,
-      "loss_fn_output_type": "ArrayRecord",
-    }
-
-  def make_training_batches(self, data: list[Datum]) -> list[list[tuple[int, Datum]]]:
-    """Group examples for the single padded forward/backward path."""
-    if len(data) <= 1:
-      return [[(idx, datum)] for idx, datum in enumerate(data)]
-
-    token_budget = int(os.getenv("OPEN_RL_TRAIN_TOKEN_BUDGET", "0"))
-
-    if token_budget <= 0:
-      return [[(idx, datum)] for idx, datum in enumerate(data)]
-
-    ordered_data = sorted(enumerate(data), key=lambda item: len(item[1].model_input))
-    batches: list[list[tuple[int, Datum]]] = []
-    batch: list[tuple[int, Datum]] = []
-    batch_max_len = 0
-
-    for item in ordered_data:
-      length = len(item[1].model_input)
-      next_max_len = max(batch_max_len, length)
-      next_size = len(batch) + 1
-      over_token_budget = next_max_len * next_size > token_budget
-
-      if batch and over_token_budget:
-        batches.append(batch)
-        batch = []
-        batch_max_len = 0
-
-      batch.append(item)
-      batch_max_len = max(batch_max_len, length)
-
-    if batch:
-      batches.append(batch)
-
-    return batches
-
-  def pad_sequences(
-    self,
-    sequences: list[list[int] | list[float]],
-    lengths: list[int],
-    dtype: torch.dtype,
-    pad_value: int | float = 0,
-  ) -> torch.Tensor:
-    """Return padded values with shape [batch, max(lengths)]."""
-    padded = torch.full((len(sequences), max(lengths)), pad_value, dtype=dtype, device=self.device)
-    for row, sequence in enumerate(sequences):
-      length = lengths[row]
-      padded[row, :length] = padded.new_tensor(sequence[:length])
-    return padded
-
-  def pad_model_inputs(
-    self,
-    data: list[Datum],
-  ) -> tuple[torch.Tensor, torch.Tensor, list[int]]:
-    """Return input_ids and attention_mask with shape [batch, max_input_len]."""
-    pad_token_id = self.tokenizer.pad_token_id if self.tokenizer and self.tokenizer.pad_token_id is not None else 0
-    batch_size = len(data)
-    input_lengths = [len(datum.model_input) for datum in data]
-    max_input_len = max(input_lengths)
-
-    input_ids = self.pad_sequences([datum.model_input for datum in data], input_lengths, torch.long, pad_token_id)
-    attention_mask = input_ids.new_zeros((batch_size, max_input_len))
-    for row, input_len in enumerate(input_lengths):
-      attention_mask[row, :input_len] = 1
-
-    return input_ids, attention_mask, input_lengths
-
-  def pad_targets_and_weights(
-    self,
-    data: list[Datum],
-    input_lengths: list[int],
-  ) -> tuple[torch.Tensor, torch.Tensor, list[int]]:
-    """Return target_token_ids and weights with shape [batch, max_target_len]."""
-    batch_size = len(data)
-    target_lengths = [len(datum.loss_fn_inputs["target_tokens"].data) for datum in data]
-    lengths = [min(input_lengths[row], target_lengths[row]) for row in range(batch_size)]
-    target_token_ids = self.pad_sequences([datum.loss_fn_inputs["target_tokens"].data for datum in data], lengths, torch.long)
-    weight_sequences = [
-      datum.loss_fn_inputs["weights"].data if "weights" in datum.loss_fn_inputs else [1.0] * target_lengths[row] for row, datum in enumerate(data)
-    ]
-    weights = self.pad_sequences(weight_sequences, lengths, torch.float32)
-
-    return target_token_ids, weights, lengths
-
-  def compute_target_logprobs(
-    self,
-    input_ids: torch.Tensor,
-    attention_mask: torch.Tensor,
-    target_token_ids: torch.Tensor,
-  ) -> torch.Tensor:
-    """Return selected target logprobs with shape [batch, max_target_len]."""
-    assert self.peft_model is not None
-
-    outputs = self.peft_model(input_ids, attention_mask=attention_mask, use_cache=False, return_dict=True)
-    logits = outputs.logits[:, : target_token_ids.shape[1], :]
-    return torch.nn.functional.log_softmax(logits, dim=-1).gather(dim=-1, index=target_token_ids.unsqueeze(-1)).squeeze(-1)
-
-  def _sanitize_float(self, val: float) -> float:
-    if math.isinf(val):
-      return -9999.0 if val < 0 else 9999.0
-    if math.isnan(val):
-      return 0.0
-    return val
+    return super().forward_backward(self.peft_model, data, loss_fn, loss_config)
 
   def set_active_adapter(self, adapter_id: str) -> None:
     """Switch which LoRA adapter is active."""
@@ -493,7 +302,7 @@ class TrainerEngine:
 
     return {
       "metrics": {
-        "grad_norm:mean": self._sanitize_float(total_norm.item()),
+        "grad_norm:mean": self.sanitize_float(total_norm.item()),
       },
     }
 
@@ -506,68 +315,9 @@ class TrainerEngine:
     model_id: str | None = None,
     include_prompt_logprobs: bool = False,
   ) -> dict[str, Any]:
-    """Generate completions from the current model."""
-    assert self.peft_model is not None, "Model must be loaded first."
-
     if model_id:
       self.peft_model.set_adapter(model_id)
-    self.peft_model.eval()
-
-    input_tensor = torch.tensor([prompt_tokens], dtype=torch.long, device=self.device)
-    do_sample = (num_samples > 1) or (temperature and temperature > 0.0)
-    prompt_logprobs = self._prompt_logprobs(input_tensor) if include_prompt_logprobs else None
-
-    with torch.no_grad():
-      attention_mask = torch.ones_like(input_tensor)
-      outputs = self.peft_model.generate(
-        input_tensor,
-        attention_mask=attention_mask,
-        max_new_tokens=max_tokens,
-        pad_token_id=self.tokenizer.pad_token_id or self.tokenizer.eos_token_id,
-        do_sample=do_sample,
-        temperature=temperature if do_sample else None,
-        top_p=None,
-        top_k=None,
-        num_return_sequences=num_samples,
-        output_scores=True,
-        return_dict_in_generate=True,
-      )
-
-    sequences_out = []
-    for seq_idx in range(num_samples):
-      gen_sequences = outputs.sequences[seq_idx]
-      generated_tokens = gen_sequences[len(prompt_tokens) :].cpu().tolist()
-
-      logprobs = []
-      for token_step_idx in range(len(generated_tokens)):
-        score_tensor = outputs.scores[token_step_idx]
-        logprob_dist = torch.nn.functional.log_softmax(score_tensor[seq_idx], dim=-1)
-        token_id = generated_tokens[token_step_idx]
-        logprob = logprob_dist[token_id].item()
-        logprobs.append(self._sanitize_float(logprob))
-
-      sequences_out.append({"tokens": generated_tokens, "logprobs": logprobs, "stop_reason": "stop"})
-
-    result = {"sequences": sequences_out}
-    if prompt_logprobs is not None:
-      result["prompt_logprobs"] = prompt_logprobs
-    return result
-
-  def _prompt_logprobs(self, input_tensor: torch.Tensor) -> list[float | None]:
-    assert self.peft_model is not None, "Model must be loaded first."
-
-    with torch.no_grad():
-      attention_mask = torch.ones_like(input_tensor)
-      outputs = self.peft_model(input_tensor, attention_mask=attention_mask)
-      logprob_dist = torch.nn.functional.log_softmax(outputs.logits[0, :-1], dim=-1)
-
-    prompt_tokens = input_tensor[0].tolist()
-    prompt_logprobs: list[float | None] = [None]
-    for token_idx, token_id in enumerate(prompt_tokens[1:]):
-      logprob = logprob_dist[token_idx, token_id].item()
-      prompt_logprobs.append(self._sanitize_float(logprob))
-
-    return prompt_logprobs
+    return super().generate(self.peft_model, prompt_tokens, max_tokens, num_samples, temperature, include_prompt_logprobs)
 
 
 def main() -> None:

--- a/src/server/training/losses.py
+++ b/src/server/training/losses.py
@@ -1,0 +1,40 @@
+import torch
+
+
+def cross_entropy_loss(target_logprobs: torch.Tensor, weights: torch.Tensor) -> torch.Tensor:
+  return -target_logprobs * weights
+
+
+def importance_sampling_loss(
+  target_logprobs: torch.Tensor,
+  weights: torch.Tensor,
+  old_logprobs: torch.Tensor,
+  advantages: torch.Tensor,
+) -> torch.Tensor:
+  ratio = policy_ratio(target_logprobs, old_logprobs)
+  elementwise_loss = -(ratio * advantages) * weights
+  return torch.nan_to_num(elementwise_loss, nan=0.0, posinf=0.0, neginf=0.0)
+
+
+def ppo_loss(
+  target_logprobs: torch.Tensor,
+  weights: torch.Tensor,
+  old_logprobs: torch.Tensor,
+  advantages: torch.Tensor,
+  loss_config: dict | None,
+) -> torch.Tensor:
+  diff = torch.clamp(target_logprobs - old_logprobs, min=-20.0, max=20.0)
+  ratio = torch.exp(diff)
+  epsilon = loss_config.get("clip_range", 0.2) if loss_config else 0.2
+  surr1 = ratio * advantages
+  surr2 = torch.clamp(ratio, 1.0 - epsilon, 1.0 + epsilon) * advantages
+  elementwise_objective = torch.min(surr1, surr2)
+  kl_coeff = loss_config.get("kl_coeff", 0.0) if loss_config else 0.0
+  if kl_coeff > 0:
+    kl = (ratio - 1) - diff
+    elementwise_objective = elementwise_objective - kl_coeff * kl
+  return -(elementwise_objective * weights)
+
+
+def policy_ratio(target_logprobs: torch.Tensor, ref_logprobs: torch.Tensor) -> torch.Tensor:
+  return torch.exp(torch.clamp(target_logprobs - ref_logprobs, min=-20.0, max=20.0))

--- a/src/server/training/trainer.py
+++ b/src/server/training/trainer.py
@@ -14,6 +14,8 @@ from peft import PeftModelForCausalLM, get_peft_model
 from pydantic import BaseModel
 from transformers import AutoModelForCausalLM, AutoTokenizer, PreTrainedModel, PreTrainedTokenizerBase
 
+from training import losses
+
 ENABLE_GRADIENT_CHECKPOINTING = os.getenv("ENABLE_GRADIENT_CHECKPOINTING", "1") == "1"
 
 
@@ -275,18 +277,36 @@ class TrainerEngine:
 
     self.peft_model.train()
 
-    for batch in self._make_training_batches(data):
+    for batch in self.make_training_batches(data):
       batch_indices = [idx for idx, _ in batch]
       batch_data = [datum for _, datum in batch]
 
-      target_logprobs, weights, aux_inputs, lengths = self._get_logprobs_batch(batch_data)
+      input_ids, attention_mask, input_lengths = self.pad_model_inputs(batch_data)
+      target_token_ids, weights, lengths = self.pad_targets_and_weights(batch_data, input_lengths)
+      target_logprobs = self.compute_target_logprobs(input_ids, attention_mask, target_token_ids)
+
       match loss_fn:
         case "cross_entropy":
-          elementwise_loss = self._cross_entropy_loss(target_logprobs, weights)
+          elementwise_loss = losses.cross_entropy_loss(target_logprobs, weights)
         case "importance_sampling":
-          elementwise_loss = self._importance_sampling_loss(target_logprobs, weights, aux_inputs)
+          old_logprobs = self.pad_sequences([datum.loss_fn_inputs["logprobs"].data for datum in batch_data], lengths, torch.float32)
+          advantages = self.pad_sequences([datum.loss_fn_inputs["advantages"].data for datum in batch_data], lengths, torch.float32)
+          elementwise_loss = losses.importance_sampling_loss(
+            target_logprobs,
+            weights,
+            old_logprobs,
+            advantages,
+          )
         case "ppo":
-          elementwise_loss = self._ppo_loss(target_logprobs, weights, aux_inputs, loss_config)
+          old_logprobs = self.pad_sequences([datum.loss_fn_inputs["logprobs"].data for datum in batch_data], lengths, torch.float32)
+          advantages = self.pad_sequences([datum.loss_fn_inputs["advantages"].data for datum in batch_data], lengths, torch.float32)
+          elementwise_loss = losses.ppo_loss(
+            target_logprobs,
+            weights,
+            old_logprobs,
+            advantages,
+            loss_config,
+          )
         case _:
           raise NotImplementedError(f"Loss {loss_fn} not supported")
 
@@ -315,7 +335,7 @@ class TrainerEngine:
       "loss_fn_output_type": "ArrayRecord",
     }
 
-  def _make_training_batches(self, data: list[Datum]) -> list[list[tuple[int, Datum]]]:
+  def make_training_batches(self, data: list[Datum]) -> list[list[tuple[int, Datum]]]:
     """Group examples for the single padded forward/backward path."""
     if len(data) <= 1:
       return [[(idx, datum)] for idx, datum in enumerate(data)]
@@ -349,97 +369,66 @@ class TrainerEngine:
 
     return batches
 
-  def _get_logprobs_batch(self, data: list[Datum]) -> tuple[torch.Tensor, torch.Tensor, dict[str, torch.Tensor], list[int]]:
-    assert self.peft_model is not None
+  def pad_sequences(
+    self,
+    sequences: list[list[int] | list[float]],
+    lengths: list[int],
+    dtype: torch.dtype,
+    pad_value: int | float = 0,
+  ) -> torch.Tensor:
+    """Return padded values with shape [batch, max(lengths)]."""
+    padded = torch.full((len(sequences), max(lengths)), pad_value, dtype=dtype, device=self.device)
+    for row, sequence in enumerate(sequences):
+      length = lengths[row]
+      padded[row, :length] = padded.new_tensor(sequence[:length])
+    return padded
 
+  def pad_model_inputs(
+    self,
+    data: list[Datum],
+  ) -> tuple[torch.Tensor, torch.Tensor, list[int]]:
+    """Return input_ids and attention_mask with shape [batch, max_input_len]."""
     pad_token_id = self.tokenizer.pad_token_id if self.tokenizer and self.tokenizer.pad_token_id is not None else 0
     batch_size = len(data)
     input_lengths = [len(datum.model_input) for datum in data]
     max_input_len = max(input_lengths)
 
-    input_tensor = torch.full((batch_size, max_input_len), pad_token_id, dtype=torch.long, device=self.device)
-    attention_mask = torch.zeros((batch_size, max_input_len), dtype=torch.long, device=self.device)
-    for row, datum in enumerate(data):
-      input_len = input_lengths[row]
-      input_tensor[row, :input_len] = torch.tensor(datum.model_input, dtype=torch.long, device=self.device)
+    input_ids = self.pad_sequences([datum.model_input for datum in data], input_lengths, torch.long, pad_token_id)
+    attention_mask = input_ids.new_zeros((batch_size, max_input_len))
+    for row, input_len in enumerate(input_lengths):
       attention_mask[row, :input_len] = 1
 
+    return input_ids, attention_mask, input_lengths
+
+  def pad_targets_and_weights(
+    self,
+    data: list[Datum],
+    input_lengths: list[int],
+  ) -> tuple[torch.Tensor, torch.Tensor, list[int]]:
+    """Return target_token_ids and weights with shape [batch, max_target_len]."""
+    batch_size = len(data)
     target_lengths = [len(datum.loss_fn_inputs["target_tokens"].data) for datum in data]
     lengths = [min(input_lengths[row], target_lengths[row]) for row in range(batch_size)]
-    max_target_len = max(lengths)
-    loss_dtype = torch.float32
+    target_token_ids = self.pad_sequences([datum.loss_fn_inputs["target_tokens"].data for datum in data], lengths, torch.long)
+    weight_sequences = [
+      datum.loss_fn_inputs["weights"].data if "weights" in datum.loss_fn_inputs else [1.0] * target_lengths[row] for row, datum in enumerate(data)
+    ]
+    weights = self.pad_sequences(weight_sequences, lengths, torch.float32)
 
-    targets = torch.zeros((batch_size, max_target_len), dtype=torch.long, device=self.device)
-    weights = torch.zeros((batch_size, max_target_len), dtype=loss_dtype, device=self.device)
-    aux_inputs: dict[str, torch.Tensor] = {}
+    return target_token_ids, weights, lengths
 
-    aux_keys = set().union(*(datum.loss_fn_inputs.keys() for datum in data)) - {"target_tokens", "weights"}
-    for key in aux_keys:
-      aux_inputs[key] = torch.zeros((batch_size, max_target_len), dtype=loss_dtype, device=self.device)
-
-    for row, datum in enumerate(data):
-      seq_len = lengths[row]
-      targets_data = datum.loss_fn_inputs["target_tokens"].data[:seq_len]
-      targets[row, :seq_len] = torch.tensor(targets_data, dtype=torch.long, device=self.device)
-
-      weights_data = datum.loss_fn_inputs["weights"].data if "weights" in datum.loss_fn_inputs else [1.0] * target_lengths[row]
-      weights[row, :seq_len] = torch.tensor(weights_data[:seq_len], dtype=loss_dtype, device=self.device)
-
-      for key, aux_tensor in aux_inputs.items():
-        if key not in datum.loss_fn_inputs:
-          continue
-        values = datum.loss_fn_inputs[key].data[:seq_len]
-        aux_tensor[row, :seq_len] = torch.tensor(values, dtype=loss_dtype, device=self.device)
-
-    outputs = self.peft_model(input_tensor, attention_mask=attention_mask, use_cache=False, return_dict=True)
-    logits = outputs.logits[:, :max_target_len, :]
-    target_logprobs = torch.nn.functional.log_softmax(logits, dim=-1).gather(dim=-1, index=targets.unsqueeze(-1)).squeeze(-1)
-
-    return target_logprobs, weights, aux_inputs, lengths
-
-  def _cross_entropy_loss(self, target_logprobs: torch.Tensor, weights: torch.Tensor) -> torch.Tensor:
-    return -target_logprobs * weights
-
-  def _importance_sampling_loss(
+  def compute_target_logprobs(
     self,
-    target_logprobs: torch.Tensor,
-    weights: torch.Tensor,
-    aux_inputs: dict[str, torch.Tensor],
+    input_ids: torch.Tensor,
+    attention_mask: torch.Tensor,
+    target_token_ids: torch.Tensor,
   ) -> torch.Tensor:
-    ref, advantages = self._reference_logprobs_and_advantages(aux_inputs, "importance_sampling")
-    ratio = self._policy_ratio(target_logprobs, ref)
-    elementwise_loss = -(ratio * advantages) * weights
-    return torch.nan_to_num(elementwise_loss, nan=0.0, posinf=0.0, neginf=0.0)
+    """Return selected target logprobs with shape [batch, max_target_len]."""
+    assert self.peft_model is not None
 
-  def _ppo_loss(
-    self,
-    target_logprobs: torch.Tensor,
-    weights: torch.Tensor,
-    aux_inputs: dict[str, torch.Tensor],
-    loss_config: dict | None,
-  ) -> torch.Tensor:
-    ref, advantages = self._reference_logprobs_and_advantages(aux_inputs, "ppo")
-    diff = torch.clamp(target_logprobs - ref, min=-20.0, max=20.0)
-    ratio = torch.exp(diff)
-    epsilon = loss_config.get("clip_range", 0.2) if loss_config else 0.2
-    surr1 = ratio * advantages
-    surr2 = torch.clamp(ratio, 1.0 - epsilon, 1.0 + epsilon) * advantages
-    elementwise_objective = torch.min(surr1, surr2)
-    kl_coeff = loss_config.get("kl_coeff", 0.0) if loss_config else 0.0
-    if kl_coeff > 0:
-      kl = (ratio - 1) - diff
-      elementwise_objective = elementwise_objective - kl_coeff * kl
-    return -(elementwise_objective * weights)
-
-  def _reference_logprobs_and_advantages(self, aux_inputs: dict[str, torch.Tensor], loss_fn: str) -> tuple[torch.Tensor, torch.Tensor]:
-    ref = aux_inputs.get("logprobs")
-    advantages = aux_inputs.get("advantages")
-    if ref is None or advantages is None:
-      raise ValueError(f"{loss_fn} requires 'logprobs' and 'advantages' in loss_fn_inputs")
-    return ref, advantages
-
-  def _policy_ratio(self, target_logprobs: torch.Tensor, ref_logprobs: torch.Tensor) -> torch.Tensor:
-    return torch.exp(torch.clamp(target_logprobs - ref_logprobs, min=-20.0, max=20.0))
+    outputs = self.peft_model(input_ids, attention_mask=attention_mask, use_cache=False, return_dict=True)
+    logits = outputs.logits[:, : target_token_ids.shape[1], :]
+    return torch.nn.functional.log_softmax(logits, dim=-1).gather(dim=-1, index=target_token_ids.unsqueeze(-1)).squeeze(-1)
 
   def _sanitize_float(self, val: float) -> float:
     if math.isinf(val):

--- a/src/server/training/trainer_worker.py
+++ b/src/server/training/trainer_worker.py
@@ -1,0 +1,264 @@
+# Shared trainer worker logic for causal-LM forward/backward and generation.
+
+import math
+import os
+from typing import Any
+
+import torch
+from pydantic import BaseModel
+from transformers import PreTrainedModel, PreTrainedTokenizerBase
+
+from training import losses
+
+
+class TensorData(BaseModel):
+  data: list[int] | list[float]
+
+
+class Datum(BaseModel):
+  loss_fn_inputs: dict[str, TensorData]
+  model_input: list[int]
+
+
+class BaseTrainerWorker:
+  def __init__(self):
+    self.tokenizer: PreTrainedTokenizerBase | None = None
+
+    if torch.cuda.is_available():
+      self.device = torch.device("cuda")
+    elif torch.backends.mps.is_available():
+      self.device = torch.device("mps")
+    else:
+      self.device = torch.device("cpu")
+
+  def forward_backward(self, model: PreTrainedModel, data: list[Datum], loss_fn: str, loss_config: dict | None = None) -> dict[str, Any]:
+    """Run a forward/backward pass on model and return Tinker-shaped loss outputs."""
+    total_loss = 0.0
+    loss_fn_outputs: list[dict[str, Any] | None] = [None] * len(data)
+
+    model.train()
+
+    for batch in self.make_training_batches(data):
+      batch_indices = [idx for idx, _ in batch]
+      batch_data = [datum for _, datum in batch]
+
+      input_ids, attention_mask, input_lengths = self.pad_model_inputs(batch_data)
+      target_token_ids, weights, lengths = self.pad_targets_and_weights(batch_data, input_lengths)
+      target_logprobs = self.compute_target_logprobs(model, input_ids, attention_mask, target_token_ids)
+
+      match loss_fn:
+        case "cross_entropy":
+          elementwise_loss = losses.cross_entropy_loss(target_logprobs, weights)
+        case "importance_sampling":
+          old_logprobs = self.pad_sequences([datum.loss_fn_inputs["logprobs"].data for datum in batch_data], lengths, torch.float32)
+          advantages = self.pad_sequences([datum.loss_fn_inputs["advantages"].data for datum in batch_data], lengths, torch.float32)
+          elementwise_loss = losses.importance_sampling_loss(
+            target_logprobs,
+            weights,
+            old_logprobs,
+            advantages,
+          )
+        case "ppo":
+          old_logprobs = self.pad_sequences([datum.loss_fn_inputs["logprobs"].data for datum in batch_data], lengths, torch.float32)
+          advantages = self.pad_sequences([datum.loss_fn_inputs["advantages"].data for datum in batch_data], lengths, torch.float32)
+          elementwise_loss = losses.ppo_loss(
+            target_logprobs,
+            weights,
+            old_logprobs,
+            advantages,
+            loss_config,
+          )
+        case _:
+          raise NotImplementedError(f"Loss {loss_fn} not supported")
+
+      per_datum_loss = elementwise_loss.sum(dim=1)
+      loss = per_datum_loss.sum()
+      loss.backward()
+      total_loss += loss.item()
+
+      detached_logprobs = target_logprobs.detach().cpu()
+      for row, original_idx in enumerate(batch_indices):
+        row_len = lengths[row]
+        logprobs_list = detached_logprobs[row, :row_len].tolist()
+        logprobs_list = [max(l, -9999.0) if not math.isinf(l) else (-9999.0 if l < 0 else 9999.0) for l in logprobs_list]
+        loss_fn_outputs[original_idx] = {"logprobs": {"data": logprobs_list, "dtype": "float32", "shape": [len(logprobs_list)]}}
+
+    mean_loss = total_loss / max(1, len(data))
+    completed_loss_fn_outputs = []
+    for output in loss_fn_outputs:
+      if output is None:
+        raise RuntimeError("forward_backward did not produce one loss_fn_output per input datum")
+      completed_loss_fn_outputs.append(output)
+
+    return {
+      "metrics": {"loss:mean": self.sanitize_float(mean_loss), "loss:sum": self.sanitize_float(total_loss)},
+      "loss_fn_outputs": completed_loss_fn_outputs,
+      "loss_fn_output_type": "ArrayRecord",
+    }
+
+  def make_training_batches(self, data: list[Datum]) -> list[list[tuple[int, Datum]]]:
+    """Group examples for the single padded forward/backward path."""
+    if len(data) <= 1:
+      return [[(idx, datum)] for idx, datum in enumerate(data)]
+
+    token_budget = int(os.getenv("OPEN_RL_TRAIN_TOKEN_BUDGET", "0"))
+
+    if token_budget <= 0:
+      return [[(idx, datum)] for idx, datum in enumerate(data)]
+
+    ordered_data = sorted(enumerate(data), key=lambda item: len(item[1].model_input))
+    batches: list[list[tuple[int, Datum]]] = []
+    batch: list[tuple[int, Datum]] = []
+    batch_max_len = 0
+
+    for item in ordered_data:
+      length = len(item[1].model_input)
+      next_max_len = max(batch_max_len, length)
+      next_size = len(batch) + 1
+      over_token_budget = next_max_len * next_size > token_budget
+
+      if batch and over_token_budget:
+        batches.append(batch)
+        batch = []
+        batch_max_len = 0
+
+      batch.append(item)
+      batch_max_len = max(batch_max_len, length)
+
+    if batch:
+      batches.append(batch)
+
+    return batches
+
+  def pad_sequences(
+    self,
+    sequences: list[list[int] | list[float]],
+    lengths: list[int],
+    dtype: torch.dtype,
+    pad_value: int | float = 0,
+  ) -> torch.Tensor:
+    """Return padded values with shape [batch, max(lengths)]."""
+    padded = torch.full((len(sequences), max(lengths)), pad_value, dtype=dtype, device=self.device)
+    for row, sequence in enumerate(sequences):
+      length = lengths[row]
+      padded[row, :length] = padded.new_tensor(sequence[:length])
+    return padded
+
+  def pad_model_inputs(
+    self,
+    data: list[Datum],
+  ) -> tuple[torch.Tensor, torch.Tensor, list[int]]:
+    """Return input_ids and attention_mask with shape [batch, max_input_len]."""
+    pad_token_id = self.tokenizer.pad_token_id if self.tokenizer and self.tokenizer.pad_token_id is not None else 0
+    batch_size = len(data)
+    input_lengths = [len(datum.model_input) for datum in data]
+    max_input_len = max(input_lengths)
+
+    input_ids = self.pad_sequences([datum.model_input for datum in data], input_lengths, torch.long, pad_token_id)
+    attention_mask = input_ids.new_zeros((batch_size, max_input_len))
+    for row, input_len in enumerate(input_lengths):
+      attention_mask[row, :input_len] = 1
+
+    return input_ids, attention_mask, input_lengths
+
+  def pad_targets_and_weights(
+    self,
+    data: list[Datum],
+    input_lengths: list[int],
+  ) -> tuple[torch.Tensor, torch.Tensor, list[int]]:
+    """Return target_token_ids and weights with shape [batch, max_target_len]."""
+    batch_size = len(data)
+    target_lengths = [len(datum.loss_fn_inputs["target_tokens"].data) for datum in data]
+    lengths = [min(input_lengths[row], target_lengths[row]) for row in range(batch_size)]
+    target_token_ids = self.pad_sequences([datum.loss_fn_inputs["target_tokens"].data for datum in data], lengths, torch.long)
+    weight_sequences = [
+      datum.loss_fn_inputs["weights"].data if "weights" in datum.loss_fn_inputs else [1.0] * target_lengths[row] for row, datum in enumerate(data)
+    ]
+    weights = self.pad_sequences(weight_sequences, lengths, torch.float32)
+
+    return target_token_ids, weights, lengths
+
+  def compute_target_logprobs(
+    self,
+    model: PreTrainedModel,
+    input_ids: torch.Tensor,
+    attention_mask: torch.Tensor,
+    target_token_ids: torch.Tensor,
+  ) -> torch.Tensor:
+    """Return selected target logprobs with shape [batch, max_target_len]."""
+    outputs = model(input_ids, attention_mask=attention_mask, use_cache=False, return_dict=True)
+    logits = outputs.logits[:, : target_token_ids.shape[1], :]
+    return torch.nn.functional.log_softmax(logits, dim=-1).gather(dim=-1, index=target_token_ids.unsqueeze(-1)).squeeze(-1)
+
+  def generate(
+    self,
+    model: PreTrainedModel,
+    prompt_tokens: list[int],
+    max_tokens: int,
+    num_samples: int = 1,
+    temperature: float = 0.0,
+    include_prompt_logprobs: bool = False,
+  ) -> dict[str, Any]:
+    """Generate completions from model."""
+    model.eval()
+
+    input_tensor = torch.tensor([prompt_tokens], dtype=torch.long, device=self.device)
+    do_sample = (num_samples > 1) or (temperature and temperature > 0.0)
+    prompt_logprobs = self.prompt_logprobs(model, input_tensor) if include_prompt_logprobs else None
+
+    with torch.no_grad():
+      attention_mask = torch.ones_like(input_tensor)
+      outputs = model.generate(
+        input_tensor,
+        attention_mask=attention_mask,
+        max_new_tokens=max_tokens,
+        pad_token_id=self.tokenizer.pad_token_id or self.tokenizer.eos_token_id,
+        do_sample=do_sample,
+        temperature=temperature if do_sample else None,
+        top_p=None,
+        top_k=None,
+        num_return_sequences=num_samples,
+        output_scores=True,
+        return_dict_in_generate=True,
+      )
+
+    sequences_out = []
+    for seq_idx in range(num_samples):
+      gen_sequences = outputs.sequences[seq_idx]
+      generated_tokens = gen_sequences[len(prompt_tokens) :].cpu().tolist()
+
+      logprobs = []
+      for token_step_idx in range(len(generated_tokens)):
+        score_tensor = outputs.scores[token_step_idx]
+        logprob_dist = torch.nn.functional.log_softmax(score_tensor[seq_idx], dim=-1)
+        token_id = generated_tokens[token_step_idx]
+        logprob = logprob_dist[token_id].item()
+        logprobs.append(self.sanitize_float(logprob))
+
+      sequences_out.append({"tokens": generated_tokens, "logprobs": logprobs, "stop_reason": "stop"})
+
+    result = {"sequences": sequences_out}
+    if prompt_logprobs is not None:
+      result["prompt_logprobs"] = prompt_logprobs
+    return result
+
+  def prompt_logprobs(self, model: PreTrainedModel, input_tensor: torch.Tensor) -> list[float | None]:
+    with torch.no_grad():
+      attention_mask = torch.ones_like(input_tensor)
+      outputs = model(input_tensor, attention_mask=attention_mask)
+      logprob_dist = torch.nn.functional.log_softmax(outputs.logits[0, :-1], dim=-1)
+
+    prompt_tokens = input_tensor[0].tolist()
+    prompt_logprobs: list[float | None] = [None]
+    for token_idx, token_id in enumerate(prompt_tokens[1:]):
+      logprob = logprob_dist[token_idx, token_id].item()
+      prompt_logprobs.append(self.sanitize_float(logprob))
+
+    return prompt_logprobs
+
+  def sanitize_float(self, val: float) -> float:
+    if math.isinf(val):
+      return -9999.0 if val < 0 else 9999.0
+    if math.isnan(val):
+      return 0.0
+    return val

--- a/tests/test_trainer_optimizer_correctness.py
+++ b/tests/test_trainer_optimizer_correctness.py
@@ -32,13 +32,15 @@ def _load_trainer_modules():
         del sys.modules[module_name]
     trainer_worker = importlib.import_module("training.trainer_worker")
     lora_trainer_worker = importlib.import_module("training.lora_trainer_worker")
+    fft_trainer_worker = importlib.import_module("training.fft_trainer_worker")
     losses = importlib.import_module("training.losses")
   sys.path = old_path
-  return trainer_worker, lora_trainer_worker, losses
+  return trainer_worker, lora_trainer_worker, fft_trainer_worker, losses
 
 
-trainer_worker_module, lora_trainer_worker_module, losses_module = _load_trainer_modules()
+trainer_worker_module, lora_trainer_worker_module, fft_trainer_worker_module, losses_module = _load_trainer_modules()
 BaseTrainerWorker = trainer_worker_module.BaseTrainerWorker
+FFTTrainingWorker = fft_trainer_worker_module.FFTTrainingWorker
 LoraTrainingWorker = lora_trainer_worker_module.LoraTrainingWorker
 
 
@@ -82,6 +84,17 @@ class _LogitModelStub:
     logits = torch.cos(input_tensor.float().unsqueeze(-1) * 0.11 + positions * 0.07 + vocab * 0.13)
     logits.requires_grad_()
     return types.SimpleNamespace(logits=logits)
+
+
+class _FullModelStub:
+  def __init__(self, params):
+    self.params = params
+
+  def train(self):
+    return None
+
+  def parameters(self):
+    yield from self.params
 
 
 def _datum(model_input, target_tokens, *, weights=None, logprobs=None, advantages=None):
@@ -132,6 +145,33 @@ class TestTrainerOptimizerCorrectness(unittest.TestCase):
     if active_param.grad is not None:
       self.assertTrue(torch.allclose(active_param.grad, torch.zeros_like(active_param.grad)))
     self.assertIsNotNone(other_param.grad)
+
+  def test_fft_optim_step_updates_full_model_trainable_params(self) -> None:
+    trainable_param = torch.nn.Parameter(torch.tensor([1.0]))
+    frozen_param = torch.nn.Parameter(torch.tensor([1.0]), requires_grad=False)
+    trainable_param.grad = torch.tensor([1.0])
+    frozen_param.grad = torch.tensor([10.0])
+
+    engine = FFTTrainingWorker()
+    engine.model = _FullModelStub([trainable_param, frozen_param])
+    engine.trainable_params = fft_trainer_worker_module.trainable_model_parameters(engine.model)
+
+    result = engine.optim_step(
+      {
+        "learning_rate": 0.1,
+        "beta1": 0.0,
+        "beta2": 0.0,
+        "eps": 1e-8,
+        "weight_decay": 0.0,
+      }
+    )
+
+    self.assertAlmostEqual(result["metrics"]["grad_norm:mean"], 1.0)
+    self.assertFalse(torch.allclose(trainable_param.detach(), torch.tensor([1.0])))
+    self.assertTrue(torch.allclose(frozen_param.detach(), torch.tensor([1.0])))
+    if trainable_param.grad is not None:
+      self.assertTrue(torch.allclose(trainable_param.grad, torch.zeros_like(trainable_param.grad)))
+    self.assertIsNotNone(frozen_param.grad)
 
 
 class TestTrainerPaddedBatchingMath(unittest.TestCase):
@@ -262,6 +302,18 @@ class TestTrainerPaddedBatchingMath(unittest.TestCase):
     for datum, output in zip(data, result["loss_fn_outputs"], strict=True):
       logprobs = output["logprobs"]
       self.assertEqual(logprobs["shape"], [min(len(datum.model_input), len(datum.loss_fn_inputs["target_tokens"].data))])
+
+  def test_fft_forward_backward_uses_single_process_model(self) -> None:
+    worker = FFTTrainingWorker()
+    worker.device = torch.device("cpu")
+    worker.tokenizer = _TokenizerStub()
+    worker.model = _LogitModelStub()
+    data = self._data()
+
+    result = worker.forward_backward(data, "cross_entropy")
+
+    self.assertEqual(len(result["loss_fn_outputs"]), len(data))
+    self.assertGreater(len(worker.model.calls), 0)
 
 
 if __name__ == "__main__":

--- a/tests/test_trainer_optimizer_correctness.py
+++ b/tests/test_trainer_optimizer_correctness.py
@@ -10,7 +10,7 @@ import torch
 from tests._server_fixture import SERVER_DIR
 
 
-def _load_trainer_module():
+def _load_trainer_modules():
   stubs = {
     "peft": types.SimpleNamespace(
       LoraConfig=object,
@@ -30,14 +30,16 @@ def _load_trainer_module():
     for module_name in list(sys.modules):
       if module_name == "training" or module_name.startswith("training."):
         del sys.modules[module_name]
-    module = importlib.import_module("training.trainer")
-    module.losses = importlib.import_module("training.losses")
+    trainer_worker = importlib.import_module("training.trainer_worker")
+    lora_trainer_worker = importlib.import_module("training.lora_trainer_worker")
+    losses = importlib.import_module("training.losses")
   sys.path = old_path
-  return module
+  return trainer_worker, lora_trainer_worker, losses
 
 
-trainer_module = _load_trainer_module()
-TrainerEngine = trainer_module.TrainerEngine
+trainer_worker_module, lora_trainer_worker_module, losses_module = _load_trainer_modules()
+BaseTrainerWorker = trainer_worker_module.BaseTrainerWorker
+LoraTrainingWorker = lora_trainer_worker_module.LoraTrainingWorker
 
 
 class _PeftModelStub:
@@ -83,14 +85,14 @@ class _LogitModelStub:
 
 
 def _datum(model_input, target_tokens, *, weights=None, logprobs=None, advantages=None):
-  loss_fn_inputs = {"target_tokens": trainer_module.TensorData(data=target_tokens)}
+  loss_fn_inputs = {"target_tokens": trainer_worker_module.TensorData(data=target_tokens)}
   if weights is not None:
-    loss_fn_inputs["weights"] = trainer_module.TensorData(data=weights)
+    loss_fn_inputs["weights"] = trainer_worker_module.TensorData(data=weights)
   if logprobs is not None:
-    loss_fn_inputs["logprobs"] = trainer_module.TensorData(data=logprobs)
+    loss_fn_inputs["logprobs"] = trainer_worker_module.TensorData(data=logprobs)
   if advantages is not None:
-    loss_fn_inputs["advantages"] = trainer_module.TensorData(data=advantages)
-  return trainer_module.Datum(model_input=model_input, loss_fn_inputs=loss_fn_inputs)
+    loss_fn_inputs["advantages"] = trainer_worker_module.TensorData(data=advantages)
+  return trainer_worker_module.Datum(model_input=model_input, loss_fn_inputs=loss_fn_inputs)
 
 
 class TestTrainerOptimizerCorrectness(unittest.TestCase):
@@ -100,7 +102,7 @@ class TestTrainerOptimizerCorrectness(unittest.TestCase):
     active_param.grad = torch.tensor([1.0])
     other_param.grad = torch.tensor([10.0])
 
-    engine = TrainerEngine()
+    engine = LoraTrainingWorker()
     engine.peft_model = _PeftModelStub(
       {
         "adapter-a": [active_param],
@@ -108,7 +110,7 @@ class TestTrainerOptimizerCorrectness(unittest.TestCase):
       }
     )
     engine.adapter_states = {
-      "adapter-a": {"trainable_params": trainer_module.active_adapter_parameters(engine.peft_model, "adapter-a"), "optimizer": None}
+      "adapter-a": {"trainable_params": lora_trainer_worker_module.active_adapter_parameters(engine.peft_model, "adapter-a"), "optimizer": None}
     }
     engine.save_adapter = lambda *_args, **_kwargs: None
 
@@ -133,12 +135,11 @@ class TestTrainerOptimizerCorrectness(unittest.TestCase):
 
 
 class TestTrainerPaddedBatchingMath(unittest.TestCase):
-  def _engine(self) -> TrainerEngine:
-    engine = TrainerEngine()
-    engine.device = torch.device("cpu")
-    engine.tokenizer = _TokenizerStub()
-    engine.peft_model = _LogitModelStub()
-    return engine
+  def _worker(self) -> BaseTrainerWorker:
+    worker = BaseTrainerWorker()
+    worker.device = torch.device("cpu")
+    worker.tokenizer = _TokenizerStub()
+    return worker
 
   def _data(self):
     return [
@@ -164,20 +165,21 @@ class TestTrainerPaddedBatchingMath(unittest.TestCase):
       ),
     ]
 
-  def training_tensors(self, engine, data):
-    input_ids, attention_mask, input_lengths = engine.pad_model_inputs(data)
-    target_token_ids, weights, lengths = engine.pad_targets_and_weights(data, input_lengths)
-    logprobs = engine.compute_target_logprobs(input_ids, attention_mask, target_token_ids)
-    old_logprobs = engine.pad_sequences([datum.loss_fn_inputs["logprobs"].data for datum in data], lengths, torch.float32)
-    advantages = engine.pad_sequences([datum.loss_fn_inputs["advantages"].data for datum in data], lengths, torch.float32)
+  def training_tensors(self, worker, model, data):
+    input_ids, attention_mask, input_lengths = worker.pad_model_inputs(data)
+    target_token_ids, weights, lengths = worker.pad_targets_and_weights(data, input_lengths)
+    logprobs = worker.compute_target_logprobs(model, input_ids, attention_mask, target_token_ids)
+    old_logprobs = worker.pad_sequences([datum.loss_fn_inputs["logprobs"].data for datum in data], lengths, torch.float32)
+    advantages = worker.pad_sequences([datum.loss_fn_inputs["advantages"].data for datum in data], lengths, torch.float32)
     return logprobs, weights, old_logprobs, advantages, lengths
 
   def test_padded_batch_logprobs_and_losses_match_per_example_math(self) -> None:
-    engine = self._engine()
+    worker = self._worker()
+    model = _LogitModelStub()
     data = self._data()
 
-    batch_logprobs, batch_weights, batch_old_logprobs, batch_advantages, batch_lengths = self.training_tensors(engine, data)
-    single_results = [self.training_tensors(engine, [datum]) for datum in data]
+    batch_logprobs, batch_weights, batch_old_logprobs, batch_advantages, batch_lengths = self.training_tensors(worker, model, data)
+    single_results = [self.training_tensors(worker, model, [datum]) for datum in data]
 
     for row, (single_logprobs, single_weights, single_old_logprobs, single_advantages, single_lengths) in enumerate(single_results):
       length = batch_lengths[row]
@@ -195,18 +197,18 @@ class TestTrainerPaddedBatchingMath(unittest.TestCase):
       return torch.stack(losses).sum()
 
     torch.testing.assert_close(
-      trainer_module.losses.cross_entropy_loss(batch_logprobs, batch_weights).sum(),
-      single_sum(lambda logprobs, weights, _old_logprobs, _advantages: trainer_module.losses.cross_entropy_loss(logprobs, weights)),
+      losses_module.cross_entropy_loss(batch_logprobs, batch_weights).sum(),
+      single_sum(lambda logprobs, weights, _old_logprobs, _advantages: losses_module.cross_entropy_loss(logprobs, weights)),
     )
     torch.testing.assert_close(
-      trainer_module.losses.importance_sampling_loss(
+      losses_module.importance_sampling_loss(
         batch_logprobs,
         batch_weights,
         batch_old_logprobs,
         batch_advantages,
       ).sum(),
       single_sum(
-        lambda logprobs, weights, old_logprobs, advantages: trainer_module.losses.importance_sampling_loss(
+        lambda logprobs, weights, old_logprobs, advantages: losses_module.importance_sampling_loss(
           logprobs,
           weights,
           old_logprobs,
@@ -216,7 +218,7 @@ class TestTrainerPaddedBatchingMath(unittest.TestCase):
     )
     ppo_config = {"clip_range": 0.2, "kl_coeff": 0.03}
     torch.testing.assert_close(
-      trainer_module.losses.ppo_loss(
+      losses_module.ppo_loss(
         batch_logprobs,
         batch_weights,
         batch_old_logprobs,
@@ -224,7 +226,7 @@ class TestTrainerPaddedBatchingMath(unittest.TestCase):
         ppo_config,
       ).sum(),
       single_sum(
-        lambda logprobs, weights, old_logprobs, advantages: trainer_module.losses.ppo_loss(
+        lambda logprobs, weights, old_logprobs, advantages: losses_module.ppo_loss(
           logprobs,
           weights,
           old_logprobs,
@@ -235,7 +237,7 @@ class TestTrainerPaddedBatchingMath(unittest.TestCase):
     )
 
   def test_token_budget_batches_preserve_examples(self) -> None:
-    engine = self._engine()
+    engine = self._worker()
     data = self._data()
     with patch.dict(os.environ, {"OPEN_RL_TRAIN_TOKEN_BUDGET": "6"}):
       batches = engine.make_training_batches(data)
@@ -247,15 +249,16 @@ class TestTrainerPaddedBatchingMath(unittest.TestCase):
       self.assertTrue(len(batch) == 1 or padded_tokens <= 6)
 
   def test_forward_backward_padded_batches_preserve_client_output_shape(self) -> None:
-    engine = self._engine()
+    worker = self._worker()
+    model = _LogitModelStub()
     data = self._data()
 
     with patch.dict(os.environ, {"OPEN_RL_TRAIN_TOKEN_BUDGET": "12"}):
-      result = engine.forward_backward(data, "cross_entropy")
+      result = worker.forward_backward(model, data, "cross_entropy")
 
     self.assertEqual(len(result["loss_fn_outputs"]), len(data))
-    self.assertGreater(len(engine.peft_model.calls), 0)
-    self.assertTrue(any(call[0].shape[0] > 1 for call in engine.peft_model.calls))
+    self.assertGreater(len(model.calls), 0)
+    self.assertTrue(any(call[0].shape[0] > 1 for call in model.calls))
     for datum, output in zip(data, result["loss_fn_outputs"], strict=True):
       logprobs = output["logprobs"]
       self.assertEqual(logprobs["shape"], [min(len(datum.model_input), len(datum.loss_fn_inputs["target_tokens"].data))])

--- a/tests/test_trainer_optimizer_correctness.py
+++ b/tests/test_trainer_optimizer_correctness.py
@@ -1,9 +1,8 @@
-import importlib.util
+import importlib
 import os
 import sys
 import types
 import unittest
-from pathlib import Path
 from unittest.mock import patch
 
 import torch
@@ -25,11 +24,15 @@ def _load_trainer_module():
       PreTrainedTokenizerBase=object,
     ),
   }
-  spec = importlib.util.spec_from_file_location("trainer_under_test", Path(SERVER_DIR) / "trainer.py")
-  assert spec is not None and spec.loader is not None
-  module = importlib.util.module_from_spec(spec)
+  old_path = list(sys.path)
+  sys.path.insert(0, str(SERVER_DIR))
   with patch.dict(sys.modules, stubs):
-    spec.loader.exec_module(module)
+    for module_name in list(sys.modules):
+      if module_name == "training" or module_name.startswith("training."):
+        del sys.modules[module_name]
+    module = importlib.import_module("training.trainer")
+    module.losses = importlib.import_module("training.losses")
+  sys.path = old_path
   return module
 
 
@@ -161,46 +164,81 @@ class TestTrainerPaddedBatchingMath(unittest.TestCase):
       ),
     ]
 
+  def training_tensors(self, engine, data):
+    input_ids, attention_mask, input_lengths = engine.pad_model_inputs(data)
+    target_token_ids, weights, lengths = engine.pad_targets_and_weights(data, input_lengths)
+    logprobs = engine.compute_target_logprobs(input_ids, attention_mask, target_token_ids)
+    old_logprobs = engine.pad_sequences([datum.loss_fn_inputs["logprobs"].data for datum in data], lengths, torch.float32)
+    advantages = engine.pad_sequences([datum.loss_fn_inputs["advantages"].data for datum in data], lengths, torch.float32)
+    return logprobs, weights, old_logprobs, advantages, lengths
+
   def test_padded_batch_logprobs_and_losses_match_per_example_math(self) -> None:
     engine = self._engine()
     data = self._data()
 
-    batch_logprobs, batch_weights, batch_aux, batch_lengths = engine._get_logprobs_batch(data)
-    single_results = [engine._get_logprobs_batch([datum]) for datum in data]
+    batch_logprobs, batch_weights, batch_old_logprobs, batch_advantages, batch_lengths = self.training_tensors(engine, data)
+    single_results = [self.training_tensors(engine, [datum]) for datum in data]
 
-    for row, (single_logprobs, single_weights, single_aux, single_lengths) in enumerate(single_results):
+    for row, (single_logprobs, single_weights, single_old_logprobs, single_advantages, single_lengths) in enumerate(single_results):
       length = batch_lengths[row]
       self.assertEqual(length, single_lengths[0])
       torch.testing.assert_close(batch_logprobs[row, :length], single_logprobs[0, :length])
       torch.testing.assert_close(batch_weights[row, :length], single_weights[0, :length])
       torch.testing.assert_close(batch_weights[row, length:], torch.zeros_like(batch_weights[row, length:]))
-      for key in ("logprobs", "advantages"):
-        torch.testing.assert_close(batch_aux[key][row, :length], single_aux[key][0, :length])
-        torch.testing.assert_close(batch_aux[key][row, length:], torch.zeros_like(batch_aux[key][row, length:]))
+      torch.testing.assert_close(batch_old_logprobs[row, :length], single_old_logprobs[0, :length])
+      torch.testing.assert_close(batch_old_logprobs[row, length:], torch.zeros_like(batch_old_logprobs[row, length:]))
+      torch.testing.assert_close(batch_advantages[row, :length], single_advantages[0, :length])
+      torch.testing.assert_close(batch_advantages[row, length:], torch.zeros_like(batch_advantages[row, length:]))
 
     def single_sum(fn):
-      losses = [fn(logprobs, weights, aux).sum() for logprobs, weights, aux, _lengths in single_results]
+      losses = [fn(logprobs, weights, old_logprobs, advantages).sum() for logprobs, weights, old_logprobs, advantages, _lengths in single_results]
       return torch.stack(losses).sum()
 
     torch.testing.assert_close(
-      engine._cross_entropy_loss(batch_logprobs, batch_weights).sum(),
-      single_sum(lambda logprobs, weights, _aux: engine._cross_entropy_loss(logprobs, weights)),
+      trainer_module.losses.cross_entropy_loss(batch_logprobs, batch_weights).sum(),
+      single_sum(lambda logprobs, weights, _old_logprobs, _advantages: trainer_module.losses.cross_entropy_loss(logprobs, weights)),
     )
     torch.testing.assert_close(
-      engine._importance_sampling_loss(batch_logprobs, batch_weights, batch_aux).sum(),
-      single_sum(lambda logprobs, weights, aux: engine._importance_sampling_loss(logprobs, weights, aux)),
+      trainer_module.losses.importance_sampling_loss(
+        batch_logprobs,
+        batch_weights,
+        batch_old_logprobs,
+        batch_advantages,
+      ).sum(),
+      single_sum(
+        lambda logprobs, weights, old_logprobs, advantages: trainer_module.losses.importance_sampling_loss(
+          logprobs,
+          weights,
+          old_logprobs,
+          advantages,
+        )
+      ),
     )
     ppo_config = {"clip_range": 0.2, "kl_coeff": 0.03}
     torch.testing.assert_close(
-      engine._ppo_loss(batch_logprobs, batch_weights, batch_aux, ppo_config).sum(),
-      single_sum(lambda logprobs, weights, aux: engine._ppo_loss(logprobs, weights, aux, ppo_config)),
+      trainer_module.losses.ppo_loss(
+        batch_logprobs,
+        batch_weights,
+        batch_old_logprobs,
+        batch_advantages,
+        ppo_config,
+      ).sum(),
+      single_sum(
+        lambda logprobs, weights, old_logprobs, advantages: trainer_module.losses.ppo_loss(
+          logprobs,
+          weights,
+          old_logprobs,
+          advantages,
+          ppo_config,
+        )
+      ),
     )
 
   def test_token_budget_batches_preserve_examples(self) -> None:
     engine = self._engine()
     data = self._data()
     with patch.dict(os.environ, {"OPEN_RL_TRAIN_TOKEN_BUDGET": "6"}):
-      batches = engine._make_training_batches(data)
+      batches = engine.make_training_batches(data)
 
     seen = [idx for batch in batches for idx, _datum in batch]
     self.assertCountEqual(seen, range(len(data)))


### PR DESCRIPTION

This PR splits the existing trainer into the shape we need for full fine-tuning. The old trainer was really a LoRA worker because one process owns a base model and serves multiple jobs by creating and switching adapters. Full fine-tuning has a different ownership model where one worker process owns one trainable model for one job. To make that distinction explicit, this introduces a shared BaseTrainerWorker, keeps LoRA-specific adapter management in LoraTrainingWorker, and adds an FFTTrainingWorker for the single-model full fine-tuning path.

Most of the actual training math is shared between the two modes, so this also moves common forward/backward, padding, logprob, batching, and generation code into the base worker. The loss functions are factored into pure tensor operations in losses.py, which makes them easier to test directly and keeps the worker classes focused on model lifecycle and orchestration.

This PR does not wire full fine-tuning into the API server yet. It just adds the worker split and shared math needed for that follow-up.