### PR TITLE
feat: wire in FFT worker

### DIFF
--- a/examples/sft/gsm8k/README.md
+++ b/examples/sft/gsm8k/README.md
@@ -1,0 +1,73 @@
+# GSM8K full fine-tuning
+
+Full-parameter SFT of a small model on GSM8K, driven through the OpenRL gateway
+with the Tinker SDK.
+
+## Why full fine-tuning goes through worker mode
+
+The public Tinker SDK entrypoint is still `create_lora_training_client()`. For
+now, OpenRL routes that same client flow to a full fine-tuning worker when the
+gateway is started with `OPEN_RL_WORKER_MODE=full`.
+
+## Run
+
+This branch launches one full fine-tuning worker process per created model. That
+worker shares requests and futures with the gateway through Redis.
+
+Start from the repository root in separate terminals.
+
+### Terminal 1: Redis
+
+```bash
+redis-server --port 6379 --save "" --appendonly no
+```
+
+### Terminal 2: Gateway
+
+```bash
+cd src/server
+REDIS_URL=redis://127.0.0.1:6379 \
+OPEN_RL_WORKER_MODE=full \
+BASE_MODEL=Qwen/Qwen2.5-0.5B \
+SAMPLING_BACKEND=torch \
+uv run --extra gpu python -m uvicorn gateway:app --host 127.0.0.1 --port 9003
+```
+
+### Terminal 3: SFT Job
+
+```bash
+uv --project examples run python examples/sft/gsm8k/gsm8k_sft.py \
+  --log-path=examples/sft/gsm8k/artifacts/job_a \
+  --max-steps=20 \
+  --base-model=Qwen/Qwen2.5-0.5B
+```
+
+Training uses `tinker_cookbook.supervised.train`, so batching, LR scheduling,
+metric logging, and final checkpoint export are handled by the cookbook loop.
+The example deletes an existing log directory by default so stale checkpoint
+metadata does not trigger resume. The training script prints
+`eval_model_path=...` when it can resolve a final checkpoint path.
+
+## Eval
+
+Eval is decoupled from OpenRL. Point vLLM at the saved Hugging Face checkpoint:
+
+```bash
+python examples/sft/gsm8k/vllm_eval.py \
+  --path <eval_model_path> \
+  --data gsm8k_test.json
+```
+
+## Result
+
+Single-job result from the original FFT prototype run:
+
+| Setup | GSM8K |
+| --- | --- |
+| Qwen2.5-0.5B base, 0-shot exact match on 250 examples | ~1.5% |
+| Qwen2.5-0.5B after full-FT SFT, 1 epoch, lr 2e-5 | ~36% |
+
+Files:
+
+- `gsm8k_sft.py`: training via the OpenRL/Tinker server.
+- `vllm_eval.py`: fast eval of the saved checkpoint directory.

--- a/examples/sft/gsm8k/README.md
+++ b/examples/sft/gsm8k/README.md
@@ -3,11 +3,11 @@
 Full-parameter SFT of a small model on GSM8K, driven through the OpenRL gateway
 with the Tinker SDK.
 
-## Why full fine-tuning goes through worker mode
+## Why full fine-tuning goes through dedicated workers
 
 The public Tinker SDK entrypoint is still `create_lora_training_client()`. For
 now, OpenRL routes that same client flow to a full fine-tuning worker when the
-gateway is started with `OPEN_RL_WORKER_MODE=full`.
+gateway is started with `OPEN_RL_ENABLE_FFT=true`.
 
 ## Run
 
@@ -27,7 +27,7 @@ redis-server --port 6379 --save "" --appendonly no
 ```bash
 cd src/server
 REDIS_URL=redis://127.0.0.1:6379 \
-OPEN_RL_WORKER_MODE=full \
+OPEN_RL_ENABLE_FFT=true \
 BASE_MODEL=Qwen/Qwen2.5-0.5B \
 SAMPLING_BACKEND=torch \
 uv run --extra gpu python -m uvicorn gateway:app --host 127.0.0.1 --port 9003

--- a/examples/sft/gsm8k/gsm8k_sft.py
+++ b/examples/sft/gsm8k/gsm8k_sft.py
@@ -1,0 +1,97 @@
+import asyncio
+import os
+from pathlib import Path
+from typing import Any, cast
+
+import chz
+import tinker
+from datasets import load_dataset
+from tinker import types
+from tinker_cookbook import checkpoint_utils, cli_utils
+from tinker_cookbook.supervised.data import SupervisedDatasetFromHFDataset
+from tinker_cookbook.supervised.train import Config as TrainConfig
+from tinker_cookbook.supervised.train import main as train
+from tinker_cookbook.supervised.types import SupervisedDatasetBuilder
+from tinker_cookbook.tokenizer_utils import get_tokenizer
+
+os.environ.setdefault("TINKER_API_KEY", "tml-dummy-key")
+
+
+@chz.chz
+class GSM8KDataset(SupervisedDatasetBuilder):
+  model_name: str
+  batch_size: int = 16
+  max_length: int = 640
+  seed: int = 0
+
+  def __call__(self):
+    tokenizer = get_tokenizer(self.model_name)
+    dataset = load_dataset("openai/gsm8k", "main", split="train").shuffle(seed=self.seed)
+
+    def make_datum(row: dict) -> tinker.Datum:
+      prompt = tokenizer.encode(f"Question: {row['question']}\nAnswer:", add_special_tokens=False)
+      completion = tokenizer.encode(" " + row["answer"].strip(), add_special_tokens=False) + [tokenizer.eos_token_id]
+      tokens = (prompt + completion)[: self.max_length]
+      weights = ([0] * len(prompt) + [1] * len(completion))[: self.max_length]
+      return types.Datum(
+        model_input=types.ModelInput.from_ints(tokens=tokens[:-1]),
+        loss_fn_inputs=cast(Any, {"target_tokens": tokens[1:], "weights": [float(w) for w in weights[1:]]}),
+      )
+
+    return SupervisedDatasetFromHFDataset(dataset, self.batch_size, map_fn=make_datum), None
+
+
+@chz.chz
+class Config:
+  base_model: str = "Qwen/Qwen2.5-0.5B"
+  base_url: str = os.getenv("TINKER_BASE_URL", os.getenv("BASE_URL", "http://127.0.0.1:9003"))
+  log_path: str = str(Path(__file__).with_name("artifacts") / "gsm8k_sft")
+  epochs: int = 1
+  batch: int = 16
+  lr: float = 2e-5
+  rank: int = 32
+  max_len: int = 640
+  seed: int = 0
+  max_steps: int | None = None
+  save_every: int = 0
+  behavior_if_log_dir_exists: cli_utils.LogdirBehavior = "delete"
+
+
+def main(config: Config) -> None:
+  cli_utils.check_log_dir(config.log_path, behavior_if_exists=config.behavior_if_log_dir_exists)
+  asyncio.run(
+    train(
+      TrainConfig(
+        log_path=config.log_path,
+        model_name=config.base_model,
+        dataset_builder=GSM8KDataset(
+          model_name=config.base_model,
+          batch_size=config.batch,
+          max_length=config.max_len,
+          seed=config.seed,
+        ),
+        learning_rate=config.lr,
+        lr_schedule="cosine",
+        num_epochs=config.epochs,
+        lora_rank=config.rank,
+        base_url=config.base_url,
+        save_every=config.save_every,
+        eval_every=0,
+        infrequent_eval_every=0,
+        max_steps=config.max_steps,
+      )
+    )
+  )
+  checkpoint = checkpoint_utils.get_last_checkpoint(config.log_path, required_key="sampler_path")
+  if checkpoint is None:
+    checkpoint = checkpoint_utils.get_last_checkpoint(config.log_path, required_key="state_path")
+  if checkpoint is not None:
+    path = checkpoint.sampler_path or checkpoint.state_path
+    if path and path.startswith("tinker://"):
+      path = str(Path(os.getenv("OPEN_RL_TMP_DIR", "/tmp/open-rl")) / "sampler_full" / path.removeprefix("tinker://"))
+    if path:
+      print(f"eval_model_path={path}")
+
+
+if __name__ == "__main__":
+  chz.nested_entrypoint(main, allow_hyphens=True)

--- a/examples/sft/gsm8k/vllm_eval.py
+++ b/examples/sft/gsm8k/vllm_eval.py
@@ -1,0 +1,43 @@
+import argparse
+import json
+import re
+import time
+
+ANS_RE = re.compile(r"-?\d[\d,]*")
+
+
+def extract(text: str) -> str | None:
+  text = re.split(r"\n\s*Question:", text)[0]
+  if "####" in text:
+    match = ANS_RE.search(text.split("####")[-1])
+    if match:
+      return match.group(0).replace(",", "")
+  numbers = ANS_RE.findall(text)
+  return numbers[-1].replace(",", "") if numbers else None
+
+
+def main() -> None:
+  from vllm import LLM, SamplingParams
+
+  parser = argparse.ArgumentParser()
+  parser.add_argument("--path", required=True)
+  parser.add_argument("--data", default="gsm8k_test.json")
+  args = parser.parse_args()
+
+  with open(args.data) as f:
+    data = json.load(f)
+
+  llm = LLM(model=args.path, dtype="bfloat16", gpu_memory_utilization=0.85, max_model_len=1024, enforce_eager=True)
+  sampling_params = SamplingParams(temperature=0.0, max_tokens=256, stop=["\nQuestion:"])
+  start = time.time()
+  outputs = llm.generate([datum["prompt"] for datum in data], sampling_params)
+  elapsed = time.time() - start
+  correct = sum(int(extract(output.outputs[0].text) == datum["gold"]) for datum, output in zip(data, outputs, strict=True))
+
+  print("***************************************************************")
+  print(f"[VLLM] {args.path} 0-shot GSM8K acc = {correct / len(data):.1%} on {len(data)} problems in {elapsed:.1f}s")
+  print("***************************************************************")
+
+
+if __name__ == "__main__":
+  main()

--- a/src/server/clock_cycle.py
+++ b/src/server/clock_cycle.py
@@ -1,5 +1,6 @@
 # This file contains the clock cycle loop implementation for orchestrating training requests in Open-RL.
 
+import argparse
 import asyncio
 import os
 import threading
@@ -16,13 +17,16 @@ from training.trainer_worker import Datum
 
 tracer = trace.get_tracer(__name__)
 
-WORKER_MODE = os.getenv("OPEN_RL_WORKER_MODE")
 
-worker = FFTTrainingWorker() if WORKER_MODE == "full" else LoraTrainingWorker()
+TrainingWorker = FFTTrainingWorker | LoraTrainingWorker
 
 
-def is_full_worker_mode() -> bool:
-  return WORKER_MODE == "full"
+def is_fft_enabled() -> bool:
+  return os.getenv("OPEN_RL_ENABLE_FFT", "").lower() == "true"
+
+
+def create_training_worker() -> TrainingWorker:
+  return FFTTrainingWorker() if is_fft_enabled() else LoraTrainingWorker()
 
 
 def parse_datum(raw: dict) -> Datum:
@@ -36,7 +40,7 @@ def parse_datum(raw: dict) -> Datum:
   return Datum(model_input=tokens, loss_fn_inputs=loss_inputs)
 
 
-async def handle_request(store, request: dict, model_id: str) -> None:
+async def handle_request(store, request: dict, model_id: str, worker: TrainingWorker, fft_enabled: bool) -> None:
   req_id = request["req_id"]
   req_type = request["type"]
 
@@ -45,27 +49,24 @@ async def handle_request(store, request: dict, model_id: str) -> None:
   token = otel_context.attach(ctx) if ctx else None
 
   try:
-    if is_full_worker_mode() and request.get("model_id") != model_id:
+    if fft_enabled and request.get("model_id") != model_id:
       raise ValueError(f"Full worker for {model_id!r} received request for {request.get('model_id')!r}")
 
     match req_type:
       case "create_model":
         base_model = request["base_model"]
 
-        if is_full_worker_mode():
+        if fft_enabled:
           raw_config = request.get("full_config") or {}
           full_config = FFTConfig(**{k: v for k, v in raw_config.items() if k in FFTConfig.model_fields})
           await asyncio.to_thread(worker.create_model, base_model, model_id, full_config)
-          # SDK compatibility: the public client currently expects LoRA-shaped training metadata,
-          # even when this process is running a full fine-tuning worker.
           await store.set_future(
             req_id,
             {
               "model_id": model_id,
-              "is_lora": True,
               "lora_rank": 16,
               "base_model": base_model,
-              "type": "create_model",
+              "type": "create_model_result",
             },
           )
         else:
@@ -76,9 +77,8 @@ async def handle_request(store, request: dict, model_id: str) -> None:
             req_id,
             {
               "model_id": model_id,
-              "is_lora": True,
               "lora_rank": lora_config.rank,
-              "type": "create_model",
+              "type": "create_model_result",
             },
           )
 
@@ -86,8 +86,14 @@ async def handle_request(store, request: dict, model_id: str) -> None:
         state_path = request["state_path"]
         restore_optimizer = bool(request.get("restore_optimizer", False))
         result = await asyncio.to_thread(worker.load_from_state, model_id, state_path, restore_optimizer)
-        result["type"] = "create_model_from_state"
-        await store.set_future(req_id, result)
+        internal_result = {
+          "model_id": result.get("model_id", model_id),
+          "base_model": result.get("base_model"),
+          "type": "create_model_from_state_result",
+        }
+        if fft_enabled:
+          internal_result["lora_rank"] = 16
+        await store.set_future(req_id, internal_result)
 
       case "forward_backward":
         raw_data = request["data"]
@@ -141,7 +147,7 @@ async def handle_request(store, request: dict, model_id: str) -> None:
         await store.set_future(req_id, {"path": state_path, "type": "load_weights"})
 
       case "save_weights_for_sampler":
-        if is_full_worker_mode():
+        if fft_enabled:
           ref = request.get("path") or request.get("sampling_session_id")
           if not ref:
             raise ValueError("save_weights_for_sampler requires path or sampling_session_id")
@@ -160,7 +166,7 @@ async def handle_request(store, request: dict, model_id: str) -> None:
         )
 
       case "save_weights":
-        if is_full_worker_mode():
+        if fft_enabled:
           await asyncio.to_thread(worker.save_model, request.get("alias") or model_id)
         else:
           await asyncio.to_thread(worker.save_adapter, model_id, request.get("alias"))
@@ -178,25 +184,25 @@ async def handle_request(store, request: dict, model_id: str) -> None:
       otel_context.detach(token)
 
 
-async def clock_cycle_loop() -> None:
-  if is_full_worker_mode() and not os.getenv("REDIS_URL"):
+async def clock_cycle_loop(worker: TrainingWorker, model_id: str | None = None) -> None:
+  fft_enabled = is_fft_enabled()
+  if fft_enabled and not os.getenv("REDIS_URL"):
     raise RuntimeError("Full fine-tuning workers require REDIS_URL so they can share queues and futures with the gateway")
+  if fft_enabled and not model_id:
+    raise RuntimeError("A dedicated FFT worker needs --model-id so it knows which per-model queue to drain")
 
   store = get_store()
-  worker_model_id = os.getenv("OPEN_RL_WORKER_MODEL_ID") if is_full_worker_mode() else None
-  if is_full_worker_mode() and not worker_model_id:
-    raise RuntimeError("OPEN_RL_WORKER_MODEL_ID is required when OPEN_RL_WORKER_MODE=full")
 
-  print(f"[WORKER] Training worker started in {WORKER_MODE} mode.")
+  print(f"[WORKER] Training worker started. FFT enabled: {fft_enabled}.")
 
   while True:
     try:
-      batch = await store.get_requests_for_model(worker_model_id) if worker_model_id else await store.get_requests()
+      batch = await store.get_requests_for_model(model_id) if fft_enabled else await store.get_requests()
       if not batch:
         await asyncio.sleep(0.1)
         continue
 
-      m_id = worker_model_id or batch[0].get("model_id", "default")
+      m_id = model_id or batch[0].get("model_id", "default")
 
       with tracer.start_as_current_span("clock_cycle_batch") as batch_span:
         batch_span.set_attribute("batch_size", len(batch))
@@ -205,7 +211,7 @@ async def clock_cycle_loop() -> None:
         print(f"\n[CLOCK CYCLE] Popped {len(batch)} requests for tenant: {m_id}")
 
         for r in batch:
-          await handle_request(store, r, m_id)
+          await handle_request(store, r, m_id, worker, fft_enabled=fft_enabled)
 
     except asyncio.CancelledError:
       break
@@ -226,26 +232,31 @@ async def clock_cycle_loop() -> None:
 
 
 def main() -> None:
+  parser = argparse.ArgumentParser()
+  parser.add_argument("--model-id", help="Model id whose per-model request queue this dedicated FFT worker drains.")
+  args = parser.parse_args()
+
   print("\n" + "=" * 50)
   print("      Open-RL PyTorch Training Worker")
   print("=" * 50)
   cuda_devs = os.getenv("CUDA_VISIBLE_DEVICES", "ALL")
   print(f"-> Hardware : CUDA_VISIBLE_DEVICES={cuda_devs}")
-  print(f"-> Worker mode: {WORKER_MODE}\n")
+  print(f"-> FFT enabled: {is_fft_enabled()}\n")
 
+  worker = create_training_worker()
   preload_target = os.getenv("BASE_MODEL")
   is_ready = False
-  if preload_target and not is_full_worker_mode():
+  if preload_target and not is_fft_enabled():
     worker.load_base_model(preload_target)
     is_ready = True
   else:
-    if is_full_worker_mode():
+    if is_fft_enabled():
       print("[WORKER] Full fine-tuning mode loads its model from the create_model request.")
     else:
       print("[WARNING] BASE_MODEL not provided. Cold-start penalty will apply on first request.")
     is_ready = True
 
-  if not is_full_worker_mode():
+  if not is_fft_enabled():
     probe_app = FastAPI()
 
     @probe_app.get("/healthz")
@@ -258,7 +269,7 @@ def main() -> None:
       uvicorn.run(probe_app, host="0.0.0.0", port=8000, log_level="warning")
 
     threading.Thread(target=run_probe_server, daemon=True).start()
-  asyncio.run(clock_cycle_loop())
+  asyncio.run(clock_cycle_loop(worker, args.model_id))
 
 
 if __name__ == "__main__":

--- a/src/server/clock_cycle.py
+++ b/src/server/clock_cycle.py
@@ -10,12 +10,19 @@ from fastapi import FastAPI, HTTPException
 from opentelemetry import context as otel_context
 from opentelemetry import propagate, trace
 from store import get_store
+from training.fft_trainer_worker import FFTConfig, FFTTrainingWorker
 from training.lora_trainer_worker import LoraConfig, LoraTrainingWorker
 from training.trainer_worker import Datum
 
 tracer = trace.get_tracer(__name__)
 
-engine = LoraTrainingWorker()
+WORKER_MODE = os.getenv("OPEN_RL_WORKER_MODE")
+
+worker = FFTTrainingWorker() if WORKER_MODE == "full" else LoraTrainingWorker()
+
+
+def is_full_worker_mode() -> bool:
+  return WORKER_MODE == "full"
 
 
 def parse_datum(raw: dict) -> Datum:
@@ -29,19 +36,167 @@ def parse_datum(raw: dict) -> Datum:
   return Datum(model_input=tokens, loss_fn_inputs=loss_inputs)
 
 
-async def clock_cycle_loop() -> None:
-  store = get_store()
+async def handle_request(store, request: dict, model_id: str) -> None:
+  req_id = request["req_id"]
+  req_type = request["type"]
 
-  print("[WORKER] Training worker started.")
+  carrier = request.get("trace_context", {})
+  ctx = propagate.extract(carrier) if carrier else None
+  token = otel_context.attach(ctx) if ctx else None
+
+  try:
+    if is_full_worker_mode() and request.get("model_id") != model_id:
+      raise ValueError(f"Full worker for {model_id!r} received request for {request.get('model_id')!r}")
+
+    match req_type:
+      case "create_model":
+        base_model = request["base_model"]
+
+        if is_full_worker_mode():
+          raw_config = request.get("full_config") or {}
+          full_config = FFTConfig(**{k: v for k, v in raw_config.items() if k in FFTConfig.model_fields})
+          await asyncio.to_thread(worker.create_model, base_model, model_id, full_config)
+          # SDK compatibility: the public client currently expects LoRA-shaped training metadata,
+          # even when this process is running a full fine-tuning worker.
+          await store.set_future(
+            req_id,
+            {
+              "model_id": model_id,
+              "is_lora": True,
+              "lora_rank": 16,
+              "base_model": base_model,
+              "type": "create_model",
+            },
+          )
+        else:
+          raw_config = request.get("lora_config") or {}
+          lora_config = LoraConfig(**{k: v for k, v in raw_config.items() if k in LoraConfig.model_fields})
+          await asyncio.to_thread(worker.create_model, base_model, model_id, lora_config)
+          await store.set_future(
+            req_id,
+            {
+              "model_id": model_id,
+              "is_lora": True,
+              "lora_rank": lora_config.rank,
+              "type": "create_model",
+            },
+          )
+
+      case "create_model_from_state":
+        state_path = request["state_path"]
+        restore_optimizer = bool(request.get("restore_optimizer", False))
+        result = await asyncio.to_thread(worker.load_from_state, model_id, state_path, restore_optimizer)
+        result["type"] = "create_model_from_state"
+        await store.set_future(req_id, result)
+
+      case "forward_backward":
+        raw_data = request["data"]
+        loss_fn = request["loss_fn"]
+        loss_config = request.get("loss_config")
+        typed_data = [parse_datum(item) for item in raw_data]
+
+        result = await asyncio.to_thread(worker.forward_backward, typed_data, loss_fn, loss_config, model_id)
+        result["type"] = "forward_backward"
+        await store.set_future(req_id, result)
+
+      case "optim_step":
+        adam_params = request["adam_params"]
+        result = await asyncio.to_thread(worker.optim_step, adam_params, model_id)
+        result["type"] = "optim_step"
+        await store.set_future(req_id, result)
+
+      case "sample":
+        prompt_tokens = request["prompt_tokens"]
+        max_tokens = request["max_tokens"]
+        num_samples = request["num_samples"]
+        temperature = request.get("temperature", 0.0)
+        prompt_logprobs = bool(request.get("prompt_logprobs", False))
+
+        result = await asyncio.to_thread(
+          worker.generate,
+          prompt_tokens,
+          max_tokens,
+          num_samples,
+          temperature,
+          model_id,
+          prompt_logprobs,
+        )
+        result["type"] = "sample"
+        await store.set_future(req_id, result)
+
+      case "save_state":
+        state_path = request["state_path"]
+        include_optimizer = bool(request.get("include_optimizer", False))
+        kind = request.get("kind", "state")
+
+        result = await asyncio.to_thread(worker.save_state, model_id, state_path, include_optimizer, kind)
+        # SDK's save_state() returns SaveWeightsResponse which requires type="save_weights".
+        result["type"] = "save_weights"
+        await store.set_future(req_id, result)
+
+      case "load_weights":
+        state_path = request["state_path"]
+        restore_optimizer = bool(request.get("restore_optimizer", False))
+        await asyncio.to_thread(worker.load_from_state, model_id, state_path, restore_optimizer)
+        await store.set_future(req_id, {"path": state_path, "type": "load_weights"})
+
+      case "save_weights_for_sampler":
+        if is_full_worker_mode():
+          ref = request.get("path") or request.get("sampling_session_id")
+          if not ref:
+            raise ValueError("save_weights_for_sampler requires path or sampling_session_id")
+          rel_path = ref[len("tinker://") :] if ref.startswith("tinker://") else ref.lstrip("/")
+          local_path = os.path.join(os.getenv("OPEN_RL_TMP_DIR", "/tmp/open-rl"), "sampler_full", rel_path)
+          await asyncio.to_thread(worker.save_state, model_id, local_path, False, "sampler")
+        else:
+          await asyncio.to_thread(worker.save_adapter, model_id, request.get("alias"))
+        await store.set_future(
+          req_id,
+          {
+            "path": request.get("path"),
+            "sampling_session_id": request.get("sampling_session_id"),
+            "type": "save_weights_for_sampler",
+          },
+        )
+
+      case "save_weights":
+        if is_full_worker_mode():
+          await asyncio.to_thread(worker.save_model, request.get("alias") or model_id)
+        else:
+          await asyncio.to_thread(worker.save_adapter, model_id, request.get("alias"))
+        await store.set_future(req_id, {"status": "ok", "type": req_type})
+
+      case _:
+        print(f"Warning: Unhandled request type: {req_type}")
+        await store.set_future(req_id, {"type": "RequestFailedResponse", "error_message": f"Unknown request type: {req_type}"})
+
+  except Exception as e:
+    traceback.print_exc()
+    await store.set_future(req_id, {"type": "RequestFailedResponse", "error_message": str(e)})
+  finally:
+    if token:
+      otel_context.detach(token)
+
+
+async def clock_cycle_loop() -> None:
+  if is_full_worker_mode() and not os.getenv("REDIS_URL"):
+    raise RuntimeError("Full fine-tuning workers require REDIS_URL so they can share queues and futures with the gateway")
+
+  store = get_store()
+  worker_model_id = os.getenv("OPEN_RL_WORKER_MODEL_ID") if is_full_worker_mode() else None
+  if is_full_worker_mode() and not worker_model_id:
+    raise RuntimeError("OPEN_RL_WORKER_MODEL_ID is required when OPEN_RL_WORKER_MODE=full")
+
+  print(f"[WORKER] Training worker started in {WORKER_MODE} mode.")
 
   while True:
     try:
-      batch = await store.get_requests()
+      batch = await store.get_requests_for_model(worker_model_id) if worker_model_id else await store.get_requests()
       if not batch:
         await asyncio.sleep(0.1)
         continue
 
-      m_id = batch[0].get("model_id", "default")
+      m_id = worker_model_id or batch[0].get("model_id", "default")
 
       with tracer.start_as_current_span("clock_cycle_batch") as batch_span:
         batch_span.set_attribute("batch_size", len(batch))
@@ -49,128 +204,8 @@ async def clock_cycle_loop() -> None:
 
         print(f"\n[CLOCK CYCLE] Popped {len(batch)} requests for tenant: {m_id}")
 
-        SKIP_ADAPTER_SWITCH = {"create_model", "create_model_from_state"}
-        if not any(r.get("type") in SKIP_ADAPTER_SWITCH for r in batch):
-          try:
-            await asyncio.to_thread(engine.set_active_adapter, m_id)
-          except Exception as e:
-            print(f"Failed to set adapter {m_id}: {e}")
-            for r in batch:
-              await store.set_future(r["req_id"], {"type": "RequestFailedResponse", "error_message": str(e)})
-            continue
-
         for r in batch:
-          req_id = r["req_id"]
-          req_type = r["type"]
-
-          carrier = r.get("trace_context", {})
-          ctx = propagate.extract(carrier) if carrier else None
-          token = otel_context.attach(ctx) if ctx else None
-
-          try:
-            match req_type:
-              case "create_model":
-                base_model = r["base_model"]
-                raw_config = r.get("lora_config") or {}
-                lora_config = LoraConfig(**{k: v for k, v in raw_config.items() if k in LoraConfig.model_fields})
-
-                await asyncio.to_thread(engine.load_base_model, base_model)
-                await asyncio.to_thread(engine.create_adapter, m_id, lora_config)
-
-                await store.set_future(
-                  req_id,
-                  {
-                    "model_id": m_id,
-                    "is_lora": True,
-                    "lora_rank": lora_config.rank,
-                    "type": "create_model",
-                  },
-                )
-
-              case "create_model_from_state":
-                state_path = r["state_path"]
-                restore_optimizer = bool(r.get("restore_optimizer", False))
-                result = await asyncio.to_thread(engine.load_from_state, m_id, state_path, restore_optimizer)
-                result["type"] = "create_model_from_state"
-                await store.set_future(req_id, result)
-
-              case "forward_backward":
-                raw_data = r["data"]
-                loss_fn = r["loss_fn"]
-                loss_config = r.get("loss_config")
-
-                typed_data = [parse_datum(item) for item in raw_data]
-
-                result = await asyncio.to_thread(engine.forward_backward, typed_data, loss_fn, loss_config, m_id)
-                result["type"] = "forward_backward"
-                await store.set_future(req_id, result)
-
-              case "optim_step":
-                adam_params = r["adam_params"]
-                result = await asyncio.to_thread(engine.optim_step, adam_params, m_id)
-                result["type"] = "optim_step"
-                await store.set_future(req_id, result)
-
-              case "sample":
-                prompt_tokens = r["prompt_tokens"]
-                max_tokens = r["max_tokens"]
-                num_samples = r["num_samples"]
-                temperature = r.get("temperature", 0.0)
-                prompt_logprobs = bool(r.get("prompt_logprobs", False))
-
-                result = await asyncio.to_thread(
-                  engine.generate,
-                  prompt_tokens,
-                  max_tokens,
-                  num_samples,
-                  temperature,
-                  m_id,
-                  prompt_logprobs,
-                )
-                result["type"] = "sample"
-                await store.set_future(req_id, result)
-
-              case "save_state":
-                state_path = r["state_path"]
-                include_optimizer = bool(r.get("include_optimizer", False))
-                kind = r.get("kind", "state")
-
-                result = await asyncio.to_thread(engine.save_state, m_id, state_path, include_optimizer, kind)
-                # SDK's save_state() returns SaveWeightsResponse which requires type="save_weights".
-                result["type"] = "save_weights"
-                await store.set_future(req_id, result)
-
-              case "load_weights":
-                state_path = r["state_path"]
-                restore_optimizer = bool(r.get("restore_optimizer", False))
-                await asyncio.to_thread(engine.load_from_state, m_id, state_path, restore_optimizer)
-                await store.set_future(req_id, {"path": state_path, "type": "load_weights"})
-
-              case "save_weights_for_sampler":
-                await asyncio.to_thread(engine.save_adapter, m_id, r.get("alias"))
-                await store.set_future(
-                  req_id,
-                  {
-                    "path": r.get("path"),
-                    "sampling_session_id": r.get("sampling_session_id"),
-                    "type": "save_weights_for_sampler",
-                  },
-                )
-
-              case "save_weights":
-                await asyncio.to_thread(engine.save_adapter, m_id, r.get("alias"))
-                await store.set_future(req_id, {"status": "ok", "type": req_type})
-
-              case _:
-                print(f"Warning: Unhandled request type: {req_type}")
-                await store.set_future(req_id, {"type": "RequestFailedResponse", "error_message": f"Unknown request type: {req_type}"})
-
-          except Exception as e:
-            traceback.print_exc()
-            await store.set_future(req_id, {"type": "RequestFailedResponse", "error_message": str(e)})
-          finally:
-            if token:
-              otel_context.detach(token)
+          await handle_request(store, r, m_id)
 
     except asyncio.CancelledError:
       break
@@ -195,29 +230,34 @@ def main() -> None:
   print("      Open-RL PyTorch Training Worker")
   print("=" * 50)
   cuda_devs = os.getenv("CUDA_VISIBLE_DEVICES", "ALL")
-  print(f"-> Hardware : CUDA_VISIBLE_DEVICES={cuda_devs}\n")
+  print(f"-> Hardware : CUDA_VISIBLE_DEVICES={cuda_devs}")
+  print(f"-> Worker mode: {WORKER_MODE}\n")
 
   preload_target = os.getenv("BASE_MODEL")
   is_ready = False
-  if preload_target:
-    engine.load_base_model(preload_target)
+  if preload_target and not is_full_worker_mode():
+    worker.load_base_model(preload_target)
     is_ready = True
   else:
-    print("[WARNING] BASE_MODEL not provided. Cold-start penalty will apply on first request.")
+    if is_full_worker_mode():
+      print("[WORKER] Full fine-tuning mode loads its model from the create_model request.")
+    else:
+      print("[WARNING] BASE_MODEL not provided. Cold-start penalty will apply on first request.")
     is_ready = True
 
-  probe_app = FastAPI()
+  if not is_full_worker_mode():
+    probe_app = FastAPI()
 
-  @probe_app.get("/healthz")
-  def healthz():
-    if is_ready:
-      return {"status": "ready"}
-    raise HTTPException(status_code=503, detail="Model Loading")
+    @probe_app.get("/healthz")
+    def healthz():
+      if is_ready:
+        return {"status": "ready"}
+      raise HTTPException(status_code=503, detail="Model Loading")
 
-  def run_probe_server():
-    uvicorn.run(probe_app, host="0.0.0.0", port=8000, log_level="warning")
+    def run_probe_server():
+      uvicorn.run(probe_app, host="0.0.0.0", port=8000, log_level="warning")
 
-  threading.Thread(target=run_probe_server, daemon=True).start()
+    threading.Thread(target=run_probe_server, daemon=True).start()
   asyncio.run(clock_cycle_loop())
 
 

--- a/src/server/gateway.py
+++ b/src/server/gateway.py
@@ -3,13 +3,10 @@
 import asyncio
 import logging
 import os
-import subprocess
-import sys
 import time
 import traceback
 import uuid
 from contextlib import asynccontextmanager
-from pathlib import Path
 
 import httpx
 from fastapi import FastAPI
@@ -19,6 +16,13 @@ from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from store import get_store
+from worker_launch_processor import (
+  CreateModelFromStateWorkerLaunchRequest,
+  CreateModelWorkerLaunchRequest,
+  FFTWorkerManager,
+  WorkerLaunchProcessor,
+  WorkerLaunchRequest,
+)
 
 store = get_store()
 
@@ -38,18 +42,16 @@ else:
   print("OpenTelemetry: No exporter configured (ENABLE_GCP_TRACE=0)")
 
 
-class _FilterNoisyEndpoints(logging.Filter):
+class FilterNoisyEndpoints(logging.Filter):
   def filter(self, record: logging.LogRecord) -> bool:
     msg = record.getMessage()
     return "retrieve_future" not in msg and "session_heartbeat" not in msg
 
 
-logging.getLogger("uvicorn.access").addFilter(_FilterNoisyEndpoints())
+logging.getLogger("uvicorn.access").addFilter(FilterNoisyEndpoints())
 
 TMP_DIR = os.getenv("OPEN_RL_TMP_DIR", "/tmp/open-rl")
 VLLM_URL = os.getenv("VLLM_URL", "http://127.0.0.1:8001")
-WORKER_MODE = os.getenv("OPEN_RL_WORKER_MODE")
-SERVER_DIR = Path(__file__).resolve().parent
 
 
 # *** Helpers ***
@@ -66,16 +68,11 @@ def get_sampler_backend() -> str:
 
 
 def get_default_model_name() -> str | None:
-  if is_single_process_mode() and not is_full_worker_mode():
-    import clock_cycle
-
-    if model_name := clock_cycle.worker.base_model_name:
-      return model_name
   return os.getenv("BASE_MODEL")
 
 
-def is_full_worker_mode() -> bool:
-  return WORKER_MODE == "full"
+def is_fft_enabled() -> bool:
+  return os.getenv("OPEN_RL_ENABLE_FFT", "").lower() == "true"
 
 
 def sampler_session_id(model_id: str, seq_id: int | str) -> str:
@@ -115,19 +112,32 @@ def is_sampler_weights_ref(model_id: str | None) -> bool:
   return len(parts) >= 3 and parts[1] == "sampler_weights"
 
 
-async def _enqueue(payload: dict) -> str:
-  """Create a pending future, inject trace context, push to store. Returns req_id."""
+async def prepare_enqueue(payload: dict) -> str:
   req_id = payload.get("req_id") or str(uuid.uuid4())
   payload["req_id"] = req_id
   carrier: dict = {}
   propagate.inject(carrier)
   payload["trace_context"] = carrier
   await store.set_future(req_id, {"status": "pending"})
+  return req_id
+
+
+async def enqueue(payload: dict) -> str:
+  """Create a pending future, inject trace context, push to store. Returns req_id."""
+  req_id = await prepare_enqueue(payload)
   await store.put_request(payload)
   return req_id
 
 
-async def _preflight_vllm() -> None:
+async def enqueue_worker_launch(payload: WorkerLaunchRequest) -> str:
+  """Create a pending future and push a create-model request to the worker launch queue."""
+  payload_data = payload.model_dump()
+  req_id = await prepare_enqueue(payload_data)
+  await store.put_worker_launch_request(payload_data)
+  return req_id
+
+
+async def preflight_vllm() -> None:
   """If SAMPLING_BACKEND=vllm, verify the vLLM worker is reachable at VLLM_URL.
 
   Prints a clear, actionable error instead of letting the first asample
@@ -147,37 +157,34 @@ async def _preflight_vllm() -> None:
     ) from exc
 
 
-class FFTWorkerLauncher:
-  def __init__(self):
-    self.processes: dict[str, subprocess.Popen] = {}
+def translate_future_result(result: dict) -> dict:
+  result_type = result.get("type")
+  if result_type not in {"create_model_result", "create_model_from_state_result"}:
+    return result
 
-  def launch(self, model_id: str) -> None:
-    if not os.getenv("REDIS_URL"):
-      raise RuntimeError("OPEN_RL_WORKER_MODE=full requires REDIS_URL so launched workers can share queues and futures")
-
-    proc = self.processes.get(model_id)
-    if proc is not None and proc.poll() is None:
-      return
-
-    env = {**os.environ, "OPEN_RL_WORKER_MODE": "full", "OPEN_RL_WORKER_MODEL_ID": model_id}
-    self.processes[model_id] = subprocess.Popen(
-      [sys.executable, "-m", "clock_cycle"],
-      cwd=SERVER_DIR,
-      env=env,
-    )
-
-  def shutdown_all(self) -> None:
-    for proc in self.processes.values():
-      if proc.poll() is None:
-        proc.terminate()
-
-
-fft_worker_launcher = FFTWorkerLauncher()
+  # SDK compatibility: the public client currently expects LoRA-shaped training metadata,
+  # even for full fine-tuning jobs.
+  response = {
+    "model_id": result["model_id"],
+    "is_lora": True,
+    "type": "create_model" if result_type == "create_model_result" else "create_model_from_state",
+  }
+  if "lora_rank" in result:
+    response["lora_rank"] = result["lora_rank"]
+  if result.get("base_model"):
+    response["base_model"] = result["base_model"]
+  return response
 
 
 @asynccontextmanager
 async def lifespan(_: FastAPI):
   task = None
+  fft_worker_manager = None
+  worker_launch_task = None
+  if is_fft_enabled():
+    fft_worker_manager = FFTWorkerManager()
+    worker_launch_processor = WorkerLaunchProcessor(store, fft_worker_manager)
+    worker_launch_task = asyncio.create_task(worker_launch_processor.run())
   if is_single_process_mode():
     base_model = os.getenv("BASE_MODEL")
     print("\n" + "=" * 50)
@@ -185,21 +192,25 @@ async def lifespan(_: FastAPI):
     print("=" * 50)
     print(f"-> Base model: {base_model or 'unset'}")
     print(f"-> Sampling backend: {get_sampler_backend()}")
-    print(f"-> Worker mode     : {WORKER_MODE}")
+    print(f"-> FFT enabled     : {is_fft_enabled()}")
     print("-> Server mode     : API server + worker loop in one process\n")
-    await _preflight_vllm()
-    if not is_full_worker_mode():
+    await preflight_vllm()
+    if not is_fft_enabled():
       import clock_cycle
 
+      worker = clock_cycle.create_training_worker()
       if base_model:
-        await asyncio.to_thread(clock_cycle.worker.load_base_model, base_model)
-      task = asyncio.create_task(clock_cycle.clock_cycle_loop())
+        await asyncio.to_thread(worker.load_base_model, base_model)
+      task = asyncio.create_task(clock_cycle.clock_cycle_loop(worker))
   try:
     yield
   finally:
     if task is not None:
       task.cancel()
-    fft_worker_launcher.shutdown_all()
+    if worker_launch_task is not None:
+      worker_launch_task.cancel()
+    if fft_worker_manager is not None:
+      fft_worker_manager.shutdown_all()
 
 
 app = FastAPI(title="Open-RL Server MVP", lifespan=lifespan)
@@ -249,18 +260,15 @@ async def create_model(req: dict):
   if not base_model:
     return JSONResponse(status_code=400, content={"error": "base_model is required"})
   model_id = str(uuid.uuid4())
-  if is_full_worker_mode():
-    fft_worker_launcher.launch(model_id)
-  req_id = await _enqueue(
-    {
-      "req_id": model_id,
-      "model_id": model_id,
-      "type": "create_model",
-      "base_model": base_model,
-      "lora_config": req.get("lora_config") or {},
-      "full_config": req.get("full_config") or {},
-    }
-  )
+  payload = {
+    "req_id": model_id,
+    "model_id": model_id,
+    "type": "create_model",
+    "base_model": base_model,
+    "lora_config": req.get("lora_config") or {},
+    "full_config": req.get("full_config") or {},
+  }
+  req_id = await enqueue_worker_launch(CreateModelWorkerLaunchRequest(**payload)) if is_fft_enabled() else await enqueue(payload)
   return {"request_id": req_id}
 
 
@@ -273,17 +281,14 @@ async def create_model_from_state(req: dict):
   # Resolve relative names under TMP_DIR/checkpoints, leave absolute paths alone.
   resolved_path = state_path if os.path.isabs(state_path) else os.path.join(TMP_DIR, "checkpoints", state_path)
   model_id = str(uuid.uuid4())
-  if is_full_worker_mode():
-    fft_worker_launcher.launch(model_id)
-  req_id = await _enqueue(
-    {
-      "req_id": model_id,
-      "model_id": model_id,
-      "type": "create_model_from_state",
-      "state_path": resolved_path,
-      "restore_optimizer": bool(req.get("restore_optimizer", False)),
-    }
-  )
+  payload = {
+    "req_id": model_id,
+    "model_id": model_id,
+    "type": "create_model_from_state",
+    "state_path": resolved_path,
+    "restore_optimizer": bool(req.get("restore_optimizer", False)),
+  }
+  req_id = await enqueue_worker_launch(CreateModelFromStateWorkerLaunchRequest(**payload)) if is_fft_enabled() else await enqueue(payload)
   return {"request_id": req_id}
 
 
@@ -318,6 +323,8 @@ async def retrieve_future(req: dict):
     return JSONResponse(status_code=400, content={"type": "RequestFailedResponse", "error_message": "Future not found"})
   if isinstance(result, dict) and result.get("type") == "RequestFailedResponse":
     return JSONResponse(status_code=400, content=result)
+  if isinstance(result, dict):
+    return translate_future_result(result)
   return result
 
 
@@ -326,7 +333,7 @@ async def retrieve_future(req: dict):
 async def forward_backward(req: dict):
   """TrainingClient.forward_backward_async()"""
   fwd_input = req.get("forward_backward_input", {})
-  req_id = await _enqueue(
+  req_id = await enqueue(
     {
       "model_id": req.get("model_id"),
       "type": "forward_backward",
@@ -341,7 +348,7 @@ async def forward_backward(req: dict):
 @app.post("/api/v1/optim_step")
 async def optim_step(req: dict):
   """TrainingClient.optim_step_async()"""
-  req_id = await _enqueue(
+  req_id = await enqueue(
     {
       "model_id": req.get("model_id"),
       "type": "optim_step",
@@ -367,7 +374,7 @@ async def save_weights_for_sampler(req: dict):
   alias = req.get("name") or req.get("alias") or req.get("path")
 
   session_id = sampler_session_id(model_id, seq_id)
-  req_id = await _enqueue(
+  req_id = await enqueue(
     {
       "model_id": model_id,
       "type": "save_weights_for_sampler",
@@ -397,7 +404,7 @@ async def save_weights(req: dict):
   state_path = checkpoint_state_path(model_id, alias)
 
   req_id = str(uuid.uuid4())
-  await _enqueue(
+  await enqueue(
     {
       "req_id": req_id,
       "model_id": model_id,
@@ -421,7 +428,7 @@ async def load_weights(req: dict):
     return JSONResponse(status_code=400, content={"error": "path is required"})
 
   resolved_path = checkpoint_state_path(model_id, state_path)
-  req_id = await _enqueue(
+  req_id = await enqueue(
     {
       "model_id": model_id,
       "type": "load_weights",
@@ -470,7 +477,7 @@ async def asample(req: dict):
   base_model_id = base_model_id_from_sampling_ref(model_id)
 
   if get_sampler_backend() == "torch":
-    req_id = await _enqueue(
+    req_id = await enqueue(
       {
         "model_id": base_model_id or model_id,
         "type": "sample",

--- a/src/server/gateway.py
+++ b/src/server/gateway.py
@@ -3,10 +3,13 @@
 import asyncio
 import logging
 import os
+import subprocess
+import sys
 import time
 import traceback
 import uuid
 from contextlib import asynccontextmanager
+from pathlib import Path
 
 import httpx
 from fastapi import FastAPI
@@ -45,6 +48,8 @@ logging.getLogger("uvicorn.access").addFilter(_FilterNoisyEndpoints())
 
 TMP_DIR = os.getenv("OPEN_RL_TMP_DIR", "/tmp/open-rl")
 VLLM_URL = os.getenv("VLLM_URL", "http://127.0.0.1:8001")
+WORKER_MODE = os.getenv("OPEN_RL_WORKER_MODE")
+SERVER_DIR = Path(__file__).resolve().parent
 
 
 # *** Helpers ***
@@ -61,12 +66,16 @@ def get_sampler_backend() -> str:
 
 
 def get_default_model_name() -> str | None:
-  if is_single_process_mode():
+  if is_single_process_mode() and not is_full_worker_mode():
     import clock_cycle
 
-    if clock_cycle.engine.base_model_name:
-      return clock_cycle.engine.base_model_name
+    if model_name := clock_cycle.worker.base_model_name:
+      return model_name
   return os.getenv("BASE_MODEL")
+
+
+def is_full_worker_mode() -> bool:
+  return WORKER_MODE == "full"
 
 
 def sampler_session_id(model_id: str, seq_id: int | str) -> str:
@@ -75,6 +84,12 @@ def sampler_session_id(model_id: str, seq_id: int | str) -> str:
 
 def sampler_weights_path(model_id: str, name: str) -> str:
   return f"tinker://{model_id}/sampler_weights/{name}"
+
+
+def checkpoint_state_path(model_id: str, name: str) -> str:
+  if os.path.isabs(name):
+    return name
+  return os.path.join(TMP_DIR, "checkpoints", model_id, "weights", name)
 
 
 def base_model_id_from_sampling_ref(model_id: str | None) -> str | None:
@@ -132,28 +147,59 @@ async def _preflight_vllm() -> None:
     ) from exc
 
 
+class FFTWorkerLauncher:
+  def __init__(self):
+    self.processes: dict[str, subprocess.Popen] = {}
+
+  def launch(self, model_id: str) -> None:
+    if not os.getenv("REDIS_URL"):
+      raise RuntimeError("OPEN_RL_WORKER_MODE=full requires REDIS_URL so launched workers can share queues and futures")
+
+    proc = self.processes.get(model_id)
+    if proc is not None and proc.poll() is None:
+      return
+
+    env = {**os.environ, "OPEN_RL_WORKER_MODE": "full", "OPEN_RL_WORKER_MODEL_ID": model_id}
+    self.processes[model_id] = subprocess.Popen(
+      [sys.executable, "-m", "clock_cycle"],
+      cwd=SERVER_DIR,
+      env=env,
+    )
+
+  def shutdown_all(self) -> None:
+    for proc in self.processes.values():
+      if proc.poll() is None:
+        proc.terminate()
+
+
+fft_worker_launcher = FFTWorkerLauncher()
+
+
 @asynccontextmanager
 async def lifespan(_: FastAPI):
   task = None
   if is_single_process_mode():
-    import clock_cycle
-
     base_model = os.getenv("BASE_MODEL")
     print("\n" + "=" * 50)
     print(" Open-RL Single-Process Mode")
     print("=" * 50)
     print(f"-> Base model: {base_model or 'unset'}")
     print(f"-> Sampling backend: {get_sampler_backend()}")
+    print(f"-> Worker mode     : {WORKER_MODE}")
     print("-> Server mode     : API server + worker loop in one process\n")
     await _preflight_vllm()
-    if base_model:
-      await asyncio.to_thread(clock_cycle.engine.load_base_model, base_model)
-    task = asyncio.create_task(clock_cycle.clock_cycle_loop())
+    if not is_full_worker_mode():
+      import clock_cycle
+
+      if base_model:
+        await asyncio.to_thread(clock_cycle.worker.load_base_model, base_model)
+      task = asyncio.create_task(clock_cycle.clock_cycle_loop())
   try:
     yield
   finally:
     if task is not None:
       task.cancel()
+    fft_worker_launcher.shutdown_all()
 
 
 app = FastAPI(title="Open-RL Server MVP", lifespan=lifespan)
@@ -203,6 +249,8 @@ async def create_model(req: dict):
   if not base_model:
     return JSONResponse(status_code=400, content={"error": "base_model is required"})
   model_id = str(uuid.uuid4())
+  if is_full_worker_mode():
+    fft_worker_launcher.launch(model_id)
   req_id = await _enqueue(
     {
       "req_id": model_id,
@@ -210,6 +258,7 @@ async def create_model(req: dict):
       "type": "create_model",
       "base_model": base_model,
       "lora_config": req.get("lora_config") or {},
+      "full_config": req.get("full_config") or {},
     }
   )
   return {"request_id": req_id}
@@ -224,6 +273,8 @@ async def create_model_from_state(req: dict):
   # Resolve relative names under TMP_DIR/checkpoints, leave absolute paths alone.
   resolved_path = state_path if os.path.isabs(state_path) else os.path.join(TMP_DIR, "checkpoints", state_path)
   model_id = str(uuid.uuid4())
+  if is_full_worker_mode():
+    fft_worker_launcher.launch(model_id)
   req_id = await _enqueue(
     {
       "req_id": model_id,
@@ -242,7 +293,9 @@ async def get_info(req: dict):
   model_name = get_default_model_name()
   if not model_name:
     return JSONResponse(status_code=404, content={"error": "No base model is configured"})
-  return {
+  # SDK compatibility: the public client currently expects LoRA-shaped training metadata,
+  # even when this process is running a full fine-tuning worker.
+  result = {
     "model_data": {"arch": "unknown", "model_name": model_name, "tokenizer_id": model_name},
     "model_id": req.get("model_id", "model-live-123"),
     "is_lora": True,
@@ -250,6 +303,7 @@ async def get_info(req: dict):
     "model_name": model_name,
     "type": "get_info",
   }
+  return result
 
 
 @app.post("/api/v1/retrieve_future")
@@ -327,12 +381,12 @@ async def save_weights_for_sampler(req: dict):
 
 @app.post("/api/v1/save_weights")
 async def save_weights(req: dict):
-  """TrainingClient.save_weights() / save_state() — persists adapter to TMP_DIR/checkpoints/<alias>.
+  """TrainingClient.save_weights() / save_state().
 
   This is the endpoint the tinker SDK hits for both save_weights() and save_state().
-  When `path` is provided we treat it as a named checkpoint alias and resolve to
-  TMP_DIR/checkpoints/<alias> (or leave absolute paths alone), so subsequent
-  `create_training_client_from_state(alias)` calls can find the adapter.
+  The SDK sends save_state(name) as `path`; we resolve that checkpoint name to
+  TMP_DIR/checkpoints/<model_id>/weights/<path> so separate training jobs do not
+  overwrite each other's named checkpoints.
   """
   model_id = req.get("model_id")
   if not model_id:
@@ -340,7 +394,7 @@ async def save_weights(req: dict):
 
   seq_id = req.get("seq_id") or int(time.time() * 1000)
   alias = req.get("path") or f"{model_id}-samp-{seq_id}"
-  state_path = alias if os.path.isabs(alias) else os.path.join(TMP_DIR, "checkpoints", alias)
+  state_path = checkpoint_state_path(model_id, alias)
 
   req_id = str(uuid.uuid4())
   await _enqueue(
@@ -366,7 +420,7 @@ async def load_weights(req: dict):
   if not state_path:
     return JSONResponse(status_code=400, content={"error": "path is required"})
 
-  resolved_path = state_path if os.path.isabs(state_path) else os.path.join(TMP_DIR, "checkpoints", state_path)
+  resolved_path = checkpoint_state_path(model_id, state_path)
   req_id = await _enqueue(
     {
       "model_id": model_id,

--- a/src/server/store.py
+++ b/src/server/store.py
@@ -16,8 +16,18 @@ class RequestStore(ABC):
     pass
 
   @abstractmethod
+  async def put_worker_launch_request(self, req_data: dict[str, Any]) -> None:
+    """Push a create-model request onto the queue that starts dedicated FFT workers."""
+    pass
+
+  @abstractmethod
   async def get_requests(self) -> list[dict[str, Any]]:
     """Block until at least 1 request is available, then return all currently queued requests."""
+    pass
+
+  @abstractmethod
+  async def get_worker_launch_requests(self) -> list[dict[str, Any]]:
+    """Block until at least 1 worker-launch request is available, then drain that queue."""
     pass
 
   @abstractmethod
@@ -43,7 +53,6 @@ class InMemoryStore(RequestStore):
     # Simple list for round-robin
     self.active_tenants: list[str] = []
     self.active_tenants_cv = asyncio.Condition()
-
     self.futures_store: dict[str, dict[str, Any]] = {}
     self.futures_events: dict[str, asyncio.Event] = {}
 
@@ -59,6 +68,9 @@ class InMemoryStore(RequestStore):
       if model_id not in self.active_tenants:
         self.active_tenants.append(model_id)
         self.active_tenants_cv.notify()
+
+  async def put_worker_launch_request(self, req_data: dict[str, Any]) -> None:
+    raise RuntimeError("Worker launch requests require REDIS_URL; in-memory queues cannot be shared across processes")
 
   async def get_requests(self) -> list[dict[str, Any]]:
     async with self.active_tenants_cv:
@@ -82,6 +94,9 @@ class InMemoryStore(RequestStore):
         self.active_tenants.remove(model_id)
 
       return batch
+
+  async def get_worker_launch_requests(self) -> list[dict[str, Any]]:
+    raise RuntimeError("Worker launch requests require REDIS_URL; in-memory queues cannot be shared across processes")
 
   async def get_requests_for_model(self, model_id: str) -> list[dict[str, Any]]:
     raise RuntimeError("Per-model full fine-tuning workers require REDIS_URL; in-memory queues cannot be shared across processes")
@@ -115,6 +130,7 @@ class RedisStore(RequestStore):
     self.active_list = "open_rl:active_tenants"
     # We also keep a set to guarantee O(1) deduplication before RPushing
     self.active_set = "open_rl:active_tenants_set"
+    self.worker_launch_queue = "open_rl:worker_launch_queue"
 
   async def put_request(self, req_data: dict[str, Any]) -> None:
     model_id = req_data.get("model_id", "default")
@@ -128,6 +144,9 @@ class RedisStore(RequestStore):
     is_new = await self.redis.sadd(self.active_set, model_id)
     if is_new == 1:
       await self.redis.rpush(self.active_list, model_id)
+
+  async def put_worker_launch_request(self, req_data: dict[str, Any]) -> None:
+    await self.redis.rpush(self.worker_launch_queue, json.dumps(req_data))
 
   async def get_requests(self) -> list[dict[str, Any]]:
     # BRPOPLPUSH blocks until an item is available.
@@ -160,6 +179,22 @@ class RedisStore(RequestStore):
       # We remove it from the list AND set
       await self.redis.lrem(self.active_list, 0, model_id)
       await self.redis.srem(self.active_set, model_id)
+
+    return batch
+
+  async def get_worker_launch_requests(self) -> list[dict[str, Any]]:
+    result = await self.redis.blpop(self.worker_launch_queue, timeout=5)
+
+    if not result:
+      return []
+
+    batch = [json.loads(result[1])]
+
+    while True:
+      item = await self.redis.lpop(self.worker_launch_queue)
+      if not item:
+        break
+      batch.append(json.loads(item))
 
     return batch
 

--- a/src/server/store.py
+++ b/src/server/store.py
@@ -21,6 +21,11 @@ class RequestStore(ABC):
     pass
 
   @abstractmethod
+  async def get_requests_for_model(self, model_id: str) -> list[dict[str, Any]]:
+    """Block until this model has at least 1 request, then return all queued requests for it."""
+    pass
+
+  @abstractmethod
   async def set_future(self, req_id: str, result: dict[str, Any]) -> None:
     """Resolve a future by its request ID."""
     pass
@@ -77,6 +82,9 @@ class InMemoryStore(RequestStore):
         self.active_tenants.remove(model_id)
 
       return batch
+
+  async def get_requests_for_model(self, model_id: str) -> list[dict[str, Any]]:
+    raise RuntimeError("Per-model full fine-tuning workers require REDIS_URL; in-memory queues cannot be shared across processes")
 
   async def set_future(self, req_id: str, result: dict[str, Any]) -> None:
     self.futures_store[req_id] = result
@@ -150,6 +158,28 @@ class RedisStore(RequestStore):
     q_len = await self.redis.llen(queue_key)
     if q_len == 0:
       # We remove it from the list AND set
+      await self.redis.lrem(self.active_list, 0, model_id)
+      await self.redis.srem(self.active_set, model_id)
+
+    return batch
+
+  async def get_requests_for_model(self, model_id: str) -> list[dict[str, Any]]:
+    queue_key = f"open_rl:queue:{model_id}"
+    result = await self.redis.blpop(queue_key, timeout=5)
+
+    if not result:
+      return []
+
+    batch = [json.loads(result[1])]
+
+    while True:
+      item = await self.redis.lpop(queue_key)
+      if not item:
+        break
+      batch.append(json.loads(item))
+
+    q_len = await self.redis.llen(queue_key)
+    if q_len == 0:
       await self.redis.lrem(self.active_list, 0, model_id)
       await self.redis.srem(self.active_set, model_id)
 

--- a/src/server/training/fft_trainer_worker.py
+++ b/src/server/training/fft_trainer_worker.py
@@ -149,9 +149,7 @@ class FFTTrainingWorker(BaseTrainerWorker):
         print(f"Restored optimizer state from {optimizer_path}")
 
     print(f"Loaded full fine-tuning state from {state_path}")
-    # SDK compatibility: the public client currently expects LoRA-shaped training metadata,
-    # even when this worker loaded full fine-tuned weights.
-    return {"model_id": model_id, "is_lora": True, "lora_rank": 16, "base_model": base_model}
+    return {"model_id": model_id, "base_model": base_model}
 
   def forward_backward(self, data: list[Datum], loss_fn: str, loss_config: dict | None = None, model_id: str | None = None) -> dict[str, Any]:
     assert self.model is not None, "Model must be loaded first."

--- a/src/server/training/fft_trainer_worker.py
+++ b/src/server/training/fft_trainer_worker.py
@@ -47,11 +47,11 @@ class FFTTrainingWorker(BaseTrainerWorker):
     dtype = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float32
 
     self.model = AutoModelForCausalLM.from_pretrained(base_model_name, dtype=dtype, device_map=self.device)
-    self.prepare_model_for_training()
     print("Successfully loaded full fine-tuning model.")
 
-  def create_model(self, model_id: str | None = None, config: FFTConfig | None = None) -> None:
-    """Prepare the loaded model for full fine-tuning."""
+  def create_model(self, base_model_name: str, model_id: str | None = None, config: FFTConfig | None = None) -> None:
+    """Load the per-job model if needed, then prepare it for full fine-tuning."""
+    self.load_base_model(base_model_name)
     if config is not None and config.seed is not None:
       torch.manual_seed(config.seed)
     self.prepare_model_for_training()
@@ -149,7 +149,9 @@ class FFTTrainingWorker(BaseTrainerWorker):
         print(f"Restored optimizer state from {optimizer_path}")
 
     print(f"Loaded full fine-tuning state from {state_path}")
-    return {"model_id": model_id, "is_lora": False, "base_model": base_model}
+    # SDK compatibility: the public client currently expects LoRA-shaped training metadata,
+    # even when this worker loaded full fine-tuned weights.
+    return {"model_id": model_id, "is_lora": True, "lora_rank": 16, "base_model": base_model}
 
   def forward_backward(self, data: list[Datum], loss_fn: str, loss_config: dict | None = None, model_id: str | None = None) -> dict[str, Any]:
     assert self.model is not None, "Model must be loaded first."

--- a/src/server/training/lora_trainer_worker.py
+++ b/src/server/training/lora_trainer_worker.py
@@ -130,6 +130,11 @@ class LoraTrainingWorker(BaseTrainerWorker):
 
     self.save_adapter(adapter_id)
 
+  def create_model(self, base_model_name: str, model_id: str, config: LoraConfig) -> None:
+    """Load the shared base model if needed, then create a trainable LoRA adapter."""
+    self.load_base_model(base_model_name)
+    self.create_adapter(model_id, config)
+
   def save_adapter(self, adapter_id: str, alias: str | None = None) -> None:
     """Save adapter weights to disk for reliability and sharing."""
     try:
@@ -138,6 +143,7 @@ class LoraTrainingWorker(BaseTrainerWorker):
       os.makedirs(save_path, exist_ok=True)
 
       # Save the adapter weights
+      self.peft_model.set_adapter(adapter_id)
       self.peft_model.save_pretrained(save_path, selected_adapters=[adapter_id])
 
       # Save minimal metadata
@@ -245,11 +251,6 @@ class LoraTrainingWorker(BaseTrainerWorker):
     if model_id:
       self.peft_model.set_adapter(model_id)
     return super().forward_backward(self.peft_model, data, loss_fn, loss_config)
-
-  def set_active_adapter(self, adapter_id: str) -> None:
-    """Switch which LoRA adapter is active."""
-    if self.peft_model is not None:
-      self.peft_model.set_adapter(adapter_id)
 
   def optim_step(self, adam_params: dict[str, Any], model_id: str) -> dict[str, Any]:
     """Apply accumulated gradients and update model weights."""

--- a/src/server/worker_launch_processor.py
+++ b/src/server/worker_launch_processor.py
@@ -1,0 +1,99 @@
+import asyncio
+import os
+import subprocess
+import sys
+import traceback
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+from store import RequestStore
+
+SERVER_DIR = Path(__file__).resolve().parent
+
+
+class CreateModelWorkerLaunchRequest(BaseModel):
+  req_id: str
+  model_id: str
+  type: Literal["create_model"]
+  base_model: str
+  lora_config: dict[str, Any] = Field(default_factory=dict)
+  full_config: dict[str, Any] = Field(default_factory=dict)
+  trace_context: dict[str, str] = Field(default_factory=dict)
+
+
+class CreateModelFromStateWorkerLaunchRequest(BaseModel):
+  req_id: str
+  model_id: str
+  type: Literal["create_model_from_state"]
+  state_path: str
+  restore_optimizer: bool = False
+  trace_context: dict[str, str] = Field(default_factory=dict)
+
+
+WorkerLaunchRequest = CreateModelWorkerLaunchRequest | CreateModelFromStateWorkerLaunchRequest
+
+
+class FFTWorkerManager:
+  def __init__(self, server_dir: Path = SERVER_DIR):
+    if not os.getenv("REDIS_URL"):
+      raise RuntimeError("OPEN_RL_ENABLE_FFT=true requires REDIS_URL so launched workers can share queues and futures")
+
+    self.server_dir = server_dir
+    self.processes: dict[str, subprocess.Popen] = {}
+
+  def launch(self, model_id: str) -> None:
+    proc = self.processes.get(model_id)
+    if proc is not None and proc.poll() is None:
+      return
+
+    env = {**os.environ, "OPEN_RL_ENABLE_FFT": "true"}
+    self.processes[model_id] = subprocess.Popen(
+      [sys.executable, "-m", "clock_cycle", "--model-id", model_id],
+      cwd=self.server_dir,
+      env=env,
+    )
+
+  def shutdown_all(self) -> None:
+    for proc in self.processes.values():
+      if proc.poll() is None:
+        proc.terminate()
+
+
+class WorkerLaunchProcessor:
+  """Drain the worker launch queue and start FFT workers before enqueueing training requests."""
+
+  def __init__(self, store: RequestStore, worker_manager: FFTWorkerManager):
+    self.store = store
+    self.worker_manager = worker_manager
+
+  async def process_request(self, request: dict) -> None:
+    try:
+      model_id = request.get("model_id")
+      if not model_id:
+        raise ValueError("worker launch request requires model_id")
+
+      self.worker_manager.launch(model_id)
+      await self.store.put_request(request)
+    except Exception as exc:
+      traceback.print_exc()
+      await self.store.set_future(request["req_id"], {"type": "RequestFailedResponse", "error_message": str(exc)})
+
+  async def process_batch(self, requests: list[dict]) -> None:
+    for request in requests:
+      await self.process_request(request)
+
+  async def run(self) -> None:
+    while True:
+      try:
+        batch = await self.store.get_worker_launch_requests()
+        if not batch:
+          await asyncio.sleep(0.1)
+          continue
+        await self.process_batch(batch)
+      except asyncio.CancelledError:
+        break
+      except Exception as exc:
+        print(f"Error in worker launch processor: {exc}")
+        traceback.print_exc()
+        await asyncio.sleep(1)

--- a/tests/test_gateway_paths.py
+++ b/tests/test_gateway_paths.py
@@ -1,0 +1,34 @@
+import os
+import sys
+import tempfile
+import unittest
+
+from tests._server_fixture import SERVER_DIR
+
+sys.path.insert(0, str(SERVER_DIR))
+
+import gateway  # noqa: E402
+
+
+class GatewayPathTest(unittest.TestCase):
+  def test_checkpoint_state_paths_are_model_scoped(self) -> None:
+    old_tmp_dir = gateway.TMP_DIR
+    with tempfile.TemporaryDirectory() as tmp_dir:
+      gateway.TMP_DIR = tmp_dir
+      self.addCleanup(setattr, gateway, "TMP_DIR", old_tmp_dir)
+
+      self.assertEqual(
+        gateway.checkpoint_state_path("job-a", "final"),
+        os.path.join(tmp_dir, "checkpoints", "job-a", "weights", "final"),
+      )
+      self.assertEqual(
+        gateway.checkpoint_state_path("job-b", "final"),
+        os.path.join(tmp_dir, "checkpoints", "job-b", "weights", "final"),
+      )
+
+  def test_checkpoint_state_paths_accept_explicit_output_directories(self) -> None:
+    self.assertEqual(gateway.checkpoint_state_path("job-a", "/mnt/checkpoints/final"), "/mnt/checkpoints/final")
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tests/test_trainer_optimizer_correctness.py
+++ b/tests/test_trainer_optimizer_correctness.py
@@ -56,8 +56,7 @@ def _load_clock_cycle_module():
   old_path = list(sys.path)
   sys.path.insert(0, str(SERVER_DIR))
   env = {
-    "OPEN_RL_WORKER_MODE": "full",
-    "OPEN_RL_WORKER_MODEL_ID": "model-a",
+    "OPEN_RL_ENABLE_FFT": "true",
     "REDIS_URL": "redis://localhost:6379",
   }
   with patch.dict(sys.modules, stubs), patch.dict(os.environ, env):
@@ -294,29 +293,26 @@ class TestTrainerOptimizerCorrectness(unittest.TestCase):
 
 
 class TestClockCycleFullMode(unittest.IsolatedAsyncioTestCase):
+  async def test_importing_clock_cycle_does_not_create_worker(self) -> None:
+    self.assertFalse(hasattr(clock_cycle_module, "worker"))
+
   async def test_clock_cycle_lora_mode_create_model_uses_worker_create_model(self) -> None:
     worker = _RecordingLoraWorker()
     store = _FutureStoreStub()
-    old_worker = clock_cycle_module.worker
-    old_is_full_worker_mode = clock_cycle_module.is_full_worker_mode
-    clock_cycle_module.worker = worker
-    clock_cycle_module.is_full_worker_mode = lambda: False
 
-    try:
-      await clock_cycle_module.handle_request(
-        store,
-        {
-          "req_id": "req-a",
-          "model_id": "adapter-a",
-          "type": "create_model",
-          "base_model": "base-model",
-          "lora_config": {"seed": 123, "rank": 2},
-        },
-        "adapter-a",
-      )
-    finally:
-      clock_cycle_module.worker = old_worker
-      clock_cycle_module.is_full_worker_mode = old_is_full_worker_mode
+    await clock_cycle_module.handle_request(
+      store,
+      {
+        "req_id": "req-a",
+        "model_id": "adapter-a",
+        "type": "create_model",
+        "base_model": "base-model",
+        "lora_config": {"seed": 123, "rank": 2},
+      },
+      "adapter-a",
+      worker,
+      fft_enabled=False,
+    )
 
     self.assertEqual(worker.loaded_base_models, [])
     base_model, model_id, config = worker.created_models[0]
@@ -326,29 +322,26 @@ class TestClockCycleFullMode(unittest.IsolatedAsyncioTestCase):
     self.assertEqual(config.rank, 2)
     result = store.results["req-a"]
     self.assertEqual(result["model_id"], "adapter-a")
-    self.assertTrue(result["is_lora"])
     self.assertEqual(result["lora_rank"], 2)
+    self.assertEqual(result["type"], "create_model_result")
 
   async def test_clock_cycle_full_mode_create_model_uses_model_worker(self) -> None:
     worker = _RecordingFullWorker()
     store = _FutureStoreStub()
-    old_worker = clock_cycle_module.worker
-    clock_cycle_module.worker = worker
 
-    try:
-      await clock_cycle_module.handle_request(
-        store,
-        {
-          "req_id": "req-a",
-          "model_id": "model-a",
-          "type": "create_model",
-          "base_model": "base-model",
-          "full_config": {"seed": 123, "rank": 8},
-        },
-        "model-a",
-      )
-    finally:
-      clock_cycle_module.worker = old_worker
+    await clock_cycle_module.handle_request(
+      store,
+      {
+        "req_id": "req-a",
+        "model_id": "model-a",
+        "type": "create_model",
+        "base_model": "base-model",
+        "full_config": {"seed": 123, "rank": 8},
+      },
+      "model-a",
+      worker,
+      fft_enabled=True,
+    )
 
     self.assertEqual(worker.loaded_base_models, [])
     base_model, model_id, config = worker.created_models[0]
@@ -357,31 +350,28 @@ class TestClockCycleFullMode(unittest.IsolatedAsyncioTestCase):
     self.assertEqual(config.seed, 123)
     result = store.results["req-a"]
     self.assertEqual(result["model_id"], "model-a")
-    self.assertTrue(result["is_lora"])
     self.assertEqual(result["lora_rank"], 16)
     self.assertEqual(result["base_model"], "base-model")
+    self.assertEqual(result["type"], "create_model_result")
 
   async def test_clock_cycle_full_mode_saves_sampler_checkpoint_as_full_state(self) -> None:
     worker = _RecordingFullWorker()
     store = _FutureStoreStub()
-    old_worker = clock_cycle_module.worker
-    clock_cycle_module.worker = worker
 
-    try:
-      with patch.dict(os.environ, {"OPEN_RL_TMP_DIR": "/tmp/open-rl-test"}):
-        await clock_cycle_module.handle_request(
-          store,
-          {
-            "req_id": "req-a",
-            "model_id": "model-a",
-            "type": "save_weights_for_sampler",
-            "path": "tinker://model-a/sampler_weights/final",
-            "sampling_session_id": "tinker://model-a/sampler_weights/sampler-7",
-          },
-          "model-a",
-        )
-    finally:
-      clock_cycle_module.worker = old_worker
+    with patch.dict(os.environ, {"OPEN_RL_TMP_DIR": "/tmp/open-rl-test"}):
+      await clock_cycle_module.handle_request(
+        store,
+        {
+          "req_id": "req-a",
+          "model_id": "model-a",
+          "type": "save_weights_for_sampler",
+          "path": "tinker://model-a/sampler_weights/final",
+          "sampling_session_id": "tinker://model-a/sampler_weights/sampler-7",
+        },
+        "model-a",
+        worker,
+        fft_enabled=True,
+      )
 
     self.assertEqual(
       worker.saved_states,
@@ -397,8 +387,8 @@ class TestClockCycleFullMode(unittest.IsolatedAsyncioTestCase):
     )
 
   async def test_clock_cycle_full_mode_requires_redis(self) -> None:
-    with patch.dict(os.environ, {}, clear=True), self.assertRaisesRegex(RuntimeError, "REDIS_URL"):
-      await clock_cycle_module.clock_cycle_loop()
+    with patch.dict(os.environ, {"OPEN_RL_ENABLE_FFT": "true"}, clear=True), self.assertRaisesRegex(RuntimeError, "REDIS_URL"):
+      await clock_cycle_module.clock_cycle_loop(_RecordingFullWorker(), "model-a")
 
 
 class TestTrainerPaddedBatchingMath(unittest.TestCase):

--- a/tests/test_trainer_optimizer_correctness.py
+++ b/tests/test_trainer_optimizer_correctness.py
@@ -1,6 +1,7 @@
 import importlib
 import os
 import sys
+import tempfile
 import types
 import unittest
 from unittest.mock import patch
@@ -38,7 +39,38 @@ def _load_trainer_modules():
   return trainer_worker, lora_trainer_worker, fft_trainer_worker, losses
 
 
+def _load_clock_cycle_module():
+  stubs = {
+    "peft": types.SimpleNamespace(
+      LoraConfig=object,
+      PeftModelForCausalLM=object,
+      get_peft_model=lambda *_args, **_kwargs: None,
+    ),
+    "transformers": types.SimpleNamespace(
+      AutoModelForCausalLM=object,
+      AutoTokenizer=object,
+      PreTrainedModel=object,
+      PreTrainedTokenizerBase=object,
+    ),
+  }
+  old_path = list(sys.path)
+  sys.path.insert(0, str(SERVER_DIR))
+  env = {
+    "OPEN_RL_WORKER_MODE": "full",
+    "OPEN_RL_WORKER_MODEL_ID": "model-a",
+    "REDIS_URL": "redis://localhost:6379",
+  }
+  with patch.dict(sys.modules, stubs), patch.dict(os.environ, env):
+    for module_name in list(sys.modules):
+      if module_name == "clock_cycle":
+        del sys.modules[module_name]
+    clock_cycle = importlib.import_module("clock_cycle")
+  sys.path = old_path
+  return clock_cycle
+
+
 trainer_worker_module, lora_trainer_worker_module, fft_trainer_worker_module, losses_module = _load_trainer_modules()
+clock_cycle_module = _load_clock_cycle_module()
 BaseTrainerWorker = trainer_worker_module.BaseTrainerWorker
 FFTTrainingWorker = fft_trainer_worker_module.FFTTrainingWorker
 LoraTrainingWorker = lora_trainer_worker_module.LoraTrainingWorker
@@ -97,6 +129,48 @@ class _FullModelStub:
     yield from self.params
 
 
+class _RecordingFullWorker:
+  def __init__(self):
+    self.base_model_name = None
+    self.loaded_base_models = []
+    self.created_models = []
+    self.saved_states = []
+
+  def load_base_model(self, base_model_name):
+    self.base_model_name = base_model_name
+    self.loaded_base_models.append(base_model_name)
+
+  def create_model(self, base_model_name, model_id, config):
+    self.created_models.append((base_model_name, model_id, config))
+
+  def forward_backward(self, data, loss_fn, loss_config=None, model_id=None):
+    return {"model_id": model_id, "loss_fn": loss_fn, "loss_config": loss_config, "data": data}
+
+  def save_state(self, model_id, state_path, include_optimizer=False, kind="state"):
+    self.saved_states.append((model_id, state_path, include_optimizer, kind))
+    return {"path": state_path}
+
+
+class _RecordingLoraWorker:
+  def __init__(self):
+    self.loaded_base_models = []
+    self.created_models = []
+
+  def load_base_model(self, base_model_name):
+    self.loaded_base_models.append(base_model_name)
+
+  def create_model(self, base_model_name, model_id, config):
+    self.created_models.append((base_model_name, model_id, config))
+
+
+class _FutureStoreStub:
+  def __init__(self):
+    self.results = {}
+
+  async def set_future(self, req_id, result):
+    self.results[req_id] = result
+
+
 def _datum(model_input, target_tokens, *, weights=None, logprobs=None, advantages=None):
   loss_fn_inputs = {"target_tokens": trainer_worker_module.TensorData(data=target_tokens)}
   if weights is not None:
@@ -109,25 +183,70 @@ def _datum(model_input, target_tokens, *, weights=None, logprobs=None, advantage
 
 
 class TestTrainerOptimizerCorrectness(unittest.TestCase):
+  def test_lora_create_model_loads_base_then_creates_adapter(self) -> None:
+    worker = LoraTrainingWorker()
+    config = lora_trainer_worker_module.LoraConfig(rank=2, seed=123)
+    calls = []
+
+    worker.load_base_model = lambda base_model_name: calls.append(("load", base_model_name))
+    worker.create_adapter = lambda model_id, adapter_config: calls.append(("adapter", model_id, adapter_config))
+
+    worker.create_model("base-model", "adapter-a", config)
+
+    self.assertEqual(calls[0], ("load", "base-model"))
+    self.assertEqual(calls[1][0], "adapter")
+    self.assertEqual(calls[1][1], "adapter-a")
+    self.assertIs(calls[1][2], config)
+
+  def test_save_adapter_selects_adapter_it_saves(self) -> None:
+    adapter_a_param = torch.nn.Parameter(torch.tensor([1.0]))
+    adapter_b_param = torch.nn.Parameter(torch.tensor([1.0]))
+    worker = LoraTrainingWorker()
+    worker.peft_model = _PeftModelStub(
+      {
+        "adapter-a": [adapter_a_param],
+        "adapter-b": [adapter_b_param],
+      }
+    )
+    worker.peft_model.set_adapter("adapter-b")
+
+    with tempfile.TemporaryDirectory() as tmp_dir, patch.dict(os.environ, {"OPEN_RL_TMP_DIR": tmp_dir}):
+      worker.save_adapter("adapter-a")
+      self.assertTrue(os.path.exists(os.path.join(tmp_dir, "peft", "adapter-a", "metadata.json")))
+
+    self.assertEqual(worker.peft_model.active_adapter, "adapter-a")
+
+  def test_fft_create_model_loads_base_then_prepares_model(self) -> None:
+    worker = FFTTrainingWorker()
+    config = fft_trainer_worker_module.FFTConfig(seed=123)
+    calls = []
+
+    worker.load_base_model = lambda base_model_name: calls.append(("load", base_model_name))
+    worker.prepare_model_for_training = lambda: calls.append(("prepare", None))
+
+    worker.create_model("base-model", "model-a", config)
+
+    self.assertEqual(calls, [("load", "base-model"), ("prepare", None)])
+
   def test_optim_step_only_updates_active_adapter_params(self) -> None:
     active_param = torch.nn.Parameter(torch.tensor([1.0]))
     other_param = torch.nn.Parameter(torch.tensor([1.0]))
     active_param.grad = torch.tensor([1.0])
     other_param.grad = torch.tensor([10.0])
 
-    engine = LoraTrainingWorker()
-    engine.peft_model = _PeftModelStub(
+    worker = LoraTrainingWorker()
+    worker.peft_model = _PeftModelStub(
       {
         "adapter-a": [active_param],
         "adapter-b": [other_param],
       }
     )
-    engine.adapter_states = {
-      "adapter-a": {"trainable_params": lora_trainer_worker_module.active_adapter_parameters(engine.peft_model, "adapter-a"), "optimizer": None}
+    worker.adapter_states = {
+      "adapter-a": {"trainable_params": lora_trainer_worker_module.active_adapter_parameters(worker.peft_model, "adapter-a"), "optimizer": None}
     }
-    engine.save_adapter = lambda *_args, **_kwargs: None
+    worker.save_adapter = lambda *_args, **_kwargs: None
 
-    result = engine.optim_step(
+    result = worker.optim_step(
       {
         "learning_rate": 0.1,
         "beta1": 0.0,
@@ -138,7 +257,7 @@ class TestTrainerOptimizerCorrectness(unittest.TestCase):
       "adapter-a",
     )
 
-    self.assertEqual(engine.peft_model.active_adapter, "adapter-a")
+    self.assertEqual(worker.peft_model.active_adapter, "adapter-a")
     self.assertAlmostEqual(result["metrics"]["grad_norm:mean"], 1.0)
     self.assertFalse(torch.allclose(active_param.detach(), torch.tensor([1.0])))
     self.assertTrue(torch.allclose(other_param.detach(), torch.tensor([1.0])))
@@ -152,11 +271,11 @@ class TestTrainerOptimizerCorrectness(unittest.TestCase):
     trainable_param.grad = torch.tensor([1.0])
     frozen_param.grad = torch.tensor([10.0])
 
-    engine = FFTTrainingWorker()
-    engine.model = _FullModelStub([trainable_param, frozen_param])
-    engine.trainable_params = fft_trainer_worker_module.trainable_model_parameters(engine.model)
+    worker = FFTTrainingWorker()
+    worker.model = _FullModelStub([trainable_param, frozen_param])
+    worker.trainable_params = fft_trainer_worker_module.trainable_model_parameters(worker.model)
 
-    result = engine.optim_step(
+    result = worker.optim_step(
       {
         "learning_rate": 0.1,
         "beta1": 0.0,
@@ -172,6 +291,114 @@ class TestTrainerOptimizerCorrectness(unittest.TestCase):
     if trainable_param.grad is not None:
       self.assertTrue(torch.allclose(trainable_param.grad, torch.zeros_like(trainable_param.grad)))
     self.assertIsNotNone(frozen_param.grad)
+
+
+class TestClockCycleFullMode(unittest.IsolatedAsyncioTestCase):
+  async def test_clock_cycle_lora_mode_create_model_uses_worker_create_model(self) -> None:
+    worker = _RecordingLoraWorker()
+    store = _FutureStoreStub()
+    old_worker = clock_cycle_module.worker
+    old_is_full_worker_mode = clock_cycle_module.is_full_worker_mode
+    clock_cycle_module.worker = worker
+    clock_cycle_module.is_full_worker_mode = lambda: False
+
+    try:
+      await clock_cycle_module.handle_request(
+        store,
+        {
+          "req_id": "req-a",
+          "model_id": "adapter-a",
+          "type": "create_model",
+          "base_model": "base-model",
+          "lora_config": {"seed": 123, "rank": 2},
+        },
+        "adapter-a",
+      )
+    finally:
+      clock_cycle_module.worker = old_worker
+      clock_cycle_module.is_full_worker_mode = old_is_full_worker_mode
+
+    self.assertEqual(worker.loaded_base_models, [])
+    base_model, model_id, config = worker.created_models[0]
+    self.assertEqual(base_model, "base-model")
+    self.assertEqual(model_id, "adapter-a")
+    self.assertEqual(config.seed, 123)
+    self.assertEqual(config.rank, 2)
+    result = store.results["req-a"]
+    self.assertEqual(result["model_id"], "adapter-a")
+    self.assertTrue(result["is_lora"])
+    self.assertEqual(result["lora_rank"], 2)
+
+  async def test_clock_cycle_full_mode_create_model_uses_model_worker(self) -> None:
+    worker = _RecordingFullWorker()
+    store = _FutureStoreStub()
+    old_worker = clock_cycle_module.worker
+    clock_cycle_module.worker = worker
+
+    try:
+      await clock_cycle_module.handle_request(
+        store,
+        {
+          "req_id": "req-a",
+          "model_id": "model-a",
+          "type": "create_model",
+          "base_model": "base-model",
+          "full_config": {"seed": 123, "rank": 8},
+        },
+        "model-a",
+      )
+    finally:
+      clock_cycle_module.worker = old_worker
+
+    self.assertEqual(worker.loaded_base_models, [])
+    base_model, model_id, config = worker.created_models[0]
+    self.assertEqual(base_model, "base-model")
+    self.assertEqual(model_id, "model-a")
+    self.assertEqual(config.seed, 123)
+    result = store.results["req-a"]
+    self.assertEqual(result["model_id"], "model-a")
+    self.assertTrue(result["is_lora"])
+    self.assertEqual(result["lora_rank"], 16)
+    self.assertEqual(result["base_model"], "base-model")
+
+  async def test_clock_cycle_full_mode_saves_sampler_checkpoint_as_full_state(self) -> None:
+    worker = _RecordingFullWorker()
+    store = _FutureStoreStub()
+    old_worker = clock_cycle_module.worker
+    clock_cycle_module.worker = worker
+
+    try:
+      with patch.dict(os.environ, {"OPEN_RL_TMP_DIR": "/tmp/open-rl-test"}):
+        await clock_cycle_module.handle_request(
+          store,
+          {
+            "req_id": "req-a",
+            "model_id": "model-a",
+            "type": "save_weights_for_sampler",
+            "path": "tinker://model-a/sampler_weights/final",
+            "sampling_session_id": "tinker://model-a/sampler_weights/sampler-7",
+          },
+          "model-a",
+        )
+    finally:
+      clock_cycle_module.worker = old_worker
+
+    self.assertEqual(
+      worker.saved_states,
+      [("model-a", "/tmp/open-rl-test/sampler_full/model-a/sampler_weights/final", False, "sampler")],
+    )
+    self.assertEqual(
+      store.results["req-a"],
+      {
+        "path": "tinker://model-a/sampler_weights/final",
+        "sampling_session_id": "tinker://model-a/sampler_weights/sampler-7",
+        "type": "save_weights_for_sampler",
+      },
+    )
+
+  async def test_clock_cycle_full_mode_requires_redis(self) -> None:
+    with patch.dict(os.environ, {}, clear=True), self.assertRaisesRegex(RuntimeError, "REDIS_URL"):
+      await clock_cycle_module.clock_cycle_loop()
 
 
 class TestTrainerPaddedBatchingMath(unittest.TestCase):
@@ -277,10 +504,10 @@ class TestTrainerPaddedBatchingMath(unittest.TestCase):
     )
 
   def test_token_budget_batches_preserve_examples(self) -> None:
-    engine = self._worker()
+    worker = self._worker()
     data = self._data()
     with patch.dict(os.environ, {"OPEN_RL_TRAIN_TOKEN_BUDGET": "6"}):
-      batches = engine.make_training_batches(data)
+      batches = worker.make_training_batches(data)
 
     seen = [idx for batch in batches for idx, _datum in batch]
     self.assertCountEqual(seen, range(len(data)))

--- a/tests/test_worker_launch_processor.py
+++ b/tests/test_worker_launch_processor.py
@@ -1,0 +1,170 @@
+import sys
+import unittest
+from unittest.mock import patch
+
+from tests._server_fixture import SERVER_DIR
+
+sys.path.insert(0, str(SERVER_DIR))
+
+import gateway  # noqa: E402
+from store import InMemoryStore  # noqa: E402
+from worker_launch_processor import CreateModelFromStateWorkerLaunchRequest, WorkerLaunchProcessor  # noqa: E402
+
+
+class StoreStub:
+  def __init__(self):
+    self.forwarded_requests = []
+    self.futures = {}
+
+  async def put_request(self, req_data: dict) -> None:
+    self.forwarded_requests.append(req_data)
+
+  async def set_future(self, req_id: str, result: dict) -> None:
+    self.futures[req_id] = result
+
+
+class WorkerManagerStub:
+  def __init__(self, error: Exception | None = None):
+    self.error = error
+    self.launched_model_ids = []
+
+  def launch(self, model_id: str) -> None:
+    self.launched_model_ids.append(model_id)
+    if self.error is not None:
+      raise self.error
+
+
+class WorkerLaunchProcessorTest(unittest.IsolatedAsyncioTestCase):
+  async def test_process_request_launches_worker_then_forwards_request(self) -> None:
+    store = StoreStub()
+    worker_manager = WorkerManagerStub()
+    processor = WorkerLaunchProcessor(store, worker_manager)
+    request = {"req_id": "model-a", "model_id": "model-a", "type": "create_model", "base_model": "base-model"}
+
+    await processor.process_request(request)
+
+    self.assertEqual(worker_manager.launched_model_ids, ["model-a"])
+    self.assertEqual(len(store.forwarded_requests), 1)
+    self.assertEqual(store.forwarded_requests[0]["type"], "create_model")
+    self.assertEqual(store.forwarded_requests[0]["base_model"], "base-model")
+    self.assertEqual(store.futures, {})
+
+  async def test_process_request_sets_future_failure_when_launch_fails(self) -> None:
+    store = StoreStub()
+    worker_manager = WorkerManagerStub(RuntimeError("boom"))
+    processor = WorkerLaunchProcessor(store, worker_manager)
+    request = {"req_id": "model-a", "model_id": "model-a", "type": "create_model", "base_model": "base-model"}
+
+    with patch("worker_launch_processor.traceback.print_exc"):
+      await processor.process_request(request)
+
+    self.assertEqual(worker_manager.launched_model_ids, ["model-a"])
+    self.assertEqual(store.forwarded_requests, [])
+    self.assertEqual(
+      store.futures["model-a"],
+      {"type": "RequestFailedResponse", "error_message": "boom"},
+    )
+
+  async def test_process_request_sets_future_failure_without_model_id(self) -> None:
+    store = StoreStub()
+    worker_manager = WorkerManagerStub()
+    processor = WorkerLaunchProcessor(store, worker_manager)
+    request = {"req_id": "model-a", "type": "create_model", "base_model": "base-model"}
+
+    with patch("worker_launch_processor.traceback.print_exc"):
+      await processor.process_request(request)
+
+    self.assertEqual(worker_manager.launched_model_ids, [])
+    self.assertEqual(store.forwarded_requests, [])
+    self.assertEqual(store.futures["model-a"]["type"], "RequestFailedResponse")
+
+  def test_create_model_from_state_launch_payload_defaults_restore_optimizer(self) -> None:
+    request = CreateModelFromStateWorkerLaunchRequest(
+      req_id="model-a",
+      model_id="model-a",
+      type="create_model_from_state",
+      state_path="/tmp/checkpoint",
+    )
+
+    self.assertEqual(request.model_dump()["restore_optimizer"], False)
+
+
+class WorkerLaunchQueueTest(unittest.IsolatedAsyncioTestCase):
+  async def test_in_memory_worker_launch_queue_is_unsupported(self) -> None:
+    store = InMemoryStore()
+
+    with self.assertRaisesRegex(RuntimeError, "REDIS_URL"):
+      await store.put_worker_launch_request({"model_id": "model-a"})
+
+
+class GatewayWorkerLaunchQueueTest(unittest.IsolatedAsyncioTestCase):
+  async def test_lifespan_full_mode_requires_redis(self) -> None:
+    with patch.dict("os.environ", {"OPEN_RL_ENABLE_FFT": "true"}, clear=True), self.assertRaisesRegex(RuntimeError, "REDIS_URL"):
+      async with gateway.lifespan(gateway.app):
+        pass
+
+  async def test_create_model_full_mode_uses_worker_launch_queue(self) -> None:
+    store = StoreStub()
+    store.worker_launch_requests = []
+
+    async def put_worker_launch_request(req_data: dict) -> None:
+      store.worker_launch_requests.append(req_data)
+
+    store.put_worker_launch_request = put_worker_launch_request
+    old_store = gateway.store
+    gateway.store = store
+
+    try:
+      with patch.dict("os.environ", {"OPEN_RL_ENABLE_FFT": "true"}):
+        result = await gateway.create_model({"base_model": "base-model"})
+    finally:
+      gateway.store = old_store
+
+    self.assertEqual(result["request_id"], store.worker_launch_requests[0]["model_id"])
+    self.assertEqual(store.worker_launch_requests[0]["type"], "create_model")
+    self.assertEqual(store.worker_launch_requests[0]["base_model"], "base-model")
+    self.assertEqual(store.forwarded_requests, [])
+
+
+class GatewayFutureTranslationTest(unittest.TestCase):
+  def test_create_model_result_translates_to_tinker_shape(self) -> None:
+    self.assertEqual(
+      gateway.translate_future_result(
+        {
+          "type": "create_model_result",
+          "model_id": "model-a",
+          "base_model": "base-model",
+          "lora_rank": 16,
+        }
+      ),
+      {
+        "type": "create_model",
+        "model_id": "model-a",
+        "base_model": "base-model",
+        "is_lora": True,
+        "lora_rank": 16,
+      },
+    )
+
+  def test_create_model_from_state_result_translates_to_tinker_shape(self) -> None:
+    self.assertEqual(
+      gateway.translate_future_result(
+        {
+          "type": "create_model_from_state_result",
+          "model_id": "model-a",
+          "base_model": "base-model",
+          "lora_rank": 16,
+        }
+      ),
+      {
+        "type": "create_model_from_state",
+        "model_id": "model-a",
+        "base_model": "base-model",
+        "is_lora": True,
+        "lora_rank": 16,
+      },
+    )
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
This PR builds on the worker split from the last PR and wires up the first usable full fine tuning mode. When OPEN_RL_WORKER_MODE=full is set, creating a model launches a dedicated FFT worker process for that job, and requests for that model are routed through Redis to that worker. LoRA keeps using the existing multi-tenant path. The worker launch logic lives in a small FFTWorkerLauncher class so the gateway owns the subprocess lifecycle in one place.

This also adds a GSM8K example so we have a concrete script for running and evaling FFT. Base line show ~1 to 5 percent accuracy and final shows ~34-35%

No snapshot integration yet.

Also while writing this I think we can start leveraging more features of FastAPI for typing the shape of the requests coming through. Seems like a good time to do it (not a high priority though)