### PR TITLE
feat: full finetuning sampler sub-system

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -28,6 +28,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Free Disk Space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -24,6 +24,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Free Disk Space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ env/
 **/venv/
 
 # Training Logs & Plots
+scratch/
 *.txt
 *.png
 *.log

--- a/Makefile
+++ b/Makefile
@@ -169,8 +169,8 @@ REMOTE_HOST ?= <PLACE_HOLDER_FOR_REMOTE_HOST_ADDRESS>
 
 # Push local workspace changes to the remote VM
 push-vm:
-	rsync -avz --exclude '.git' --exclude '.venv' --exclude '__pycache__' --exclude '*.pyc' --exclude '.DS_Store' ./ $(REMOTE_HOST):~/open-rl
+	rsync -avz --exclude '.git' --exclude '.venv' --exclude '__pycache__' --exclude '*.pyc' --exclude '.DS_Store' --exclude 'scratch' ./ $(REMOTE_HOST):~/open-rl
 
 # Pull changes from the remote VM back to the local workspace
 pull-vm:
-	rsync -avz --exclude '.git' --exclude '.venv' --exclude '__pycache__' --exclude '*.pyc' --exclude '.DS_Store' $(REMOTE_HOST):~/open-rl/ ./
+	rsync -avz --exclude '.git' --exclude '.venv' --exclude '__pycache__' --exclude '*.pyc' --exclude '.DS_Store' --exclude 'scratch' $(REMOTE_HOST):~/open-rl/ ./

--- a/examples/tiny/tiny_rl.py
+++ b/examples/tiny/tiny_rl.py
@@ -141,6 +141,7 @@ def main(config: Config) -> None:
   finally:
     import json
     import urllib.request
+
     try:
       model_id = trainer._guaranteed_model_id()
       url = f"{config.base_url}/api/v1/delete_model"

--- a/examples/tiny/tiny_rl.py
+++ b/examples/tiny/tiny_rl.py
@@ -95,47 +95,62 @@ def main(config: Config) -> None:
     # PEFT warning and vLLM cannot load lm_head adapter weights at all.
     train_unembed=False,
   )
-  tokenizer = trainer.get_tokenizer()
-  prompt_tokens = tokenizer.encode(config.prompt, add_special_tokens=False)
-  prompt = types.ModelInput.from_ints(tokens=prompt_tokens)
-  sampling_params = types.SamplingParams(max_tokens=config.max_tokens, temperature=config.temperature)
 
-  mean_reward = 0.0
-  for step in range(1, config.steps + 1):
-    sampler = trainer.save_weights_and_get_sampling_client()
-    sequences = sampler.sample(prompt=prompt, num_samples=config.samples_per_prompt, sampling_params=sampling_params).result().sequences
+  try:
+    tokenizer = trainer.get_tokenizer()
+    prompt_tokens = tokenizer.encode(config.prompt, add_special_tokens=False)
+    prompt = types.ModelInput.from_ints(tokens=prompt_tokens)
+    sampling_params = types.SamplingParams(max_tokens=config.max_tokens, temperature=config.temperature)
 
-    rewards = []
-    for sequence in sequences:
-      tokens, logprobs = list(sequence.tokens), list(sequence.logprobs or [])
-      if not tokens or len(tokens) != len(logprobs):
-        raise RuntimeError(f"Sampler must return aligned tokens and logprobs, got {len(tokens)} tokens and {len(logprobs)} logprobs")
-      rewards.append(1.0 if config.target in tokenizer.decode(tokens) else 0.0)
+    mean_reward = 0.0
+    for step in range(1, config.steps + 1):
+      sampler = trainer.save_weights_and_get_sampling_client()
+      sequences = sampler.sample(prompt=prompt, num_samples=config.samples_per_prompt, sampling_params=sampling_params).result().sequences
 
-    # Group-centered advantages; when every reward ties, fall back to a uniform
-    # positive advantage so the update still exercises a nonzero gradient.
-    mean_reward = statistics.fmean(rewards)
-    advantages = [reward - mean_reward for reward in rewards]
-    if all(abs(advantage) < 1e-8 for advantage in advantages):
-      advantages = [1.0] * len(rewards)
+      rewards = []
+      for sequence in sequences:
+        tokens, logprobs = list(sequence.tokens), list(sequence.logprobs or [])
+        if not tokens or len(tokens) != len(logprobs):
+          raise RuntimeError(f"Sampler must return aligned tokens and logprobs, got {len(tokens)} tokens and {len(logprobs)} logprobs")
+        rewards.append(1.0 if config.target in tokenizer.decode(tokens) else 0.0)
 
-    datums = [
-      build_datum(prompt_tokens, list(sequence.tokens), list(sequence.logprobs or []), advantage)
-      for sequence, advantage in zip(sequences, advantages)
-    ]
-    fwdbwd = trainer.forward_backward(datums, config.loss_fn).result()
-    trainer.optim_step(types.AdamParams(learning_rate=config.learning_rate, grad_clip_norm=config.grad_clip_norm)).result()
+      # Group-centered advantages; when every reward ties, fall back to a uniform
+      # positive advantage so the update still exercises a nonzero gradient.
+      mean_reward = statistics.fmean(rewards)
+      advantages = [reward - mean_reward for reward in rewards]
+      if all(abs(advantage) < 1e-8 for advantage in advantages):
+        advantages = [1.0] * len(rewards)
 
-    loss = float(fwdbwd.metrics.get("loss:mean", 0.0))
-    if not math.isfinite(loss):
-      raise RuntimeError(f"Loss must be finite, got {loss!r}")
-    write_metric(log_dir, {"phase": "train", "step": step, "loss": loss, "mean_reward": mean_reward, "num_datums": len(datums)})
-    print(f"[tiny-rl] step={step:02d}/{config.steps} loss={loss:.6f} mean_reward={mean_reward:.2f} datums={len(datums)}")
+      datums = [
+        build_datum(prompt_tokens, list(sequence.tokens), list(sequence.logprobs or []), advantage)
+        for sequence, advantage in zip(sequences, advantages)
+      ]
+      fwdbwd = trainer.forward_backward(datums, config.loss_fn).result()
+      trainer.optim_step(types.AdamParams(learning_rate=config.learning_rate, grad_clip_norm=config.grad_clip_norm)).result()
 
-  final_state_path = trainer.save_state("tiny-rl-final").result().path
-  write_metric(log_dir, {"phase": "final", "step": config.steps, "final_state_path": final_state_path, "mean_reward": mean_reward})
-  print(f"[tiny-rl] mean_reward={mean_reward:.2f}")
-  print(f"final_state_path={final_state_path}")
+      loss = float(fwdbwd.metrics.get("loss:mean", 0.0))
+      if not math.isfinite(loss):
+        raise RuntimeError(f"Loss must be finite, got {loss!r}")
+      write_metric(log_dir, {"phase": "train", "step": step, "loss": loss, "mean_reward": mean_reward, "num_datums": len(datums)})
+      print(f"[tiny-rl] step={step:02d}/{config.steps} loss={loss:.6f} mean_reward={mean_reward:.2f} datums={len(datums)}")
+
+    final_state_path = trainer.save_state("tiny-rl-final").result().path
+    write_metric(log_dir, {"phase": "final", "step": config.steps, "final_state_path": final_state_path, "mean_reward": mean_reward})
+    print(f"[tiny-rl] mean_reward={mean_reward:.2f}")
+    print(f"final_state_path={final_state_path}")
+  finally:
+    import json
+    import urllib.request
+    try:
+      model_id = trainer._guaranteed_model_id()
+      url = f"{config.base_url}/api/v1/delete_model"
+      data = json.dumps({"model_id": model_id}).encode("utf-8")
+      req = urllib.request.Request(url, data=data, headers={"Content-Type": "application/json"})
+      with urllib.request.urlopen(req) as response:
+        response.read()
+      print(f"[tiny-rl] successfully requested cleanup of workers for model {model_id}")
+    except Exception as exc:
+      print(f"[tiny-rl] warning: failed to request worker cleanup: {exc}")
 
 
 if __name__ == "__main__":

--- a/examples/tiny/tiny_rl.py
+++ b/examples/tiny/tiny_rl.py
@@ -142,6 +142,9 @@ def main(config: Config) -> None:
     import json
     import urllib.request
 
+    # The upstream Tinker SDK does not expose a delete_model() method. We make a
+    # direct HTTP POST call to Open-RL's custom /api/v1/delete_model gateway
+    # endpoint to signal background trainer and sampler worker processes to exit.
     try:
       model_id = trainer._guaranteed_model_id()
       url = f"{config.base_url}/api/v1/delete_model"

--- a/fft_sampler.md
+++ b/fft_sampler.md
@@ -1,0 +1,332 @@
+# Full Fine-Tuning (FFT) Dynamic Sampler & Weight Swapping
+
+This document describes the design, architecture, and implementation of the dynamic weight-reloading sampler loop for Full Fine-Tuning (FFT) Reinforcement Learning (RL) in the Open-RL framework.
+
+---
+
+## 1. Context & Key Challenge
+In Reinforcement Learning, the training loop alternates continuously between:
+1. **Sampling**: Generating completions (rollouts) using the current model weights.
+2. **Training**: Updating the model weights using the collected rollouts.
+
+For **LoRA**, vLLM natively supports dynamic adapter loading at runtime (via Multi-LoRA). 
+For **Full Fine-Tuning (FFT)**, the entire base model weights are modified. vLLM does not natively support changing the base model architecture/weights dynamically during active inference. 
+
+To run both PyTorch FSDP training and high-throughput vLLM inference on resource-constrained hardware (e.g. sharing a single GPU, or running on separate GPUs), we utilize **vLLM Sleep Mode** (Level 2 Sleep) and **Redis Queue-Based Pull Sampling** to perform fast, in-place base weights reloading without restarting the sampler engine.
+
+---
+
+## 2. Architecture: Queue-Based Pull Model
+
+Open-RL uses a **decoupled, queue-based pull architecture** to coordinate gateway requests, PyTorch training, and vLLM sampling. 
+
+### Sequence Diagram:
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Client as Tinker Client
+    participant GW as Gateway Server
+    participant Redis as Redis Queue & Futures
+    participant TS as Trainer Process (PyTorch)
+    participant VS as Sampler Process (vLLM)
+
+    Note over Client, VS: 1. Trainer Initialization
+    Client->>GW: create_model(model_id)
+    GW->>Redis: enqueues create_model request
+    Note over GW: Worker Launch Processor drains launch queue
+    GW->>TS: Dynamically Spawns training request processor (--model-id)
+
+    Note over Client, VS: 2. Sampler On-Demand Initialization
+    Client->>GW: create_sampling_session() / save_weights_for_sampler()
+    GW->>Redis: enqueues launch_sampler request
+    Note over GW: Worker Launch Processor drains launch queue
+    GW->>VS: Dynamically Spawns vLLM sampler worker (--model-id)
+    VS->>VS: Initializes vLLM Engine (Sleep Mode enabled)
+    VS->>Redis: Set open_rl:sampler_ready:{model_id} = 1
+
+    Note over Client, VS: 3. Iterative RL Training / Rollout Loop
+    Note over GW: Blocks until open_rl:sampler_ready key is 1
+    GW-->>Client: Returns session ID / completes request
+
+    Client->>GW: sample_async(prompt, model_id)
+    GW->>Redis: Pushes request (prompt, weights_path) to sampler_queue:<model_id>
+    
+    Note over VS: Sampler pops request from Redis
+    alt weights_path != current_loaded_weights
+        VS->>VS: await engine.sleep(level=2) (frees VRAM)
+        VS->>VS: await engine.wake_up(tags=["weights"])
+        VS->>VS: await engine.collective_rpc("reload_weights", weights_path)
+        VS->>VS: await engine.wake_up(tags=["kv_cache"])
+    end
+    VS->>VS: await engine.generate(prompts)
+    VS->>Redis: Resolves future with completions
+    GW-->>Client: Returns completions
+```
+
+---
+
+## 3. Key Components
+
+### 1. Redis Request Store (`src/server/store.py`)
+Provides list-based queueing for sampling requests to decouple the API gateway from sampler processes:
+- `put_sampling_request(req_data)`: Pushes a serialization of sampling prompts, constraints, and target `weights_path` onto `open_rl:sampler_queue:<model_id>`.
+- `get_sampling_requests_for_model(model_id)`: Drains the queue in batches and passes them to the sampler worker.
+
+### 2. API Gateway (`src/server/gateway.py`)
+- `/api/v1/create_sampling_session`: Resolves the active model ID and blocks requests until the dynamically spawned sampler worker registers itself as ready in Redis.
+- `/api/v1/asample`: Resolves Tinker sequence/session IDs (e.g. `tinker://model-id/sampler_weights/sampler-seq`) to absolute local directories under `/tmp/open-rl/sampler_full/`. It packages the target directory as `weights_path` and enqueues the request to Redis.
+
+### 3. Worker Launcher & Compatibility (`src/server/worker_launch_processor.py` & `scripts/run_training_e2e.py`)
+- **FFT Mode**: Trainer and sampler processes are launched dynamically on demand:
+  - Spawns Trainer: `python -m server.training_requests_processor --model-id <model_id>` (triggered during `create_model`).
+  - Spawns Sampler: `python -m server.vllm_sampler --model-id <model_id>` (triggered during `create_sampling_session` / `save_weights_for_sampler`, overriding `CUDA_VISIBLE_DEVICES` using `SAMPLER_CUDA_VISIBLE_DEVICES`).
+- **LoRA Mode**: The sampler worker is launched statically on startup with `--model-id <base_model_name>` and drains the corresponding queue directly.
+- **Readiness Checks**: The launcher uses a raw socket Redis client wrapper (`redis_key_ready`) to verify when a statically launched sampler has completed startup/compilation.
+
+### 4. Dynamic Sampler Worker (`src/server/vllm_sampler.py`)
+Runs a headless pull-mode loop:
+- Initializes the AsyncLLMEngine.
+- Blocks until requests are pushed to `open_rl:sampler_queue:<model_id>`.
+- Drains the queue in batches and executes them concurrently using `asyncio.gather(*tasks)`. This allows vLLM to internally batch concurrent rollout requests for maximum hardware utilization.
+- Uses a local `reload_lock = asyncio.Lock()` to handle weights reloading safely:
+  - If multiple concurrent requests are popped, they check if `weights_path` matches the loaded model.
+  - The first task to acquire the lock will perform the sleep-wake-reload loop if a weights change is detected:
+    1. Calls `engine.sleep(level=2)` to discard active weights and KV caches, releasing ~85% of GPU memory.
+    2. Calls `engine.wake_up(tags=["weights"])` to allocate memory for the new checkpoint.
+    3. Calls `engine.collective_rpc("reload_weights")` to load safetensors in-place.
+    4. Calls `engine.wake_up(tags=["kv_cache"])` to initialize a clean KV cache pool.
+  - Subsequent concurrent tasks with matching paths bypass reloading immediately once the lock is released.
+- Feeds token ids into `engine.generate()` and pushes completions to the future's Redis channel.
+
+---
+
+## 4. Key Performance Characteristics
+
+Measurements captured during end-to-end training runs using `Qwen2.5-0.5B` on NVIDIA L4 GPUs:
+- **Sleep Memory Release**: Freeing `27+ GiB` of VRAM is nearly instantaneous.
+- **Weights Allocation**: `~0.05 seconds`.
+- **In-place weights reload (disk to VRAM)**: `~0.80 seconds` for a `0.92 GiB` model checkpoint.
+- **KV Cache Allocation**: `~0.67 seconds`.
+- **Total Weights Swap Latency**: **`~1.5 seconds`** in the active RL training loop.
+
+---
+
+## 5. Sharing vs. Dedicated Sampler Workers: Inter-Job Turn Taking
+
+When running multiple concurrent RL jobs ($N > 2$) sharing node resources, both training and sampling processes must coordinate their access to their respective GPUs to avoid VRAM conflicts. 
+
+### Symmetric Turn-Taking Architecture
+To support concurrent jobs, the Open-RL system boots two separate, isolated Snapshot Agent daemons:
+1. **`snapshot-agent-trainer`** (socket: `snapshot-agent-trainer.sock`): Manages and time-slices GPU 0 (the training GPU).
+2. **`snapshot-agent-sampler`** (socket: `snapshot-agent-sampler.sock`): Manages and time-slices GPU 1 (the sampling GPU).
+
+```mermaid
+graph LR
+    subgraph GPU 0: Trainer GPU
+        TrainerA[Job A Trainer Process] <-->|acquire/release| SAT[snapshot-agent-trainer]
+        TrainerB[Job B Trainer Process] <-->|acquire/release| SAT
+    end
+    subgraph GPU 1: Sampler GPU
+        EngineCoreA[Job A EngineCore Process] <-->|acquire/release| SAS[snapshot-agent-sampler]
+        EngineCoreB[Job B EngineCore Process] <-->|acquire/release| SAS
+    end
+```
+
+#### Rationale for Separate Snapshot Agent Instances
+Running two separate snapshot agent daemons (trainer and sampler) provides two vital benefits:
+1. **Independent Preemption Locking (GPU Concurrency)**: The snapshot agent operates on a single global preemption lock. If we shared a single agent instance, acquiring the lock to train on GPU 0 would block sampler processes from running on GPU 1. Isolating the daemons ensures training and sampling locks do not interfere, enabling parallel training-rollout overlaps between Job A and Job B.
+2. **CUDA Device Context Isolation**: Trainer processes run with `CUDA_VISIBLE_DEVICES=0` while samplers run with `CUDA_VISIBLE_DEVICES=1`. Inside their respective processes, both refer to their active GPU as index `0`. Separate daemons cleanly align lock requests with the target physical GPUs without device collisions.
+
+### Option A: Single Shared vLLM Instance
+A single `vllm-worker` process runs on the GPU. It pulls requests sequentially from Redis and checks `weights_path`. If Job A and Job B both submit requests, it swaps weights back and forth:
+- **Pros**:
+  - **Memory (RAM) Efficiency**: The model weights are loaded into CPU memory only once. Excellent for large models (13B+) where running multiple instances would exhaust host RAM.
+- **Cons**:
+  - **I/O Latency**: Every swap requires reading safetensors from the network filesystem and compiling. Swapping takes **`~1.5 seconds`** on every step.
+
+### Option B: Dedicated vLLM Instance Per Job (IMPLEMENTED)
+Each job launches its own dedicated `vllm_sampler` process (each listening to its own `sampler_queue:<model_id>`). Both processes share GPU 1. To share the GPU transparently, they take turns using `snapshot-agent-sampler`:
+- **Parent Proxying**: The parent `vllm_sampler` process runs on CPU and resolves the PID of its child `EngineCore` process (which holds all CUDA contexts).
+- **Coordinated Engine Initialization (Lock Transfer)**:
+  - During engine startup (`from_engine_args`), vLLM allocates the KV cache and warms up CUDA graphs (which requires exclusive GPU access and allocates up to 70% VRAM).
+  - To prevent concurrent workers from initializing at the same time and causing OOMs on startup, the workers serialize their warmups using a coordinated lock transfer:
+    1. The parent `vllm_sampler` process registers its parent PID with the Snapshot Agent and acquires the GPU lock.
+    2. Under the parent lock, it calls `init_engine()` safely.
+    3. Once initialized, it resolves the child `EngineCore` process PID and registers it.
+    4. To prevent other waiting processes from stealing the GPU lock before the newly spawned child can be checkpointed, the worker calls `TRANSFER_LOCK` to transfer ownership of the active GPU lock from the parent PID to the child PID.
+    5. The parent process safely releases its acquire context (treated as a successful no-op on the daemon since the lock was transferred).
+    6. Finally, the worker calls `RELEASE` on the child PID, which checkpoints the child (freeing its GPU VRAM from 70% to ~0 MiB) and releases the GPU lock to the next waiting worker.
+- **GPU Checkpoint/Restore (with VRAM Pre-release)**:
+  - When Job A needs to generate rollouts, its parent sampler process calls `acquire(EngineCoreA_PID)` via `snapshot-agent-sampler.sock`. This checkpoints Job B's `EngineCore` process and restores Job A's `EngineCore` process.
+  - **Optimization**: Once the batch of sampling requests completes, but **before** releasing the GPU lock, the sampler calls `await engine.sleep(level=2)`. This releases Job A's active weights and KV caches from the GPU (reducing its VRAM usage to ~0 MiB).
+  - Consequently, when the Snapshot Agent executes `cuda-checkpoint` on the process, there is almost no memory to copy, dropping checkpoint latency from **`~14 seconds`** to **`~0.5 seconds`** (a 28x speedup).
+- **Pros**:
+  - **Fast Wake Up & Checkpoint**: Checkpointing is near-instantaneous (~0.5s). Waking up the engine on restore only requires copying weights from CPU RAM back to GPU VRAM, taking only **`~0.7 seconds`** (no disk I/O).
+- **Cons**:
+  - **RAM Overhead**: Each inactive instance holds a full copy of the model weights in CPU RAM. High risk of system OOMs on large models.
+
+### Recommendation Grid:
+- **Small/Medium Models (up to ~8B)**: Use **Option B (Dedicated Instances)** to gain a 2x latency benefit during step switches.
+- **Large Models (13B+)**: Use **Option A (Shared Instance)** to maintain host memory stability.
+- **Heterogeneous Architectures (e.g. Qwen + Gemma)**: **Must** use **Option B** (separate processes), as a single instance cannot reload between different configuration shapes.
+
+---
+
+## 6. Out-of-Order / Parallel Sampling of Different Weight Versions
+
+If a client (or multiple clients sharing an instance) submits concurrent sampling requests for **different** weights versions (e.g. Request A for `sampler-1` and Request B for `sampler-2` simultaneously):
+
+1. **Serialized Swapping (Thrashing)**: If they are processed sequentially, the worker will successfully process both but will thrash back and forth, triggering a full `sleep -> wake -> reload -> wake` cycle on every step transition, which adds `~1.5 seconds` of latency overhead per swap.
+2. **Cancellation on Active Generations**: If Request B (triggering a reload to `sampler-2`) starts executing *concurrently* (via `asyncio.gather`) while Request A (using `sampler-1`) is still generating tokens inside vLLM:
+   - Request B will acquire the reload lock and call `engine.sleep(level=2)`.
+   - vLLM's `sleep` call immediately cancels all active generations and frees memory.
+   - Request A's running generation will be interrupted and fail with a `RequestFailedResponse` (e.g., EngineDeadError or cancellation exception).
+   - Request B's generation will succeed.
+   
+*Note: In normal GRPO/PPO RL training, the training loop is strictly synchronous (all rollouts for the current policy weights are collected and completed before the trainer updates weights for the next step). Therefore, parallel execution of different weight versions does not occur within a single job context. For multi-job contexts, **Option B (Dedicated Instances)** should be used to isolate environments.*
+
+---
+
+## 7. Configuration & Environment Variables
+
+To configure and run disaggregated GPU training/sampling:
+
+| Environment Variable | Description |
+| :--- | :--- |
+| `OPEN_RL_ENABLE_FFT=true` | Configures the framework, gateway, and vLLM sampler to run in Full Fine-Tuning mode. |
+| `SAMPLING_BACKEND=vllm` | Sets the sampling engine to vLLM (defaults to PyTorch/Torch if unset). |
+| `CUDA_VISIBLE_DEVICES=0` | Sets the GPU visibility for the PyTorch trainer (bound to the gateway process). |
+| `SAMPLER_CUDA_VISIBLE_DEVICES=1` | Sets the GPU visibility for the dynamic vLLM sampler subprocess. |
+| `VLLM_GPU_MEMORY_UTILIZATION=0.70` | Allocates VRAM bounds for the sampler engine. |
+
+### Running the End-to-End Suite:
+To run a single FFT RL job in vLLM mode:
+```bash
+make test e2e tiny-fft-rl TRAINING_TEST_ARGS="sampling_backend=vllm trainer_gpu=0 sampler_gpu=1 steps=10"
+```
+To run two concurrent FFT RL jobs sharing both trainer and sampler GPUs via Snapshot Agent preemption:
+```bash
+make test e2e tiny-fft-rl-x2 TRAINING_TEST_ARGS="sampling_backend=vllm trainer_gpu=0 sampler_gpu=1 steps=5"
+```
+
+---
+
+## 8. Session-ID and Weight Versioning
+
+In Open-RL, the `sampling_session_id` acts as a versioned weight reference that pins sampling requests to a specific iteration of the policy weights.
+
+### How it Works:
+1. **Weight Generation & Versioning**:
+   - The trainer calls `trainer.save_weights_for_sampler(name=alias)`.
+   - The request runs through the queue to ensure prior training steps are complete.
+   - The trainer writes the model weights to a versioned folder and registers a tinker URI: `tinker://<model_id>/sampler_weights/<alias>` (where `<alias>` contains a sequence number or timestamp).
+2. **Session Creation**:
+   - The client calls `create_sampling_client(weights_path)` passing the versioned `tinker://` URI.
+   - The gateway's `/api/v1/create_sampling_session` validates the model path, blocks until the model's dynamic sampler worker registers as ready in Redis, and returns the URI as the `sampling_session_id`.
+3. **Session Pinning during Sampling**:
+   - When the client requests generation, it calls `sample_async(prompt)` on the returned client, which sends a request to `/api/v1/asample` with the pinned `sampling_session_id`.
+   - The gateway extracts the relative path portion of the `tinker://` URI and resolves it to the absolute local directory: `/tmp/open-rl/sampler_full/<model_id>/sampler_weights/<alias>`.
+   - It packages this absolute path into the `weights_path` field of the sampling request payload and enqueues it to `open_rl:sampler_queue:<model_id>`.
+   - The sampler worker pops the request, compares the target `weights_path` to its currently loaded weights directory, and triggers a sleep-reload cycle if a change is detected. This ensures that the generated tokens are always sampled from the exact version of the policy weights corresponding to that session.
+
+---
+
+## 9. Control Plane & Data Plane Decoupling (Lifecycle Management)
+
+The framework segregates operations into **Control Plane** (infrastructure, worker lifecycles, configuration) and **Data Plane** (training metrics, token sampling) to enable asynchronous execution, fail-safe scaling, and zero-drop request drainage.
+
+```
+[Control Plane Operations]
+Gateway Control Queue (open_rl:worker_launch_queue) ---> WorkerLaunchProcessor (launches/gracefully stops PIDs)
+
+[Data Plane Operations]
+Gateway Data Queues (queue:<model_id>, sampler_queue:<model_id>) ---> Workers (runs steps/computes tokens)
+```
+
+### 1. Queue Division & Protocols
+
+| Plane | Operation | Protocol / Redis Key | Consumer |
+| :--- | :--- | :--- | :--- |
+| **Control Plane** | `create_model` (Launch trainer) | `open_rl:worker_launch_queue` (Central) | `WorkerLaunchProcessor` |
+| **Control Plane** | `launch_sampler` (Launch sampler) | `open_rl:worker_launch_queue` (Central) | `WorkerLaunchProcessor` |
+| **Control Plane** | `delete_model` (Stop workers) | `open_rl:worker_launch_queue` (Central) | `WorkerLaunchProcessor` |
+| **Control Plane** | `create_sampling_session` | Registry Metadata Key (Redis) | Gateway |
+| **Data Plane** | `forward_backward`, `optim_step` | `open_rl:queue:<model_id>` (Isolated) | PyTorch Trainer |
+| **Data Plane** | `save_weights_for_sampler`, `save_state` | `open_rl:queue:<model_id>` (Isolated) | PyTorch Trainer |
+| **Data Plane** | `sample`, `asample` | `open_rl:sampler_queue:<model_id>` (Isolated) | vLLM Sampler |
+
+---
+
+### 2. Provisioning & Activation (Control Plane)
+- **Trainer Provisioning**: When a client initializes a model via `/api/v1/create_model`, the gateway enqueues a `create_model` command to `open_rl:worker_launch_queue`. The `WorkerLaunchProcessor` daemon pops the request and invokes `FFTWorkerManager.launch_trainer(model_id)` to spawn the dedicated PyTorch trainer subprocess.
+- **Sampler Provisioning**: When a client initializes a sampling session via `/api/v1/create_sampling_session` (or saves weights for sampling via `/api/v1/save_weights_for_sampler`), the gateway enqueues a `launch_sampler` command to `open_rl:worker_launch_queue`. The processor pops it and invokes `FFTWorkerManager.launch_sampler(model_id)` to spawn the dedicated vLLM sampler worker (if not already running).
+- **Readiness**: The sampler worker compiles CUDA graphs and writes `open_rl:sampler_ready:<model_id> = "1"`. The gateway blocks and polls this key, returning the versioned `session_id` to the client only when ready.
+
+---
+
+### 3. Graceful Queue-Based Teardown (Implemented)
+To prevent dropping in-flight sampling or optimization steps, de-provisioning is fully queue-decoupled using the **Sentinel Pattern**:
+
+1. **Teardown Trigger**: When a client completes training, it sends a `POST` request to the Gateway's `/api/v1/delete_model` endpoint.
+2. **Sentinel Enqueueing**: Instead of hard-killing processes, the Gateway writes a `shutdown_workers` control command to `open_rl:worker_launch_queue`.
+3. **Control-to-Data Signaling**: The `WorkerLaunchProcessor` pops the command and enqueues a **Shutdown Sentinel (Poison Pill)** (`{"request_id": "SHUTDOWN_SENTINEL"}`) to the tails of both the trainer (`open_rl:queue:<model_id>`) and sampler (`open_rl:sampler_queue:<model_id>`) FIFO data queues.
+4. **FIFO Request Drainage**:
+   - The workers continue to pop and process all pending requests in their queues.
+   - When a worker pops the sentinel, it halts polling, awaits any active asyncio tasks (token generation or backward steps), unregisters its PID from the Snapshot Agent, and exits gracefully.
+5. **Background Process Reaping**:
+   - `FFTWorkerManager` runs a non-blocking background task to monitor the spawned PIDs.
+   - If they exit cleanly, it clears them from the registry. If they fail to exit within a grace period (e.g. 30 seconds), it falls back to a hard `terminate()` to reclaim resources.
+6. **Snapshot Resiliency**:
+   - The Snapshot Agent (`serve.py`) checks PID liveness before/during preemption tasks. Dead or zombie processes are skipped gracefully, and socket closure automatically cleans up daemon state.
+
+---
+
+### 4. Proposed De-provisioning (Idle Timeout)
+To clean up stale workers in the event of hard client VM crashes or unhandled script kills:
+
+- **Server-Side Idle Timeout**:
+  - The `WorkerLaunchProcessor` daemon monitors active tenant activity.
+  - If a tenant's data queue has been idle (no requests popped/enqueued) for a configurable timeout (e.g. 10 minutes), the processor automatically triggers the sentinel shutdown flow for that `model_id`.
+  - If the client subsequently resumes training, the processor detects the missing workers and dynamically re-provisions them transparently.
+  - This ensures maximum robustness against crash-induced leaks without requiring client-side handlers.
+
+---
+
+## 10. Snapshot Agent Integration & Lock Management
+
+To coordinate GPU sharing, workers communicate with local Snapshot Agent instances via UNIX domain sockets:
+- `snapshot-agent-trainer.sock` (manages GPU 0 for trainers)
+- `snapshot-agent-sampler.sock` (manages GPU 1 for samplers)
+
+### 1. Lock Management & API Command Set
+The Snapshot Agent daemon supports the following JSON-based socket interface commands:
+- `REGISTER`: Registers a process PID to participate in scheduling.
+- `UNREGISTER`: Removes a process PID and cleans up its lock allocations.
+- `ACQUIRE`: Requests the global preemption lock for a PID. Blocks until the lock is acquired, and automatically suspends the active running process.
+- `RELEASE`: Signals that a process is yielding its GPU lock, triggering an immediate checkpoint snapshot.
+- `TRANSFER_LOCK`: Moves the ownership of an active lock from one PID to another atomically.
+
+---
+
+### 2. Architectural Requirement for the `TRANSFER_LOCK` Primitive
+
+During full fine-tuning rollouts, the vLLM sampler worker must serialize its engine startup to prevent CUDA Out of Memory (OOM) errors during CUDA graph warmups (which consume up to 70% VRAM). This is achieved through the coordinated parent-to-child lock transfer sequence:
+
+1. **Process Tree & CUDA Context Separation**:
+   - vLLM splits the sampler into a Python **parent process** (managing queues/IPC) and a dynamically spawned **child process** (`EngineCore` / `ModelExecutor`).
+   - The actual CUDA driver context and VRAM footprint reside entirely inside the child process.
+   - The utility `cuda-checkpoint` operates strictly on a **single target PID** (using direct POSIX real-time signals) and is not aware of the process tree. Thus, checkpointing/restoring must target the child process directly to reclaim/restore VRAM.
+
+2. **The Startup OOM Race Condition**:
+   - Because the child process PID is dynamically allocated during engine creation, the worker cannot know its PID beforehand.
+   - To serialize the initialization phase and prevent multiple samplers from compiling graphs simultaneously (which causes a CUDA OOM), the parent process must proxy the lock:
+     - The **parent** acquires the Snapshot Agent lock.
+     - The parent initializes the vLLM engine, which spawns the child process.
+     - The parent registers the child PID with the Snapshot Agent.
+
+3. **Why We Must "Transfer" Instead of "Release"**:
+   - If the parent released its lock using standard context managers immediately after initialization, a waiting concurrent worker would instantly acquire the lock and begin its graph warmups.
+   - At this moment, the first worker's child process is still running in memory because the Snapshot Agent has not yet checkpointed it (checkpointing is triggered asynchronously on release or preemption).
+   - This leads to two active engines compiling graphs at the same time, causing a CUDA OOM.
+   - **The Solution**: The parent calls **`TRANSFER_LOCK`** to transfer ownership of the active lock to the child process PID *before* exiting its code block. This keeps the GPU lock continuously active, blocking other workers until the child process is explicitly checkpointed (`RELEASE` command) to release its VRAM down to 0 MiB.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,3 +107,12 @@ torchvision = [
 vllm = [
     { index = "vllm-cu129", extra = "vllm", marker = "sys_platform == 'linux'" },
 ]
+
+[tool.ruff]
+exclude = [
+    ".git",
+    ".venv",
+    "__pycache__",
+    "scratch",
+    "scratch/**",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,7 @@ vllm = [
 ]
 
 [tool.ruff]
+force-exclude = true
 exclude = [
     ".git",
     ".venv",

--- a/scripts/run_training_e2e.py
+++ b/scripts/run_training_e2e.py
@@ -116,17 +116,6 @@ def redis_ok(host: str, port: int) -> bool:
     return client.recv(64).startswith(b"+PONG")
 
 
-def redis_key_ready(host: str, port: int, key: str) -> bool:
-  try:
-    with socket.create_connection((host, port), timeout=1) as client:
-      cmd = f"*2\r\n$3\r\nGET\r\n${len(key)}\r\n{key}\r\n"
-      client.sendall(cmd.encode("utf-8"))
-      res = client.recv(1024)
-      return b"$1\r\n1\r\n" in res
-  except Exception:
-    return False
-
-
 def print_log_tail(path: Path, lines: int = 100) -> None:
   if not path.exists():
     return
@@ -277,12 +266,6 @@ def start_backend(config: RunConfig, processes: list[ManagedProcess]) -> str:
       vllm_env = env.copy()
       vllm_env["CUDA_VISIBLE_DEVICES"] = config.sampler_gpu
       vllm_env["VLLM_GPU_MEMORY_UTILIZATION"] = str(config.vllm_gpu_memory_utilization)
-      redis_url = env.get("REDIS_URL")
-      if redis_url:
-        parts = redis_url.split(":")
-        r_port = int(parts[-1].split("/")[0])
-      else:
-        r_port = 6379
       base_model = config.base_model
       launch(
         processes,
@@ -290,7 +273,7 @@ def start_backend(config: RunConfig, processes: list[ManagedProcess]) -> str:
         uv_run(config.eval_uv_extra) + ["python", "-m", "server.vllm_sampler", "--model-id", base_model],
         vllm_env,
         log_dir / "vllm_worker.log",
-        lambda: redis_key_ready("127.0.0.1", r_port, f"open_rl:sampler_ready:{base_model}"),
+        lambda: True,
         timeout=config.startup_timeout,
       )
 

--- a/scripts/run_training_e2e.py
+++ b/scripts/run_training_e2e.py
@@ -451,7 +451,7 @@ def check_snapshot_interleaving(config: RunConfig) -> None:
     print(f"[training-e2e] trainer snapshot agent time-sliced: checkpointed pids {sorted(cp_t)}, restored pids {sorted(rs_t)}")
 
   sampler_log = Path(config.log_dir) / "snapshot-agent-sampler.log"
-  if sampler_log.exists():
+  if config.sampling_backend == "vllm" and sampler_log.exists():
     text_s = sampler_log.read_text(encoding="utf-8", errors="replace")
     cp_s = set(re.findall(r"checkpointed pid (\d+)", text_s))
     rs_s = set(re.findall(r"restored pid (\d+)", text_s))

--- a/scripts/run_training_e2e.py
+++ b/scripts/run_training_e2e.py
@@ -227,31 +227,18 @@ def start_backend(config: RunConfig, processes: list[ManagedProcess]) -> str:
         "cuda-checkpoint is required for FFT e2e scenarios (the snapshot agent checkpoints workers around every batch); "
         "install the binary matching your driver from https://github.com/NVIDIA/cuda-checkpoint"
       )
-    trainer_snapshot_socket = log_dir / "snapshot-agent-trainer.sock"
-    trainer_snapshot_socket.unlink(missing_ok=True)
+    snapshot_socket = log_dir / "snapshot-agent.sock"
+    snapshot_socket.unlink(missing_ok=True)
     launch(
       processes,
-      "snapshot-agent-trainer",
+      "snapshot-agent",
       uv_run(config.uv_extra) + ["python", "-m", "snapshot_agent.serve"],
-      {**base_env(config), "OPEN_RL_SNAPSHOT_AGENT_SOCKET": str(trainer_snapshot_socket)},
-      log_dir / "snapshot-agent-trainer.log",
-      trainer_snapshot_socket.is_socket,
+      {**base_env(config), "OPEN_RL_SNAPSHOT_AGENT_SOCKET": str(snapshot_socket)},
+      log_dir / "snapshot-agent.log",
+      snapshot_socket.is_socket,
       timeout=60,
     )
-    env["OPEN_RL_SNAPSHOT_AGENT_SOCKET"] = str(trainer_snapshot_socket)
-
-    sampler_snapshot_socket = log_dir / "snapshot-agent-sampler.sock"
-    sampler_snapshot_socket.unlink(missing_ok=True)
-    launch(
-      processes,
-      "snapshot-agent-sampler",
-      uv_run(config.uv_extra) + ["python", "-m", "snapshot_agent.serve"],
-      {**base_env(config), "OPEN_RL_SNAPSHOT_AGENT_SOCKET": str(sampler_snapshot_socket)},
-      log_dir / "snapshot-agent-sampler.log",
-      sampler_snapshot_socket.is_socket,
-      timeout=60,
-    )
-    env["OPEN_RL_SAMPLER_SNAPSHOT_AGENT_SOCKET"] = str(sampler_snapshot_socket)
+    env["OPEN_RL_SNAPSHOT_AGENT_SOCKET"] = str(snapshot_socket)
     env["REDIS_URL"] = f"redis://127.0.0.1:{redis_port}/0"
     env["OPEN_RL_ENABLE_FFT"] = "true"
   else:
@@ -439,25 +426,25 @@ def check_snapshot_interleaving(config: RunConfig) -> None:
     print("[training-e2e] external backend; skipping snapshot agent interleave check")
     return
 
-  trainer_log = Path(config.log_dir) / "snapshot-agent-trainer.log"
-  if trainer_log.exists():
-    text_t = trainer_log.read_text(encoding="utf-8", errors="replace")
-    cp_t = set(re.findall(r"checkpointed pid (\d+)", text_t))
-    rs_t = set(re.findall(r"restored pid (\d+)", text_t))
-    if len(cp_t) < 2 or len(rs_t) < 2:
-      raise RuntimeError(
-        f"Expected both FFT trainer workers to interleave, but saw checkpoints {sorted(cp_t)} and restores {sorted(rs_t)} in {trainer_log}"
-      )
-    print(f"[training-e2e] trainer snapshot agent time-sliced: checkpointed pids {sorted(cp_t)}, restored pids {sorted(rs_t)}")
+  log_path = Path(config.log_dir) / "snapshot-agent.log"
+  if not log_path.exists():
+    return
+  text = log_path.read_text(encoding="utf-8", errors="replace")
 
-  sampler_log = Path(config.log_dir) / "snapshot-agent-sampler.log"
-  if config.sampling_backend == "vllm" and sampler_log.exists():
-    text_s = sampler_log.read_text(encoding="utf-8", errors="replace")
-    cp_s = set(re.findall(r"checkpointed pid (\d+)", text_s))
-    rs_s = set(re.findall(r"restored pid (\d+)", text_s))
+  cp_t = set(re.findall(r"checkpointed pid (\d+) \(group trainers\)", text))
+  rs_t = set(re.findall(r"restored pid (\d+) \(group trainers\)", text))
+  if len(cp_t) < 2 or len(rs_t) < 2:
+    raise RuntimeError(
+      f"Expected both FFT trainer workers to interleave, but saw checkpoints {sorted(cp_t)} and restores {sorted(rs_t)} in {log_path}"
+    )
+  print(f"[training-e2e] trainer snapshot agent time-sliced: checkpointed pids {sorted(cp_t)}, restored pids {sorted(rs_t)}")
+
+  if config.sampling_backend == "vllm":
+    cp_s = set(re.findall(r"checkpointed pid (\d+) \(group samplers\)", text))
+    rs_s = set(re.findall(r"restored pid (\d+) \(group samplers\)", text))
     if len(cp_s) < 2 or len(rs_s) < 2:
       raise RuntimeError(
-        f"Expected both FFT sampler workers to interleave, but saw checkpoints {sorted(cp_s)} and restores {sorted(rs_s)} in {sampler_log}"
+        f"Expected both FFT sampler workers to interleave, but saw checkpoints {sorted(cp_s)} and restores {sorted(rs_s)} in {log_path}"
       )
     print(f"[training-e2e] sampler snapshot agent time-sliced: checkpointed pids {sorted(cp_s)}, restored pids {sorted(rs_s)}")
 

--- a/scripts/run_training_e2e.py
+++ b/scripts/run_training_e2e.py
@@ -36,6 +36,7 @@ import shlex
 import shutil
 import signal
 import socket
+import struct
 import subprocess
 import threading
 import time
@@ -53,7 +54,10 @@ GSM8K_ANSWER_RE = re.compile(r"-?\d[\d,]*")
 
 @chz.chz
 class RunConfig:
-  scenario: Literal["tiny-lora", "tiny-fft", "tiny-rl", "lora-textsql", "fft-gsm8k", "fft-gsm8k-x2"]
+  scenario: Literal["tiny-lora", "tiny-fft", "tiny-rl", "tiny-fft-rl", "tiny-fft-rl-x2", "lora-textsql", "fft-gsm8k", "fft-gsm8k-x2"]
+  sampling_backend: str = "torch"
+  trainer_gpu: str = "0"
+  sampler_gpu: str = "1"
   base_url: str = ""
   base_model: str = "Qwen/Qwen2.5-0.5B"
   steps: int | None = None
@@ -71,9 +75,6 @@ class RunConfig:
   startup_timeout: float = 300.0
   train_token_budget: int = 65_536
   vllm_gpu_memory_utilization: float = 0.70
-  # Where OPEN_RL_TMP_DIR lives on the cluster's shared PVC; used to print the
-  # scripts/run_cluster_eval.py command when the checkpoint is not visible locally.
-  cluster_tmp_dir: str = "/mnt/shared/open-rl"
 
 
 @dataclass
@@ -85,6 +86,7 @@ class ManagedProcess:
 
 def unused_tcp_port() -> int:
   with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, struct.pack('ii', 1, 0))
     sock.bind(("127.0.0.1", 0))
     return int(sock.getsockname()[1])
 
@@ -114,6 +116,17 @@ def redis_ok(host: str, port: int) -> bool:
     return client.recv(64).startswith(b"+PONG")
 
 
+def redis_key_ready(host: str, port: int, key: str) -> bool:
+  try:
+    with socket.create_connection((host, port), timeout=1) as client:
+      cmd = f"*2\r\n$3\r\nGET\r\n${len(key)}\r\n{key}\r\n"
+      client.sendall(cmd.encode("utf-8"))
+      res = client.recv(1024)
+      return b"$1\r\n1\r\n" in res
+  except Exception:
+    return False
+
+
 def print_log_tail(path: Path, lines: int = 100) -> None:
   if not path.exists():
     return
@@ -133,21 +146,30 @@ def launch(
   timeout: float,
 ) -> None:
   print(f"[training-e2e] starting {name}: {' '.join(command)}")
-  with log_path.open("w", encoding="utf-8") as log_file:
-    process = subprocess.Popen(
-      command,
-      cwd=REPO_ROOT,
-      env=env,
-      stdout=log_file,
-      stderr=subprocess.STDOUT,
-      text=True,
-      start_new_session=True,
-    )
+  process = subprocess.Popen(
+    command,
+    cwd=REPO_ROOT,
+    env=env,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.STDOUT,
+    text=True,
+    start_new_session=True,
+  )
+
+  def stream_log():
+    with log_path.open("w", encoding="utf-8") as log_file:
+      for line in iter(process.stdout.readline, ""):
+        log_file.write(line)
+        log_file.flush()
+        print(f"[{name}] {line.rstrip()}")
+
+  t = threading.Thread(target=stream_log, daemon=True)
+  t.start()
+
   processes.append(ManagedProcess(name=name, process=process, log_path=log_path))
   try:
     wait_until(name, ready, timeout)
   except Exception:
-    print_log_tail(log_path)
     raise
 
 
@@ -181,7 +203,7 @@ def base_env(config: RunConfig) -> dict[str, str]:
     "OPEN_RL_TMP_DIR": str(open_rl_tmp_dir(config)),
     "OPEN_RL_TRAIN_TOKEN_BUDGET": str(config.train_token_budget),
     "PYTHONUNBUFFERED": "1",
-    "SAMPLING_BACKEND": "torch",
+    "SAMPLING_BACKEND": config.sampling_backend,
     "TINKER_API_KEY": os.environ.get("TINKER_API_KEY", "tml-dummy-key"),
     "TOKENIZERS_PARALLELISM": "false",
   }
@@ -196,6 +218,7 @@ def start_backend(config: RunConfig, processes: list[ManagedProcess]) -> str:
   port = config.port or unused_tcp_port()
   base_url = f"http://{config.host}:{port}"
   env = base_env(config)
+  env["CUDA_VISIBLE_DEVICES"] = config.trainer_gpu
 
   if "fft" in config.scenario:
     if shutil.which("redis-server") is None:
@@ -215,23 +238,61 @@ def start_backend(config: RunConfig, processes: list[ManagedProcess]) -> str:
         "cuda-checkpoint is required for FFT e2e scenarios (the snapshot agent checkpoints workers around every batch); "
         "install the binary matching your driver from https://github.com/NVIDIA/cuda-checkpoint"
       )
-    snapshot_socket = log_dir / "snapshot-agent.sock"
-    snapshot_socket.unlink(missing_ok=True)
+    trainer_snapshot_socket = log_dir / "snapshot-agent-trainer.sock"
+    trainer_snapshot_socket.unlink(missing_ok=True)
     launch(
       processes,
-      "snapshot-agent",
+      "snapshot-agent-trainer",
       uv_run(config.uv_extra) + ["python", "-m", "snapshot_agent.serve"],
-      {**base_env(config), "OPEN_RL_SNAPSHOT_AGENT_SOCKET": str(snapshot_socket)},
-      log_dir / "snapshot-agent.log",
-      snapshot_socket.is_socket,
+      {**base_env(config), "OPEN_RL_SNAPSHOT_AGENT_SOCKET": str(trainer_snapshot_socket)},
+      log_dir / "snapshot-agent-trainer.log",
+      trainer_snapshot_socket.is_socket,
       timeout=60,
     )
-    env["OPEN_RL_SNAPSHOT_AGENT_SOCKET"] = str(snapshot_socket)
+    env["OPEN_RL_SNAPSHOT_AGENT_SOCKET"] = str(trainer_snapshot_socket)
+
+    sampler_snapshot_socket = log_dir / "snapshot-agent-sampler.sock"
+    sampler_snapshot_socket.unlink(missing_ok=True)
+    launch(
+      processes,
+      "snapshot-agent-sampler",
+      uv_run(config.uv_extra) + ["python", "-m", "snapshot_agent.serve"],
+      {**base_env(config), "OPEN_RL_SNAPSHOT_AGENT_SOCKET": str(sampler_snapshot_socket)},
+      log_dir / "snapshot-agent-sampler.log",
+      sampler_snapshot_socket.is_socket,
+      timeout=60,
+    )
+    env["OPEN_RL_SAMPLER_SNAPSHOT_AGENT_SOCKET"] = str(sampler_snapshot_socket)
     env["REDIS_URL"] = f"redis://127.0.0.1:{redis_port}/0"
     env["OPEN_RL_ENABLE_FFT"] = "true"
   else:
     env.pop("REDIS_URL", None)
     env.pop("OPEN_RL_ENABLE_FFT", None)
+
+  if env.get("SAMPLING_BACKEND") == "vllm":
+    if "fft" in config.scenario:
+      env["SAMPLER_CUDA_VISIBLE_DEVICES"] = config.sampler_gpu
+      env["VLLM_GPU_MEMORY_UTILIZATION"] = str(config.vllm_gpu_memory_utilization)
+    else:
+      vllm_env = env.copy()
+      vllm_env["CUDA_VISIBLE_DEVICES"] = config.sampler_gpu
+      vllm_env["VLLM_GPU_MEMORY_UTILIZATION"] = str(config.vllm_gpu_memory_utilization)
+      redis_url = env.get("REDIS_URL")
+      if redis_url:
+        parts = redis_url.split(":")
+        r_port = int(parts[-1].split("/")[0])
+      else:
+        r_port = 6379
+      base_model = config.base_model
+      launch(
+        processes,
+        "vllm-worker",
+        uv_run(config.eval_uv_extra) + ["python", "-m", "server.vllm_sampler", "--model-id", base_model],
+        vllm_env,
+        log_dir / "vllm_worker.log",
+        lambda: redis_key_ready("127.0.0.1", r_port, f"open_rl:sampler_ready:{base_model}"),
+        timeout=config.startup_timeout,
+      )
 
   launch(
     processes,
@@ -303,15 +364,15 @@ def run_example(config: RunConfig, script: list[str], defaults: dict[str, str], 
 
 
 def run_tiny(config: RunConfig, base_url: str, watch: list[ManagedProcess]) -> None:
-  script = "tiny_rl" if config.scenario == "tiny-rl" else "tiny_sft"
+  script = "tiny_rl" if "rl" in config.scenario else "tiny_sft"
   defaults = {
     "base_model": config.base_model,
     "base_url": base_url,
     "log_dir": str(Path(config.log_dir) / config.scenario.replace("-", "_")),
   }
-  if config.scenario == "tiny-fft":
-    # tiny_sft's 1e-3 default is tuned for LoRA adapters; full fine-tuning all
-    # params with Adam at that rate diverges (observed loss 0.93 -> 35).
+  if "fft" in config.scenario:
+    # tiny SFT/RL default is tuned for LoRA adapters; full fine-tuning all
+    # params with Adam at that rate diverges.
     defaults["learning_rate"] = "1e-5"
   if config.steps is not None:
     defaults["steps"] = str(config.steps)
@@ -342,11 +403,11 @@ def write_gsm8k_eval_data(config: RunConfig) -> Path:
   return data_path
 
 
-def resolve_eval_model_path(output: str, must_exist: bool = True) -> str:
+def resolve_eval_model_path(output: str) -> str:
   for line in reversed(output.splitlines()):
     if line.startswith("eval_model_path="):
       path = line.removeprefix("eval_model_path=").strip()
-      if must_exist and not Path(path).exists():
+      if not Path(path).exists():
         raise RuntimeError(f"Eval model path does not exist: {path}")
       return path
   raise RuntimeError("GSM8K SFT finished without printing eval_model_path=...")
@@ -385,52 +446,39 @@ def run_gsm8k_eval(config: RunConfig, model_path: str) -> None:
   )
 
 
-def cluster_model_path(model_path: str, cluster_tmp_dir: str) -> str:
-  """Re-root a shared OpenRL artifact path onto the cluster's OPEN_RL_TMP_DIR.
-
-  gsm8k_sft prints eval_model_path using the *client's* OPEN_RL_TMP_DIR; against
-  a remote backend the checkpoint actually lives under the cluster's tmp dir on
-  the shared PVC, so swap the prefix while keeping the OpenRL artifact tail.
-  """
-  for marker in ("/sampler_full/", "/checkpoints/"):
-    if marker in model_path:
-      return cluster_tmp_dir.rstrip("/") + marker + model_path.split(marker, 1)[1]
-  return model_path
-
-
-def run_or_print_gsm8k_eval(config: RunConfig, model_path: str, label: str = "") -> None:
-  """Eval locally when the checkpoint is reachable; otherwise print the exact
-  command that runs the same eval as a job on the cluster (the checkpoint lives
-  on the cluster's PVC when the backend was remote)."""
-  if Path(model_path).exists():
-    run_gsm8k_eval(config, model_path)
-    return
-  remote_path = cluster_model_path(model_path, config.cluster_tmp_dir)
-  tag = f" {label}" if label else ""
-  print(f"[training-e2e]{tag} checkpoint {model_path} is not visible locally (remote backend at {config.base_url}).")
-  print(f"[training-e2e]{tag} run the GSM8K eval on the cluster with:")
-  print(f"    make cluster-eval EVAL_MODEL_PATH={shlex.quote(remote_path)} EVAL_EXAMPLES={config.eval_examples}")
-
-
 def run_gsm8k(config: RunConfig, base_url: str, watch: list[ManagedProcess]) -> None:
   output = run_gsm8k_train(config, base_url, watch, "fft_gsm8k")
-  run_or_print_gsm8k_eval(config, resolve_eval_model_path(output, must_exist=not config.base_url))
+  run_gsm8k_eval(config, resolve_eval_model_path(output))
 
 
 def check_snapshot_interleaving(config: RunConfig) -> None:
-  log_path = Path(config.log_dir) / "snapshot-agent.log"
   if config.base_url:
     print("[training-e2e] external backend; skipping snapshot agent interleave check")
     return
-  text = log_path.read_text(encoding="utf-8", errors="replace")
-  checkpointed = set(re.findall(r"checkpointed pid (\d+)", text))
-  restored = set(re.findall(r"restored pid (\d+)", text))
-  if len(checkpointed) < 2 or len(restored) < 2:
-    raise RuntimeError(
-      f"Expected both FFT workers to round-trip through the snapshot agent, "
-      f"but saw checkpointed pids {sorted(checkpointed)} and restored pids {sorted(restored)}; see {log_path}"
-    )
-  print(f"[training-e2e] snapshot agent time-sliced workers: checkpointed pids {sorted(checkpointed)}, restored pids {sorted(restored)}")
+
+  trainer_log = Path(config.log_dir) / "snapshot-agent-trainer.log"
+  if trainer_log.exists():
+    text_t = trainer_log.read_text(encoding="utf-8", errors="replace")
+    cp_t = set(re.findall(r"checkpointed pid (\d+)", text_t))
+    rs_t = set(re.findall(r"restored pid (\d+)", text_t))
+    if len(cp_t) < 2 or len(rs_t) < 2:
+      raise RuntimeError(
+        f"Expected both FFT trainer workers to interleave, but saw checkpoints "
+        f"{sorted(cp_t)} and restores {sorted(rs_t)} in {trainer_log}"
+      )
+    print(f"[training-e2e] trainer snapshot agent time-sliced: checkpointed pids {sorted(cp_t)}, restored pids {sorted(rs_t)}")
+
+  sampler_log = Path(config.log_dir) / "snapshot-agent-sampler.log"
+  if sampler_log.exists():
+    text_s = sampler_log.read_text(encoding="utf-8", errors="replace")
+    cp_s = set(re.findall(r"checkpointed pid (\d+)", text_s))
+    rs_s = set(re.findall(r"restored pid (\d+)", text_s))
+    if len(cp_s) < 2 or len(rs_s) < 2:
+      raise RuntimeError(
+        f"Expected both FFT sampler workers to interleave, but saw checkpoints "
+        f"{sorted(cp_s)} and restores {sorted(rs_s)} in {sampler_log}"
+      )
+    print(f"[training-e2e] sampler snapshot agent time-sliced: checkpointed pids {sorted(cp_s)}, restored pids {sorted(rs_s)}")
 
 
 def run_gsm8k_x2(config: RunConfig, base_url: str, watch: list[ManagedProcess]) -> None:
@@ -458,7 +506,40 @@ def run_gsm8k_x2(config: RunConfig, base_url: str, watch: list[ManagedProcess]) 
   for job, result in sorted(results.items()):
     assert isinstance(result, str)
     print(f"[training-e2e] evaluating {job}")
-    run_or_print_gsm8k_eval(config, resolve_eval_model_path(result, must_exist=not config.base_url), label=job)
+    run_gsm8k_eval(config, resolve_eval_model_path(result))
+
+
+def run_tiny_fft_rl_x2(config: RunConfig, base_url: str, watch: list[ManagedProcess]) -> None:
+  """Two concurrent FFT RL jobs against the same backend: each create_model spawns
+  its own trainer and dedicated sampler worker, and the snapshot agent time-slices them."""
+  results: dict[str, str | BaseException] = {}
+
+  def train(job: str) -> None:
+    try:
+      script = "tiny_rl"
+      defaults = {
+        "base_model": config.base_model,
+        "base_url": base_url,
+        "log_dir": str(Path(config.log_dir) / f"{config.scenario.replace('-', '_')}_{job}"),
+        "learning_rate": "1e-5",
+      }
+      if config.steps is not None:
+        defaults["steps"] = str(config.steps)
+      results[job] = run_example(config, [f"examples/tiny/{script}.py"], defaults, watch=watch, prefix=f"[{job}] ")
+    except BaseException as exc:
+      results[job] = exc
+
+  threads = [threading.Thread(target=train, args=(job,)) for job in ("job-a", "job-b")]
+  for thread in threads:
+    thread.start()
+  for thread in threads:
+    thread.join()
+
+  for job, result in sorted(results.items()):
+    if isinstance(result, BaseException):
+      raise RuntimeError(f"tiny-fft-rl-x2 {job} failed") from result
+
+  check_snapshot_interleaving(config)
 
 
 def read_jsonl(path: Path) -> list[dict]:
@@ -522,6 +603,8 @@ def main() -> None:
       run_gsm8k_x2(config, base_url, processes)
     elif config.scenario == "lora-textsql":
       run_textsql(config, base_url, processes)
+    elif config.scenario == "tiny-fft-rl-x2":
+      run_tiny_fft_rl_x2(config, base_url, processes)
     else:
       run_tiny(config, base_url, processes)
   finally:

--- a/scripts/run_training_e2e.py
+++ b/scripts/run_training_e2e.py
@@ -86,7 +86,7 @@ class ManagedProcess:
 
 def unused_tcp_port() -> int:
   with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-    sock.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, struct.pack('ii', 1, 0))
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, struct.pack("ii", 1, 0))
     sock.bind(("127.0.0.1", 0))
     return int(sock.getsockname()[1])
 
@@ -463,8 +463,7 @@ def check_snapshot_interleaving(config: RunConfig) -> None:
     rs_t = set(re.findall(r"restored pid (\d+)", text_t))
     if len(cp_t) < 2 or len(rs_t) < 2:
       raise RuntimeError(
-        f"Expected both FFT trainer workers to interleave, but saw checkpoints "
-        f"{sorted(cp_t)} and restores {sorted(rs_t)} in {trainer_log}"
+        f"Expected both FFT trainer workers to interleave, but saw checkpoints {sorted(cp_t)} and restores {sorted(rs_t)} in {trainer_log}"
       )
     print(f"[training-e2e] trainer snapshot agent time-sliced: checkpointed pids {sorted(cp_t)}, restored pids {sorted(rs_t)}")
 
@@ -475,8 +474,7 @@ def check_snapshot_interleaving(config: RunConfig) -> None:
     rs_s = set(re.findall(r"restored pid (\d+)", text_s))
     if len(cp_s) < 2 or len(rs_s) < 2:
       raise RuntimeError(
-        f"Expected both FFT sampler workers to interleave, but saw checkpoints "
-        f"{sorted(cp_s)} and restores {sorted(rs_s)} in {sampler_log}"
+        f"Expected both FFT sampler workers to interleave, but saw checkpoints {sorted(cp_s)} and restores {sorted(rs_s)} in {sampler_log}"
       )
     print(f"[training-e2e] sampler snapshot agent time-sliced: checkpointed pids {sorted(cp_s)}, restored pids {sorted(rs_s)}")
 

--- a/src/server/Dockerfile
+++ b/src/server/Dockerfile
@@ -40,15 +40,13 @@ ENV UV_COMPILE_BYTECODE=1 \
 # Install dependencies using uv with BuildKit cache
 # --frozen ensures it uses the uv.lock exactly
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen --no-install-project --extra gpu --extra vllm \
-    && uv cache clean
+    uv sync --frozen --no-install-project --extra gpu --extra vllm
 
 # Copy source code
 COPY . .
 
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen --extra gpu --extra vllm \
-    && uv cache clean
+    uv sync --frozen --extra gpu --extra vllm
 
 # TODO: this is a hack until vllm is fixed upstream
 # Apply Gemma 4 LoRA deduplication patch

--- a/src/server/Dockerfile
+++ b/src/server/Dockerfile
@@ -40,13 +40,15 @@ ENV UV_COMPILE_BYTECODE=1 \
 # Install dependencies using uv with BuildKit cache
 # --frozen ensures it uses the uv.lock exactly
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen --no-install-project --extra gpu --extra vllm
+    uv sync --frozen --no-install-project --extra gpu --extra vllm \
+    && uv cache clean
 
 # Copy source code
 COPY . .
 
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen --extra gpu --extra vllm
+    uv sync --frozen --extra gpu --extra vllm \
+    && uv cache clean
 
 # TODO: this is a hack until vllm is fixed upstream
 # Apply Gemma 4 LoRA deduplication patch

--- a/src/server/gateway.py
+++ b/src/server/gateway.py
@@ -146,12 +146,20 @@ async def launch_worker_and_enqueue(request: dict) -> str:
   request_id = request["request_id"]
   await store.set_future(request_id, {"status": "pending"})
   try:
-    await asyncio.to_thread(fft_worker_manager.launch, request["model_id"])
+    await asyncio.to_thread(fft_worker_manager.launch_trainer, request["model_id"])
   except Exception as exc:
     traceback.print_exc()
     await store.set_future(request_id, {"type": "RequestFailedResponse", "error_message": str(exc)})
     return request_id
   return await enqueue(request)
+
+
+async def ensure_sampler_launched(model_id: str) -> None:
+  if is_fft_enabled() and fft_worker_manager is not None and get_sampler_backend() == "vllm":
+    try:
+      await asyncio.to_thread(fft_worker_manager.launch_sampler, model_id)
+    except Exception:
+      traceback.print_exc()
 
 
 async def preflight_vllm() -> None:
@@ -307,6 +315,18 @@ async def create_model(req: dict):
   return {"request_id": req_id}
 
 
+@app.post("/api/v1/delete_model")
+async def delete_model(req: dict):
+  model_id = req.get("model_id")
+  if not model_id:
+    return JSONResponse(status_code=400, content={"error": "model_id is required"})
+  if is_fft_enabled():
+    print(f"[GATEWAY] Requesting shutdown of workers for model {model_id}...")
+    await store.put_request({"request_id": "SHUTDOWN_SENTINEL", "model_id": model_id, "op": "shutdown_workers"})
+    await store.put_sampling_request({"request_id": "SHUTDOWN_SENTINEL", "model_id": model_id})
+  return {"status": "ok"}
+
+
 @app.post("/api/v1/create_model_from_state")
 async def create_model_from_state(req: dict):
   """ServiceClient.create_training_client_from_state_async()"""
@@ -409,6 +429,7 @@ async def save_weights_for_sampler(req: dict):
   if not model_id:
     return JSONResponse(status_code=400, content={"error": "model_id is required"})
 
+  await ensure_sampler_launched(model_id)
   seq_id = req.get("sampling_session_seq_id") or int(time.time() * 1000)
   alias = req.get("name") or req.get("alias") or req.get("path")
 
@@ -494,10 +515,30 @@ async def create_sampling_session(req: dict):
 
   if model_path and model_path.startswith("tinker://"):
     sess_id = model_path
+    path = model_path[len("tinker://") :]
+    parts = path.split("/")
+    target_model_id = parts[0]
   elif base_model:
     sess_id = base_model
+    target_model_id = base_model
   else:
     sess_id = model_id or "samp-session-live-123"
+    target_model_id = sess_id
+
+  if is_fft_enabled() and get_sampler_backend() == "vllm" and target_model_id:
+    await ensure_sampler_launched(target_model_id)
+    s = get_store()
+    if hasattr(s, "redis"):
+      print(f"[GATEWAY] Waiting for dynamic vLLM sampler worker to be ready for model {target_model_id}...")
+      start_time = time.monotonic()
+      while True:
+        is_ready = await s.redis.get(f"open_rl:sampler_ready:{target_model_id}")
+        if is_ready == "1" or is_ready == b"1":
+          print(f"[GATEWAY] Dynamic vLLM sampler worker is ready! (took {time.monotonic() - start_time:.2f}s)")
+          break
+        if time.monotonic() - start_time > 300:
+          raise TimeoutError("Timed out waiting for dynamic vLLM sampler worker to be ready")
+        await asyncio.sleep(1)
 
   return {"sampling_session_id": sess_id, "type": "create_sampling_session"}
 
@@ -539,40 +580,39 @@ async def asample(req: dict):
 
   # vLLM backend
   req_id = str(uuid.uuid4())
+  carrier: dict = {}
+  propagate.inject(carrier)
   await store.set_future(req_id, {"status": "pending"})
 
-  lora_path = os.path.join(TMP_DIR, "peft", base_model_id, base_model_id) if is_sampler_weights_ref(model_id) else None
-  headers: dict[str, str] = {"Content-Type": "application/json"}
-  propagate.inject(headers)
+  if is_fft_enabled():
+    rel_path = model_id[len("tinker://") :] if model_id.startswith("tinker://") else model_id.lstrip("/")
+    local_path = os.path.join(TMP_DIR, "sampler_full", rel_path)
+    weights_path = local_path
+    lora_id = None
+    lora_path = None
+  else:
+    weights_path = None
+    lora_id = model_id
+    lora_path = os.path.join(TMP_DIR, "peft", base_model_id, base_model_id) if is_sampler_weights_ref(model_id) else None
 
-  try:
-    async with httpx.AsyncClient(timeout=120.0) as client:
-      resp = await client.post(
-        f"{VLLM_URL.rstrip('/')}/generate",
-        json={
-          "request_id": req_id,
-          "prompt_token_ids": prompt,
-          "max_tokens": max_tokens,
-          "temperature": temperature,
-          "stop": stop,
-          "top_p": top_p,
-          "top_k": top_k,
-          "num_samples": num_samples,
-          "lora_id": model_id,
-          "lora_path": lora_path,
-          "include_prompt_logprobs": include_prompt_logprobs,
-        },
-        headers=headers,
-      )
-      resp.raise_for_status()
-      data = resp.json()
-      if data.get("type") != "RequestFailedResponse":
-        data["type"] = "sample"
-      await store.set_future(req_id, data)
-  except Exception as e:
-    traceback.print_exc()
-    await store.set_future(req_id, {"type": "RequestFailedResponse", "error_message": str(e)})
+  sampling_req = {
+    "request_id": req_id,
+    "prompt_token_ids": prompt,
+    "max_tokens": max_tokens,
+    "temperature": temperature,
+    "stop": stop,
+    "top_p": top_p,
+    "top_k": top_k,
+    "num_samples": num_samples,
+    "lora_id": lora_id,
+    "lora_path": lora_path,
+    "weights_path": weights_path,
+    "include_prompt_logprobs": include_prompt_logprobs,
+    "model_id": base_model_id or model_id,
+    "trace_context": carrier,
+  }
 
+  await store.put_sampling_request(sampling_req)
   return {"request_id": req_id}
 
 

--- a/src/server/gateway.py
+++ b/src/server/gateway.py
@@ -525,8 +525,9 @@ async def create_sampling_session(req: dict):
     sess_id = model_id or "samp-session-live-123"
     target_model_id = sess_id
 
-  if is_fft_enabled() and get_sampler_backend() == "vllm" and target_model_id:
-    await ensure_sampler_launched(target_model_id)
+  if get_sampler_backend() == "vllm" and target_model_id:
+    if is_fft_enabled():
+      await ensure_sampler_launched(target_model_id)
     s = get_store()
     if hasattr(s, "redis"):
       print(f"[GATEWAY] Waiting for dynamic vLLM sampler worker to be ready for model {target_model_id}...")

--- a/src/server/k8s_worker_manager.py
+++ b/src/server/k8s_worker_manager.py
@@ -58,8 +58,18 @@ class KubernetesFFTWorkerManager:
     self.core_api = core_api
 
   def launch(self, model_id: str) -> None:
+    self.launch_trainer(model_id)
+
+  def launch_trainer(self, model_id: str) -> None:
+    self._launch_pod(model_id, role="trainer")
+
+  def launch_sampler(self, model_id: str) -> None:
+    self._launch_pod(model_id, role="sampler")
+
+  def _launch_pod(self, model_id: str, role: str) -> None:
     job_id = sanitize_job_id(model_id)
-    pod_name = POD_NAME_PREFIX + job_id
+    prefix = "open-rl-trainer-" if role == "trainer" else "open-rl-sampler-"
+    pod_name = prefix + job_id
 
     existing = self.read_pod(pod_name)
     if existing is not None:
@@ -68,41 +78,43 @@ class KubernetesFFTWorkerManager:
       self.delete_pod_and_wait(pod_name)
 
     try:
-      self.core_api.create_namespaced_pod(namespace=self.namespace, body=self.render_pod(pod_name, model_id, job_id))
+      self.core_api.create_namespaced_pod(namespace=self.namespace, body=self.render_pod(pod_name, model_id, job_id, role=role))
     except Exception as exc:
-      # Another gateway replica created it between our read and create.
       if getattr(exc, "status", None) != 409:
         raise
 
   def shutdown(self, model_id: str) -> None:
-    pod_name = POD_NAME_PREFIX + sanitize_job_id(model_id)
-    try:
-      self.core_api.delete_namespaced_pod(name=pod_name, namespace=self.namespace)
-    except Exception as exc:
-      if getattr(exc, "status", None) != 404:
-        raise
+    job_id = sanitize_job_id(model_id)
+    for prefix in ("open-rl-trainer-", "open-rl-sampler-"):
+      pod_name = prefix + job_id
+      try:
+        self.core_api.delete_namespaced_pod(name=pod_name, namespace=self.namespace)
+      except Exception as exc:
+        if getattr(exc, "status", None) != 404:
+          raise
 
   def shutdown_all(self) -> None:
-    # Trainer worker pods deliberately outlive gateway restarts; Kubernetes owns them.
     pass
 
-  def render_pod(self, pod_name: str, model_id: str, job_id: str) -> dict[str, Any]:
+  def render_pod(self, pod_name: str, model_id: str, job_id: str, role: str = "trainer") -> dict[str, Any]:
     pod = copy.deepcopy(self.pod_template)
     metadata = pod.setdefault("metadata", {})
     metadata["name"] = pod_name
+    app_label = "open-rl-trainer-worker" if role == "trainer" else "open-rl-sampler-worker"
+    group_val = self.group_id if role == "trainer" else "samplers"
     metadata.setdefault("labels", {}).update(
       {
-        "app": "open-rl-trainer-worker",
+        "app": app_label,
         "snapshot-agent": "true",
-        "timeslice.io/group": self.group_id,
+        "timeslice.io/group": group_val,
         "timeslice.io/job-id": job_id,
       }
     )
 
     container = pod["spec"]["containers"][0]
+    if role == "sampler":
+      container["command"] = ["uv", "run", "python", "-u", "-m", "server.vllm_sampler"]
     container.setdefault("args", []).extend(["--model-id", model_id])
-    # Keep the env value aligned with the label so current and future
-    # coordination clients use the same sanitized job id.
     container.setdefault("env", []).append({"name": "OPEN_RL_TIME_SLICE_JOB_ID", "value": job_id})
     return pod
 

--- a/src/server/store.py
+++ b/src/server/store.py
@@ -10,9 +10,6 @@ from typing import Any
 import redis.asyncio as redis
 from redis.exceptions import TimeoutError as RedisTimeoutError
 
-# How long a resolved request result stays available to retrieve_future polling.
-FUTURE_TTL_S = int(os.getenv("OPEN_RL_FUTURE_TTL_S", "300"))
-
 
 class RequestStore(ABC):
   @abstractmethod
@@ -21,13 +18,33 @@ class RequestStore(ABC):
     pass
 
   @abstractmethod
+  async def put_worker_launch_request(self, req_data: dict[str, Any]) -> None:
+    """Push a create-model request onto the queue that starts dedicated FFT workers."""
+    pass
+
+  @abstractmethod
   async def get_requests(self) -> list[dict[str, Any]]:
     """Block until at least 1 request is available, then return all currently queued requests."""
     pass
 
   @abstractmethod
+  async def get_worker_launch_requests(self) -> list[dict[str, Any]]:
+    """Block until at least 1 worker-launch request is available, then drain that queue."""
+    pass
+
+  @abstractmethod
   async def get_requests_for_model(self, model_id: str) -> list[dict[str, Any]]:
     """Block until this model has at least 1 request, then return all queued requests for it."""
+    pass
+
+  @abstractmethod
+  async def put_sampling_request(self, req_data: dict[str, Any]) -> None:
+    """Push a sampling request into the queue for its model."""
+    pass
+
+  @abstractmethod
+  async def get_sampling_requests_for_model(self, model_id: str) -> list[dict[str, Any]]:
+    """Block until this model has at least 1 sampling request, then return all queued requests for it."""
     pass
 
   @abstractmethod
@@ -64,6 +81,9 @@ class InMemoryStore(RequestStore):
         self.active_tenants.append(model_id)
         self.active_tenants_cv.notify()
 
+  async def put_worker_launch_request(self, req_data: dict[str, Any]) -> None:
+    raise RuntimeError("Worker launch requests require REDIS_URL; in-memory queues cannot be shared across processes")
+
   async def get_requests(self) -> list[dict[str, Any]]:
     async with self.active_tenants_cv:
       # Block until at least one tenant is active
@@ -87,8 +107,17 @@ class InMemoryStore(RequestStore):
 
       return batch
 
+  async def get_worker_launch_requests(self) -> list[dict[str, Any]]:
+    raise RuntimeError("Worker launch requests require REDIS_URL; in-memory queues cannot be shared across processes")
+
   async def get_requests_for_model(self, model_id: str) -> list[dict[str, Any]]:
     raise RuntimeError("Per-model full fine-tuning workers require REDIS_URL; in-memory queues cannot be shared across processes")
+
+  async def put_sampling_request(self, req_data: dict[str, Any]) -> None:
+    raise RuntimeError("Sampling queues require REDIS_URL")
+
+  async def get_sampling_requests_for_model(self, model_id: str) -> list[dict[str, Any]]:
+    raise RuntimeError("Sampling queues require REDIS_URL")
 
   async def set_future(self, req_id: str, result: dict[str, Any]) -> None:
     self.futures_store[req_id] = result
@@ -119,6 +148,7 @@ class RedisStore(RequestStore):
     self.active_list = "open_rl:active_tenants"
     # We also keep a set to guarantee O(1) deduplication before RPushing
     self.active_set = "open_rl:active_tenants_set"
+    self.worker_launch_queue = "open_rl:worker_launch_queue"
 
   async def put_request(self, req_data: dict[str, Any]) -> None:
     model_id = req_data.get("model_id", "default")
@@ -132,6 +162,9 @@ class RedisStore(RequestStore):
     is_new = await self.redis.sadd(self.active_set, model_id)
     if is_new == 1:
       await self.redis.rpush(self.active_list, model_id)
+
+  async def put_worker_launch_request(self, req_data: dict[str, Any]) -> None:
+    await self.redis.rpush(self.worker_launch_queue, json.dumps(req_data))
 
   async def get_requests(self) -> list[dict[str, Any]]:
     # BRPOPLPUSH blocks until an item is available.
@@ -170,6 +203,25 @@ class RedisStore(RequestStore):
 
     return batch
 
+  async def get_worker_launch_requests(self) -> list[dict[str, Any]]:
+    try:
+      result = await self.redis.blpop(self.worker_launch_queue, timeout=5)
+    except RedisTimeoutError:
+      return []
+
+    if not result:
+      return []
+
+    batch = [json.loads(result[1])]
+
+    while True:
+      item = await self.redis.lpop(self.worker_launch_queue)
+      if not item:
+        break
+      batch.append(json.loads(item))
+
+    return batch
+
   async def get_requests_for_model(self, model_id: str) -> list[dict[str, Any]]:
     queue_key = f"open_rl:queue:{model_id}"
     try:
@@ -195,36 +247,60 @@ class RedisStore(RequestStore):
 
     return batch
 
+  async def put_sampling_request(self, req_data: dict[str, Any]) -> None:
+    model_id = req_data.get("model_id", "default")
+    queue_key = f"open_rl:sampler_queue:{model_id}"
+    await self.redis.rpush(queue_key, json.dumps(req_data))
+
+  async def get_sampling_requests_for_model(self, model_id: str) -> list[dict[str, Any]]:
+    queue_key = f"open_rl:sampler_queue:{model_id}"
+    try:
+      result = await self.redis.blpop(queue_key, timeout=5)
+    except RedisTimeoutError:
+      return []
+
+    if not result:
+      return []
+
+    batch = [json.loads(result[1])]
+
+    while True:
+      item = await self.redis.lpop(queue_key)
+      if not item:
+        break
+      batch.append(json.loads(item))
+
+    return batch
+
   async def set_future(self, req_id: str, result: dict[str, Any]) -> None:
     if result.get("status") == "pending":
       return
 
-    # The value key is the source of truth; the publish only wakes long-pollers.
-    # Late subscribers and lost messages still find the result with a plain GET.
-    await self.redis.set(f"open_rl:future:{req_id}", json.dumps(result), ex=FUTURE_TTL_S)
-    await self.redis.publish(f"open_rl:future_done:{req_id}", "1")
+    key = f"open_rl:future:{req_id}"
+    await self.redis.rpush(key, json.dumps(result))
+    await self.redis.expire(key, 300)
 
   async def get_future(self, req_id: str, timeout: float) -> dict[str, Any] | None:
     key = f"open_rl:future:{req_id}"
-    if (value := await self.redis.get(key)) is not None:
-      return json.loads(value)
 
-    async with self.redis.pubsub() as pubsub:
-      await pubsub.subscribe(f"open_rl:future_done:{req_id}")
-      # The result may have landed between the GET above and the subscribe.
-      if (value := await self.redis.get(key)) is not None:
-        return json.loads(value)
-      # Wait in slices shorter than the client's 5s default socket timeout, and
-      # re-check the key each slice in case the publish was missed entirely.
-      deadline = time.monotonic() + timeout
-      while (remaining := deadline - time.monotonic()) > 0:
-        try:
-          await pubsub.get_message(ignore_subscribe_messages=True, timeout=min(3.0, remaining))
-        except RedisTimeoutError:
-          pass
-        if (value := await self.redis.get(key)) is not None:
-          return json.loads(value)
-    return {"type": "try_again", "request_id": req_id, "queue_state": "active"}
+    # redis-py 8 defaults the client socket timeout to 5s, so a single BLPOP can
+    # never block for the full long-poll window. Poll in slices shorter than the
+    # socket timeout until the deadline so clients only see try_again when the
+    # request genuinely outlived the window.
+    deadline = time.monotonic() + timeout
+    while True:
+      remaining = deadline - time.monotonic()
+      if remaining <= 0:
+        return {"type": "try_again", "request_id": req_id, "queue_state": "active"}
+      try:
+        result = await self.redis.blpop(key, timeout=min(3, max(1, int(remaining))))
+      except RedisTimeoutError:
+        result = None
+      if result:
+        payload = json.loads(result[1])
+        await self.redis.rpush(key, result[1])
+        await self.redis.expire(key, 300)
+        return payload
 
 
 # Global singleton factory

--- a/src/server/training_requests_processor.py
+++ b/src/server/training_requests_processor.py
@@ -251,6 +251,20 @@ class FFTTrainingRequestsProcessor(TrainingRequestsProcessor):
     self.snapshot_client = snapshot_client
     self.snapshot_registered = False
 
+  async def exit_gracefully(self) -> None:
+    print(f"[WORKER] Initiating immediate exit for model {self.model_id} trainer worker...")
+    if self.snapshot_registered:
+      try:
+        await self.snapshot_client.unregister(self.pid)
+        self.snapshot_registered = False
+      except Exception as exc:
+        print(f"[WORKER] Failed to unregister: {exc}")
+    try:
+      await self.snapshot_client.close()
+    except Exception:
+      pass
+    os._exit(0)
+
   async def run(self) -> None:
     print("[WORKER] Full fine-tuning training requests processor started.")
 
@@ -279,14 +293,26 @@ class FFTTrainingRequestsProcessor(TrainingRequestsProcessor):
       await asyncio.sleep(0.1)
       return
 
+    has_shutdown = False
+    training_reqs = []
+    for req in batch:
+      if req.get("request_id") == "SHUTDOWN_SENTINEL" or req.get("op") in {"shutdown", "shutdown_workers"}:
+        has_shutdown = True
+      else:
+        training_reqs.append(req)
+
     with tracer.start_as_current_span("training_requests_batch") as batch_span:
-      batch_span.set_attribute("batch_size", len(batch))
+      batch_span.set_attribute("batch_size", len(training_reqs))
       batch_span.set_attribute("model_id", self.model_id)
 
-      print(f"\n[TRAINING REQUESTS] Popped {len(batch)} requests for model: {self.model_id}")
-      async with self.snapshot_client.acquire(self.pid):
-        for request in batch:
-          await self.process_request(request, self.model_id)
+      if training_reqs:
+        print(f"\n[TRAINING REQUESTS] Popped {len(training_reqs)} requests for model: {self.model_id}")
+        async with self.snapshot_client.acquire(self.pid):
+          for request in training_reqs:
+            await self.process_request(request, self.model_id)
+
+    if has_shutdown:
+      await self.exit_gracefully()
 
   async def create_model(self, payload: dict[str, Any], model_id: str) -> dict[str, Any]:
     raw_config = payload.get("full_config") or {}

--- a/src/server/training_requests_processor.py
+++ b/src/server/training_requests_processor.py
@@ -248,6 +248,7 @@ class FFTTrainingRequestsProcessor(TrainingRequestsProcessor):
     self.worker = worker
     self.model_id = model_id
     self.pid = os.getpid()
+    self.group = os.getenv("OPEN_RL_TIMESLICE_GROUP", "trainers")
     self.snapshot_client = snapshot_client
     self.snapshot_registered = False
 
@@ -255,7 +256,7 @@ class FFTTrainingRequestsProcessor(TrainingRequestsProcessor):
     print(f"[WORKER] Initiating immediate exit for model {self.model_id} trainer worker...")
     if self.snapshot_registered:
       try:
-        await self.snapshot_client.unregister(self.pid)
+        await self.snapshot_client.unregister(self.pid, group=self.group)
         self.snapshot_registered = False
       except Exception as exc:
         print(f"[WORKER] Failed to unregister: {exc}")
@@ -269,7 +270,7 @@ class FFTTrainingRequestsProcessor(TrainingRequestsProcessor):
     print("[WORKER] Full fine-tuning training requests processor started.")
 
     try:
-      await self.snapshot_client.register(self.pid)
+      await self.snapshot_client.register(self.pid, group=self.group)
       self.snapshot_registered = True
       while True:
         try:
@@ -283,7 +284,7 @@ class FFTTrainingRequestsProcessor(TrainingRequestsProcessor):
     finally:
       try:
         if self.snapshot_registered:
-          await self.snapshot_client.unregister(self.pid)
+          await self.snapshot_client.unregister(self.pid, group=self.group)
       finally:
         await self.snapshot_client.close()
 
@@ -307,7 +308,7 @@ class FFTTrainingRequestsProcessor(TrainingRequestsProcessor):
 
       if training_reqs:
         print(f"\n[TRAINING REQUESTS] Popped {len(training_reqs)} requests for model: {self.model_id}")
-        async with self.snapshot_client.acquire(self.pid):
+        async with self.snapshot_client.acquire(self.pid, group=self.group):
           for request in training_reqs:
             await self.process_request(request, self.model_id)
 

--- a/src/server/vllm_sampler.py
+++ b/src/server/vllm_sampler.py
@@ -53,33 +53,6 @@ def is_fft_enabled() -> bool:
   return os.getenv("OPEN_RL_ENABLE_FFT", "").lower() == "true"
 
 
-def get_engine_core_pid(model_id: str) -> int:
-  import multiprocessing
-
-  children = multiprocessing.active_children()
-  print(f"[vLLM Worker] Active multiprocessing children: {[(c.name, c.pid) for c in children]}")
-  for child in children:
-    if child.pid is not None:
-      return child.pid
-
-  parent_pid = os.getpid()
-  try:
-    out = subprocess.check_output(["ps", "-o", "pid,command", "--no-headers", "--ppid", str(parent_pid)])
-    lines = out.decode().splitlines()
-    for line in lines:
-      parts = line.strip().split(None, 1)
-      if len(parts) >= 2:
-        child_pid = int(parts[0])
-        cmd = parts[1]
-        if "multiprocessing" in cmd or "EngineCore" in cmd or "vllm" in cmd:
-          return child_pid
-    if lines:
-      return int(lines[0].strip().split()[0])
-  except Exception as e:
-    print(f"[vLLM Worker] Warning: failed to find engine child pid: {e}")
-  return parent_pid
-
-
 snapshot_client: Any = None
 socket_path = os.getenv("OPEN_RL_SNAPSHOT_AGENT_SOCKET")
 if is_fft_enabled() and socket_path:
@@ -295,39 +268,24 @@ async def run_sampling_worker(model_id: str) -> None:
 
   store = get_store()
   snapshot_registered = False
-  preempt_pid = None
+  worker_pid = os.getpid()
 
   if snapshot_client is not None:
     try:
-      parent_pid = os.getpid()
-      print(f"[vLLM Worker] Registering parent PID {parent_pid} for initialization lock...")
-      await snapshot_client.register(parent_pid)
-      async with snapshot_client.acquire(parent_pid):
+      print(f"[vLLM Worker] Registering parent PID {worker_pid} for initialization lock...")
+      await snapshot_client.register(worker_pid)
+      snapshot_registered = True
+      async with snapshot_client.acquire(worker_pid):
         print("[vLLM Worker] Initializing vLLM engine under parent lock...")
         init_engine()
-        preempt_pid = get_engine_core_pid(model_id)
-        print(f"[vLLM Worker] Engine initialized. Target child PID: {preempt_pid}")
-        await snapshot_client.register(preempt_pid)
-        snapshot_registered = True
-
-        # Transfer lock from parent_pid to preempt_pid before releasing the acquire context
-        print(f"[vLLM Worker] Transferring lock to child PID {preempt_pid}...")
-        await snapshot_client.transfer_lock(parent_pid, preempt_pid)
-
-      await snapshot_client.unregister(parent_pid)
-
-      # Now release the lock on preempt_pid (which was transferred to it) to checkpoint it and free VRAM
-      print(f"[vLLM Worker] Releasing lock on child PID {preempt_pid} to trigger initial checkpoint...")
-      await snapshot_client.request({"command": "RELEASE", "pid": preempt_pid})
+        print("[vLLM Worker] Engine initialized successfully.")
     except Exception as exc:
       print(f"[vLLM Worker] Failed to perform coordinated initialization: {exc}")
       traceback.print_exc()
-      if preempt_pid is None:
+      if engine is None:
         init_engine()
-        preempt_pid = get_engine_core_pid(model_id)
   else:
     init_engine()
-    preempt_pid = get_engine_core_pid(model_id)
 
   if snapshot_client is not None:
     import signal
@@ -337,7 +295,7 @@ async def run_sampling_worker(model_id: str) -> None:
       nonlocal snapshot_registered
       if snapshot_registered:
         try:
-          await snapshot_client.unregister(preempt_pid)
+          await snapshot_client.unregister(worker_pid)
           snapshot_registered = False
         except Exception as exc:
           print(f"[vLLM Worker] Failed to unregister: {exc}")
@@ -381,7 +339,7 @@ async def run_sampling_worker(model_id: str) -> None:
 
         if sampling_reqs:
           if snapshot_client is not None:
-            async with snapshot_client.acquire(preempt_pid):
+            async with snapshot_client.acquire(worker_pid):
               tasks = [asyncio.create_task(process_sampling_request(req, store)) for req in sampling_reqs]
               await asyncio.gather(*tasks)
               if has_shutdown:
@@ -407,7 +365,7 @@ async def run_sampling_worker(model_id: str) -> None:
     if snapshot_client is not None:
       try:
         if snapshot_registered:
-          await snapshot_client.unregister(preempt_pid)
+          await snapshot_client.unregister(worker_pid)
       finally:
         await snapshot_client.close()
         os._exit(0)

--- a/src/server/vllm_sampler.py
+++ b/src/server/vllm_sampler.py
@@ -1,14 +1,13 @@
 # This file contains the vLLM worker implementation for high-throughput inference in Open-RL.
 
+import argparse
 import asyncio
 import hashlib
 import os
+import subprocess
 import sys
-from contextlib import asynccontextmanager
+import traceback
 from typing import Any
-
-import uvicorn
-from fastapi import FastAPI, Request
 
 try:
   from vllm import SamplingParams
@@ -26,8 +25,7 @@ except ImportError:
   RequestOutputKind = None
   VLLM_AVAILABLE = False
 
-from opentelemetry import trace
-from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+from opentelemetry import propagate, trace
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
@@ -47,14 +45,50 @@ if os.getenv("ENABLE_GCP_TRACE", "0") == "1":
 tracer = trace.get_tracer("vllm.inference.worker")
 
 engine: Any = None
+CURRENT_LOADED_SAMPLER_WEIGHTS: str | None = None
+reload_lock = asyncio.Lock()
+def is_fft_enabled() -> bool:
+  return os.getenv("OPEN_RL_ENABLE_FFT", "").lower() == "true"
 
 
-@asynccontextmanager
-async def lifespan(app: FastAPI):
+def get_engine_core_pid(model_id: str) -> int:
+  import multiprocessing
+  children = multiprocessing.active_children()
+  print(f"[vLLM Worker] Active multiprocessing children: {[(c.name, c.pid) for c in children]}")
+  for child in children:
+    if child.pid is not None:
+      return child.pid
+
+  parent_pid = os.getpid()
+  try:
+    out = subprocess.check_output(["ps", "-o", "pid,command", "--no-headers", "--ppid", str(parent_pid)])
+    lines = out.decode().splitlines()
+    for line in lines:
+      parts = line.strip().split(None, 1)
+      if len(parts) >= 2:
+        child_pid = int(parts[0])
+        cmd = parts[1]
+        if "multiprocessing" in cmd or "EngineCore" in cmd or "vllm" in cmd:
+          return child_pid
+    if lines:
+      return int(lines[0].strip().split()[0])
+  except Exception as e:
+    print(f"[vLLM Worker] Warning: failed to find engine child pid: {e}")
+  return parent_pid
+
+
+snapshot_client: Any = None
+socket_path = os.getenv("OPEN_RL_SNAPSHOT_AGENT_SOCKET")
+if is_fft_enabled() and socket_path:
+  from snapshot_agent.client import SnapshotAgentClient
+  snapshot_client = SnapshotAgentClient(socket_path)
+
+
+def init_engine():
   global engine
 
   print("\n" + "=" * 50)
-  print("        Open-RL vLLM Inference Engine")
+  print("        Open-RL vLLM Inference Engine (Queue Mode)")
   print("=" * 50)
   cuda_devs = os.getenv("CUDA_VISIBLE_DEVICES", "ALL")
   model_name = os.getenv("BASE_MODEL") or os.getenv("VLLM_MODEL")
@@ -63,9 +97,9 @@ async def lifespan(app: FastAPI):
 
   mock_vllm = os.getenv("MOCK_VLLM", "0") == "1"
   if mock_vllm or not VLLM_AVAILABLE:
-    print("[vLLM Subprocess] MOCK_VLLM=1 or vllm not installed, bypassing real engine init for local dev.")
+    print("[vLLM Worker] MOCK_VLLM=1 or vllm not installed, bypassing real engine init for local dev.")
   elif not model_name:
-    print("[vLLM Subprocess] Error: BASE_MODEL environment variable is required.")
+    print("[vLLM Worker] Error: BASE_MODEL environment variable is required.")
     sys.exit(1)
   else:
     hf_overrides: dict = {}
@@ -75,53 +109,40 @@ async def lifespan(app: FastAPI):
 
     engine_kwargs = {
       "model": model_name,
-      "enable_lora": True,
-      "max_loras": 8,
-      "max_lora_rank": 64,
+      "enable_sleep_mode": is_fft_enabled(),
+      "enable_lora": not is_fft_enabled(),
       "max_model_len": int(os.getenv("VLLM_MAX_MODEL_LEN", "8192")),
       "max_num_seqs": int(os.getenv("VLLM_MAX_NUM_SEQS", "64")),
       "gpu_memory_utilization": float(os.getenv("VLLM_GPU_MEMORY_UTILIZATION", "0.90")),
       "enable_prefix_caching": False,
       "enforce_eager": os.getenv("VLLM_ENFORCE_EAGER", "0") == "1",
     }
+    if not is_fft_enabled():
+      engine_kwargs["max_loras"] = 8
+      engine_kwargs["max_lora_rank"] = 64
     if hf_overrides:
       engine_kwargs["hf_overrides"] = hf_overrides
 
     engine_args = AsyncEngineArgs(**engine_kwargs)
     engine = AsyncLLMEngine.from_engine_args(engine_args)
 
-    print("[vLLM Subprocess] Engine initialized and ready to serve IPC requests.")
-
-  yield
+    print("[vLLM Worker] Engine initialized successfully.")
 
 
-app = FastAPI(title="Open-RL vLLM Subprocess", lifespan=lifespan)
-FastAPIInstrumentor.instrument_app(app, excluded_urls="/healthz")
-
-
-@app.get("/healthz")
-async def healthz():
-  return {"status": "ok", "mock": engine is None}
-
-
-@app.post("/generate")
-async def generate(req: Request):
+async def run_generation_backend(
+  request_id: str,
+  prompt_token_ids: list[int],
+  max_tokens: int,
+  temperature: float,
+  stop: list[int] | None,
+  top_p: float,
+  top_k: int,
+  num_samples: int,
+  lora_id: str | None,
+  lora_path: str | None,
+  include_prompt_logprobs: bool,
+) -> dict[str, Any]:
   try:
-    data = await req.json()
-
-    request_id = data.get("request_id")
-    prompt_token_ids = data.get("prompt_token_ids")
-    max_tokens = data.get("max_tokens", 20)
-    temperature = data.get("temperature", 1.0)
-    stop = data.get("stop", None)
-    top_p = data.get("top_p", 1.0)
-    top_k = data.get("top_k", -1)
-    num_samples = data.get("num_samples", 1)
-
-    lora_id = data.get("lora_id", None)
-    lora_path = data.get("lora_path", None)
-    include_prompt_logprobs = data.get("include_prompt_logprobs", False)
-
     current_engine = engine
     if current_engine is None:
       # Mocking for local Mac dev
@@ -191,14 +212,214 @@ async def generate(req: Request):
           else:
             prompt_logprobs_out.append(None)
 
-    return {"sequences": sequences_out, "prompt_logprobs": prompt_logprobs_out}
+    res = {"sequences": sequences_out}
+    if prompt_logprobs_out is not None:
+      res["prompt_logprobs"] = prompt_logprobs_out
+    return res
   except Exception as e:
-    import traceback
-
     traceback.print_exc()
-    # Return explicit 500 so upstream client logs it
     return {"type": "RequestFailedResponse", "error_message": f"vLLM Worker Error: {str(e)}"}
 
 
+async def process_sampling_request(req: dict, store: Any) -> None:
+  global engine
+  global CURRENT_LOADED_SAMPLER_WEIGHTS
+
+  request_id = req["request_id"]
+  trace_context = req.get("trace_context", {})
+
+  parent_span = propagate.extract(trace_context)
+  with tracer.start_as_current_span("process_sampling_request", context=parent_span):
+    try:
+      # 1. Manage weights reloading
+      weights_path = req.get("weights_path")
+      if is_fft_enabled() and weights_path:
+        async with reload_lock:
+          if weights_path != CURRENT_LOADED_SAMPLER_WEIGHTS:
+            print(f"[vLLM Worker] Weight change detected. Current: {CURRENT_LOADED_SAMPLER_WEIGHTS}, Target: {weights_path}")
+            if engine is not None:
+              print("[vLLM Worker] Triggering sleep level 2...")
+              await engine.sleep(level=2)
+              print("[vLLM Worker] Waking up weights...")
+              await engine.wake_up(tags=["weights"])
+              print(f"[vLLM Worker] Reloading weights from {weights_path} in-place...")
+              await engine.collective_rpc("reload_weights", kwargs={"weights_path": weights_path})
+              print("[vLLM Worker] Waking up KV cache...")
+              await engine.wake_up(tags=["kv_cache"])
+            CURRENT_LOADED_SAMPLER_WEIGHTS = weights_path
+            print("[vLLM Worker] Weights reload completed successfully!")
+
+      # 2. Run inference
+      prompt_token_ids = req.get("prompt_token_ids", [])
+      max_tokens = req.get("max_tokens", 20)
+      temperature = req.get("temperature", 1.0)
+      stop = req.get("stop")
+      top_p = req.get("top_p", 1.0)
+      top_k = req.get("top_k", -1)
+      num_samples = req.get("num_samples", 1)
+      lora_id = req.get("lora_id")
+      lora_path = req.get("lora_path")
+      include_prompt_logprobs = req.get("include_prompt_logprobs", False)
+
+      result = await run_generation_backend(
+        request_id=request_id,
+        prompt_token_ids=prompt_token_ids,
+        max_tokens=max_tokens,
+        temperature=temperature,
+        stop=stop,
+        top_p=top_p,
+        top_k=top_k,
+        num_samples=num_samples,
+        lora_id=lora_id,
+        lora_path=lora_path,
+        include_prompt_logprobs=include_prompt_logprobs,
+      )
+
+      if result.get("type") != "RequestFailedResponse":
+        result["type"] = "sample"
+
+      await store.set_future(request_id, result)
+    except Exception as exc:
+      traceback.print_exc()
+      await store.set_future(request_id, {"type": "RequestFailedResponse", "error_message": f"vLLM Worker Error: {str(exc)}"})
+
+
+async def run_sampling_worker(model_id: str) -> None:
+  global engine
+  global CURRENT_LOADED_SAMPLER_WEIGHTS
+  from server.store import get_store
+
+  store = get_store()
+  snapshot_registered = False
+  preempt_pid = None
+
+
+  if snapshot_client is not None:
+    try:
+      parent_pid = os.getpid()
+      print(f"[vLLM Worker] Registering parent PID {parent_pid} for initialization lock...")
+      await snapshot_client.register(parent_pid)
+      async with snapshot_client.acquire(parent_pid):
+        print("[vLLM Worker] Initializing vLLM engine under parent lock...")
+        init_engine()
+        preempt_pid = get_engine_core_pid(model_id)
+        print(f"[vLLM Worker] Engine initialized. Target child PID: {preempt_pid}")
+        await snapshot_client.register(preempt_pid)
+        snapshot_registered = True
+
+        # Transfer lock from parent_pid to preempt_pid before releasing the acquire context
+        print(f"[vLLM Worker] Transferring lock to child PID {preempt_pid}...")
+        await snapshot_client.transfer_lock(parent_pid, preempt_pid)
+
+      await snapshot_client.unregister(parent_pid)
+
+      # Now release the lock on preempt_pid (which was transferred to it) to checkpoint it and free VRAM
+      print(f"[vLLM Worker] Releasing lock on child PID {preempt_pid} to trigger initial checkpoint...")
+      await snapshot_client.request({"command": "RELEASE", "pid": preempt_pid})
+    except Exception as exc:
+      print(f"[vLLM Worker] Failed to perform coordinated initialization: {exc}")
+      traceback.print_exc()
+      if preempt_pid is None:
+        init_engine()
+        preempt_pid = get_engine_core_pid(model_id)
+  else:
+    init_engine()
+    preempt_pid = get_engine_core_pid(model_id)
+
+  if snapshot_client is not None:
+    import signal
+
+    async def exit_gracefully() -> None:
+      print(f"[vLLM Worker] Initiating immediate exit for model {model_id} sampler worker...")
+      nonlocal snapshot_registered
+      if snapshot_registered:
+        try:
+          await snapshot_client.unregister(preempt_pid)
+          snapshot_registered = False
+        except Exception as exc:
+          print(f"[vLLM Worker] Failed to unregister: {exc}")
+      try:
+        await snapshot_client.close()
+      except Exception:
+        pass
+      os._exit(0)
+
+    async def handle_shutdown():
+      print(f"[vLLM Worker] Received termination signal, shutting down model {model_id} sampler worker...")
+      await exit_gracefully()
+
+    try:
+      loop = asyncio.get_running_loop()
+      for sig in (signal.SIGTERM, signal.SIGINT):
+        loop.add_signal_handler(sig, lambda: asyncio.create_task(handle_shutdown()))
+    except NotImplementedError:
+      pass
+
+  if hasattr(store, "redis"):
+    await store.redis.set(f"open_rl:sampler_ready:{model_id}", "1")
+    await store.redis.expire(f"open_rl:sampler_ready:{model_id}", 3600)
+
+  print(f"[vLLM Worker] Listening for sampling requests on queue for model: {model_id}...")
+  try:
+    while True:
+      try:
+        batch = await store.get_sampling_requests_for_model(model_id)
+        if not batch:
+          await asyncio.sleep(0.05)
+          continue
+
+        has_shutdown = False
+        sampling_reqs = []
+        for req in batch:
+          if req.get("request_id") == "SHUTDOWN_SENTINEL":
+            has_shutdown = True
+          else:
+            sampling_reqs.append(req)
+
+        if sampling_reqs:
+          if snapshot_client is not None:
+            async with snapshot_client.acquire(preempt_pid):
+              tasks = [asyncio.create_task(process_sampling_request(req, store)) for req in sampling_reqs]
+              await asyncio.gather(*tasks)
+              if has_shutdown:
+                await exit_gracefully()
+              if engine is not None:
+                print("[vLLM Worker] Exiting batch: sleeping engine to yield GPU memory...")
+                await engine.sleep(level=2)
+                CURRENT_LOADED_SAMPLER_WEIGHTS = None
+          else:
+            tasks = [asyncio.create_task(process_sampling_request(req, store)) for req in sampling_reqs]
+            await asyncio.gather(*tasks)
+
+        if has_shutdown:
+          print("[vLLM Worker] Shutdown sentinel popped from queue. Initiating clean exit...")
+          await exit_gracefully()
+      except asyncio.CancelledError:
+        break
+      except Exception as exc:
+        print(f"Error in sampling worker loop: {exc}")
+        traceback.print_exc()
+        await asyncio.sleep(1)
+  finally:
+    if snapshot_client is not None:
+      try:
+        if snapshot_registered:
+          await snapshot_client.unregister(preempt_pid)
+      finally:
+        await snapshot_client.close()
+        os._exit(0)
+
+
+def main() -> None:
+  parser = argparse.ArgumentParser(description="Open-RL vLLM Pull-Mode Sampler Worker")
+  parser.add_argument("--model-id", type=str, required=True, help="The model ID of the RL job to process requests for")
+  args = parser.parse_args()
+
+  try:
+    asyncio.run(run_sampling_worker(args.model_id))
+  except KeyboardInterrupt:
+    print("[vLLM Worker] Exiting via KeyboardInterrupt.")
+
+
 if __name__ == "__main__":
-  uvicorn.run(app, host="0.0.0.0", port=8001)
+  main()

--- a/src/server/vllm_sampler.py
+++ b/src/server/vllm_sampler.py
@@ -268,13 +268,14 @@ async def run_sampling_worker(model_id: str) -> None:
   store = get_store()
   snapshot_registered = False
   worker_pid = os.getpid()
+  group = os.getenv("OPEN_RL_TIMESLICE_GROUP", "samplers")
 
   if snapshot_client is not None:
     try:
-      print(f"[vLLM Worker] Registering parent PID {worker_pid} for initialization lock...")
-      await snapshot_client.register(worker_pid)
+      print(f"[vLLM Worker] Registering parent PID {worker_pid} (group {group}) for initialization lock...")
+      await snapshot_client.register(worker_pid, group=group)
       snapshot_registered = True
-      async with snapshot_client.acquire(worker_pid):
+      async with snapshot_client.acquire(worker_pid, group=group):
         print("[vLLM Worker] Initializing vLLM engine under parent lock...")
         init_engine()
         print("[vLLM Worker] Engine initialized successfully.")

--- a/src/server/vllm_sampler.py
+++ b/src/server/vllm_sampler.py
@@ -4,7 +4,6 @@ import argparse
 import asyncio
 import hashlib
 import os
-import subprocess
 import sys
 import traceback
 from typing import Any

--- a/src/server/vllm_sampler.py
+++ b/src/server/vllm_sampler.py
@@ -47,12 +47,15 @@ tracer = trace.get_tracer("vllm.inference.worker")
 engine: Any = None
 CURRENT_LOADED_SAMPLER_WEIGHTS: str | None = None
 reload_lock = asyncio.Lock()
+
+
 def is_fft_enabled() -> bool:
   return os.getenv("OPEN_RL_ENABLE_FFT", "").lower() == "true"
 
 
 def get_engine_core_pid(model_id: str) -> int:
   import multiprocessing
+
   children = multiprocessing.active_children()
   print(f"[vLLM Worker] Active multiprocessing children: {[(c.name, c.pid) for c in children]}")
   for child in children:
@@ -81,6 +84,7 @@ snapshot_client: Any = None
 socket_path = os.getenv("OPEN_RL_SNAPSHOT_AGENT_SOCKET")
 if is_fft_enabled() and socket_path:
   from snapshot_agent.client import SnapshotAgentClient
+
   snapshot_client = SnapshotAgentClient(socket_path)
 
 
@@ -292,7 +296,6 @@ async def run_sampling_worker(model_id: str) -> None:
   store = get_store()
   snapshot_registered = False
   preempt_pid = None
-
 
   if snapshot_client is not None:
     try:

--- a/src/server/worker_manager.py
+++ b/src/server/worker_manager.py
@@ -20,6 +20,14 @@ class WorkerManager(Protocol):
     """Ensure the model's worker exists; idempotent per model_id."""
     ...
 
+  def launch_trainer(self, model_id: str) -> None:
+    """Ensure the trainer worker exists."""
+    ...
+
+  def launch_sampler(self, model_id: str) -> None:
+    """Ensure the sampler worker exists."""
+    ...
+
   def shutdown(self, model_id: str) -> None:
     """Tear down the model's worker, if any. The idempotent launch can revive it later."""
     ...
@@ -28,34 +36,65 @@ class WorkerManager(Protocol):
 
 
 class FFTWorkerManager:
-  """Runs one local trainer subprocess per FFT model."""
+  """Runs local trainer and sampler subprocesses per FFT model."""
 
   def __init__(self, project_dir: Path = PROJECT_DIR):
     if not os.getenv("REDIS_URL"):
       raise RuntimeError("OPEN_RL_ENABLE_FFT=true requires REDIS_URL so launched workers can share queues and futures")
 
     self.project_dir = project_dir
-    self.processes: dict[str, subprocess.Popen] = {}
+    self.train_processes: dict[str, subprocess.Popen] = {}
+    self.sampler_processes: dict[str, subprocess.Popen] = {}
 
   def launch(self, model_id: str) -> None:
-    proc = self.processes.get(model_id)
+    self.launch_trainer(model_id)
+
+  def launch_trainer(self, model_id: str) -> None:
+    proc = self.train_processes.get(model_id)
     if proc is not None and proc.poll() is None:
       return
 
     env = {**os.environ, "OPEN_RL_ENABLE_FFT": "true"}
-    self.processes[model_id] = subprocess.Popen(
-      [sys.executable, "-m", "server.training_requests_processor", "--model-id", model_id],
+    self.train_processes[model_id] = subprocess.Popen(
+      [sys.executable, "-u", "-m", "server.training_requests_processor", "--model-id", model_id],
       cwd=self.project_dir,
       env=env,
     )
 
+  def launch_sampler(self, model_id: str) -> None:
+    proc = self.sampler_processes.get(model_id)
+    if proc is not None and proc.poll() is None:
+      return
+
+    env = {**os.environ, "OPEN_RL_ENABLE_FFT": "true"}
+    sampling_backend = os.getenv("SAMPLING_BACKEND", "vllm").lower()
+    if sampling_backend == "vllm":
+      sampler_env = env.copy()
+      sampler_env["OPEN_RL_MODEL_ID"] = model_id
+      sampler_gpu = os.getenv("SAMPLER_CUDA_VISIBLE_DEVICES")
+      if sampler_gpu:
+        sampler_env["CUDA_VISIBLE_DEVICES"] = sampler_gpu
+
+      sampler_socket = os.getenv("OPEN_RL_SAMPLER_SNAPSHOT_AGENT_SOCKET")
+      if sampler_socket:
+        sampler_env["OPEN_RL_SNAPSHOT_AGENT_SOCKET"] = sampler_socket
+
+      self.sampler_processes[model_id] = subprocess.Popen(
+        [sys.executable, "-u", "-m", "server.vllm_sampler", "--model-id", model_id],
+        cwd=self.project_dir,
+        env=sampler_env,
+      )
+
   def shutdown(self, model_id: str) -> None:
-    proc = self.processes.pop(model_id, None)
+    proc = self.train_processes.pop(model_id, None)
     if proc is not None and proc.poll() is None:
       proc.terminate()
+    proc_s = self.sampler_processes.pop(model_id, None)
+    if proc_s is not None and proc_s.poll() is None:
+      proc_s.terminate()
 
   def shutdown_all(self) -> None:
-    for model_id in list(self.processes):
+    for model_id in set(list(self.train_processes) + list(self.sampler_processes)):
       self.shutdown(model_id)
 
 

--- a/src/server/worker_manager.py
+++ b/src/server/worker_manager.py
@@ -7,12 +7,22 @@ the launched-worker state, and both launchers are idempotent per model_id.
 """
 
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
 from typing import Protocol
 
 PROJECT_DIR = Path(__file__).resolve().parents[2]
+
+
+def _py_cmd(extras: list[str], module: str, model_id: str) -> list[str]:
+  if shutil.which("uv"):
+    extra_args = []
+    for e in extras:
+      extra_args.extend(["--extra", e])
+    return ["uv", "run", *extra_args, "python", "-u", "-m", module, "--model-id", model_id]
+  return [sys.executable, "-u", "-m", module, "--model-id", model_id]
 
 
 class WorkerManager(Protocol):
@@ -56,7 +66,7 @@ class FFTWorkerManager:
 
     env = {**os.environ, "OPEN_RL_ENABLE_FFT": "true"}
     self.train_processes[model_id] = subprocess.Popen(
-      [sys.executable, "-u", "-m", "server.training_requests_processor", "--model-id", model_id],
+      _py_cmd(["gpu"], "server.training_requests_processor", model_id),
       cwd=self.project_dir,
       env=env,
     )
@@ -80,7 +90,7 @@ class FFTWorkerManager:
         sampler_env["OPEN_RL_SNAPSHOT_AGENT_SOCKET"] = sampler_socket
 
       self.sampler_processes[model_id] = subprocess.Popen(
-        [sys.executable, "-u", "-m", "server.vllm_sampler", "--model-id", model_id],
+        _py_cmd(["gpu", "vllm"], "server.vllm_sampler", model_id),
         cwd=self.project_dir,
         env=sampler_env,
       )

--- a/src/server/worker_manager.py
+++ b/src/server/worker_manager.py
@@ -64,7 +64,7 @@ class FFTWorkerManager:
     if proc is not None and proc.poll() is None:
       return
 
-    env = {**os.environ, "OPEN_RL_ENABLE_FFT": "true"}
+    env = {**os.environ, "OPEN_RL_ENABLE_FFT": "true", "OPEN_RL_TIMESLICE_GROUP": "trainers"}
     self.train_processes[model_id] = subprocess.Popen(
       _py_cmd(["gpu"], "server.training_requests_processor", model_id),
       cwd=self.project_dir,
@@ -81,13 +81,10 @@ class FFTWorkerManager:
     if sampling_backend == "vllm":
       sampler_env = env.copy()
       sampler_env["OPEN_RL_MODEL_ID"] = model_id
+      sampler_env["OPEN_RL_TIMESLICE_GROUP"] = "samplers"
       sampler_gpu = os.getenv("SAMPLER_CUDA_VISIBLE_DEVICES")
       if sampler_gpu:
         sampler_env["CUDA_VISIBLE_DEVICES"] = sampler_gpu
-
-      sampler_socket = os.getenv("OPEN_RL_SAMPLER_SNAPSHOT_AGENT_SOCKET")
-      if sampler_socket:
-        sampler_env["OPEN_RL_SNAPSHOT_AGENT_SOCKET"] = sampler_socket
 
       self.sampler_processes[model_id] = subprocess.Popen(
         _py_cmd(["gpu", "vllm"], "server.vllm_sampler", model_id),

--- a/src/snapshot_agent/checkpoint.py
+++ b/src/snapshot_agent/checkpoint.py
@@ -9,10 +9,10 @@ logger = logging.getLogger(__name__)
 
 
 class CheckpointRestorer(Protocol):
-  def checkpoint(self, pid: int) -> None:
+  def checkpoint(self, pid: int | list[int]) -> None:
     pass
 
-  def restore(self, pid: int) -> None:
+  def restore(self, pid: int | list[int]) -> None:
     pass
 
 
@@ -21,22 +21,31 @@ class CudaCheckpointRestorer:
     self.cuda_checkpoint_bin = cuda_checkpoint_bin or os.getenv("CUDA_CHECKPOINT_BIN", "cuda-checkpoint")
     self.timeout_ms = timeout_ms
 
-  def checkpoint(self, pid: int) -> None:
+  def _pid_args(self, pids: int | list[int]) -> list[str]:
+    args = []
+    target_pids = pids if isinstance(pids, list) else [pids]
+    for p in target_pids:
+      args.extend(["--pid", str(p)])
+    return args
+
+  def checkpoint(self, pid: int | list[int]) -> None:
     start = time.perf_counter()
     logger.info("checkpoint pid=%s", pid)
-    lock_args = ["--action", "lock", "--pid", str(pid)]
+    pid_args = self._pid_args(pid)
+    lock_args = ["--action", "lock", *pid_args]
     if self.timeout_ms is not None:
       lock_args.extend(["--timeout", str(self.timeout_ms)])
 
     self.run_cuda_checkpoint(lock_args)
-    self.run_cuda_checkpoint(["--action", "checkpoint", "--pid", str(pid)])
+    self.run_cuda_checkpoint(["--action", "checkpoint", *pid_args])
     logger.info("checkpoint pid=%s took %.0f ms", pid, (time.perf_counter() - start) * 1000)
 
-  def restore(self, pid: int) -> None:
+  def restore(self, pid: int | list[int]) -> None:
     start = time.perf_counter()
     logger.info("restore pid=%s", pid)
-    self.run_cuda_checkpoint(["--action", "restore", "--pid", str(pid)])
-    self.run_cuda_checkpoint(["--action", "unlock", "--pid", str(pid)])
+    pid_args = self._pid_args(pid)
+    self.run_cuda_checkpoint(["--action", "restore", *pid_args])
+    self.run_cuda_checkpoint(["--action", "unlock", *pid_args])
     logger.info("restore pid=%s took %.0f ms", pid, (time.perf_counter() - start) * 1000)
 
   def run_cuda_checkpoint(self, args: list[str]) -> None:

--- a/src/snapshot_agent/client.py
+++ b/src/snapshot_agent/client.py
@@ -10,11 +10,11 @@ DEFAULT_TCP_PORT = 9753
 
 
 class SnapshotClient(Protocol):
-  async def register(self, pid: int) -> dict[str, Any]: ...
+  async def register(self, pid: int, group: str = "default") -> dict[str, Any]: ...
 
-  async def unregister(self, pid: int) -> dict[str, Any]: ...
+  async def unregister(self, pid: int, group: str = "default") -> dict[str, Any]: ...
 
-  def acquire(self, pid: int) -> AbstractAsyncContextManager[None]: ...
+  def acquire(self, pid: int, group: str = "default") -> AbstractAsyncContextManager[None]: ...
 
   async def close(self) -> None: ...
 
@@ -43,19 +43,19 @@ class SnapshotAgentClient:
     self.reader = None
     self.writer = None
 
-  async def register(self, pid: int) -> dict[str, Any]:
-    return await self.request({"command": "REGISTER", "pid": pid})
+  async def register(self, pid: int, group: str = "default") -> dict[str, Any]:
+    return await self.request({"command": "REGISTER", "pid": pid, "group": group})
 
-  async def unregister(self, pid: int) -> dict[str, Any]:
-    return await self.request({"command": "UNREGISTER", "pid": pid})
+  async def unregister(self, pid: int, group: str = "default") -> dict[str, Any]:
+    return await self.request({"command": "UNREGISTER", "pid": pid, "group": group})
 
   @asynccontextmanager
-  async def acquire(self, pid: int) -> AsyncIterator[None]:
-    await self.request({"command": "ACQUIRE", "pid": pid})
+  async def acquire(self, pid: int, group: str = "default") -> AsyncIterator[None]:
+    await self.request({"command": "ACQUIRE", "pid": pid, "group": group})
     try:
       yield
     finally:
-      await self.request({"command": "RELEASE", "pid": pid})
+      await self.request({"command": "RELEASE", "pid": pid, "group": group})
 
   async def request(self, payload: dict[str, Any]) -> dict[str, Any]:
     await self.connect()
@@ -80,14 +80,14 @@ class NoopSnapshotAgentClient:
   async def close(self) -> None:
     pass
 
-  async def register(self, pid: int) -> dict[str, Any]:
-    return {"ok": True, "pid": pid}
+  async def register(self, pid: int, group: str = "default") -> dict[str, Any]:
+    return {"ok": True, "pid": pid, "group": group}
 
-  async def unregister(self, pid: int) -> dict[str, Any]:
-    return {"ok": True, "pid": pid}
+  async def unregister(self, pid: int, group: str = "default") -> dict[str, Any]:
+    return {"ok": True, "pid": pid, "group": group}
 
   @asynccontextmanager
-  async def acquire(self, pid: int) -> AsyncIterator[None]:
+  async def acquire(self, pid: int, group: str = "default") -> AsyncIterator[None]:
     yield
 
 

--- a/src/snapshot_agent/client.py
+++ b/src/snapshot_agent/client.py
@@ -57,6 +57,19 @@ class SnapshotAgentClient:
     finally:
       await self.request({"command": "RELEASE", "pid": pid})
 
+  @asynccontextmanager
+  async def acquire_transferred(self, pid: int) -> AsyncIterator[None]:
+    try:
+      yield
+    finally:
+      await self.request({"command": "RELEASE", "pid": pid})
+
+  async def release(self, pid: int) -> dict[str, Any]:
+    return await self.request({"command": "RELEASE", "pid": pid})
+
+  async def transfer_lock(self, from_pid: int, to_pid: int) -> dict[str, Any]:
+    return await self.request({"command": "TRANSFER_LOCK", "pid": from_pid, "to_pid": to_pid})
+
   async def request(self, payload: dict[str, Any]) -> dict[str, Any]:
     await self.connect()
     assert self.reader is not None

--- a/src/snapshot_agent/client.py
+++ b/src/snapshot_agent/client.py
@@ -57,19 +57,6 @@ class SnapshotAgentClient:
     finally:
       await self.request({"command": "RELEASE", "pid": pid})
 
-  @asynccontextmanager
-  async def acquire_transferred(self, pid: int) -> AsyncIterator[None]:
-    try:
-      yield
-    finally:
-      await self.request({"command": "RELEASE", "pid": pid})
-
-  async def release(self, pid: int) -> dict[str, Any]:
-    return await self.request({"command": "RELEASE", "pid": pid})
-
-  async def transfer_lock(self, from_pid: int, to_pid: int) -> dict[str, Any]:
-    return await self.request({"command": "TRANSFER_LOCK", "pid": from_pid, "to_pid": to_pid})
-
   async def request(self, payload: dict[str, Any]) -> dict[str, Any]:
     await self.connect()
     assert self.reader is not None

--- a/src/snapshot_agent/serve.py
+++ b/src/snapshot_agent/serve.py
@@ -21,7 +21,6 @@ class ProcessRegistration:
   connection_id: int | None
   checkpointed: bool = False
   failed: bool = False
-  transferred_lock: bool = False
 
 
 class SnapshotAgent:
@@ -38,6 +37,43 @@ class SnapshotAgent:
       return "Z" in output
     except Exception:
       return False
+
+  def _has_cuda(self, pid: int) -> bool:
+    try:
+      maps_file = Path(f"/proc/{pid}/maps")
+      if not maps_file.exists():
+        return True
+      content = maps_file.read_text(errors="ignore")
+      return "libcuda" in content or "nvidia" in content
+    except Exception:
+      return True
+
+  def _get_descendants(self, root_pid: int) -> list[int]:
+    try:
+      out = subprocess.check_output(["ps", "-e", "-o", "pid=,ppid="], text=True)
+      children: dict[int, list[int]] = {}
+      for line in out.splitlines():
+        parts = line.split()
+        if len(parts) == 2:
+          p, pp = int(parts[0]), int(parts[1])
+          children.setdefault(pp, []).append(p)
+
+      tree = []
+      queue = deque(children.get(root_pid, []))
+      while queue:
+        curr = queue.popleft()
+        tree.append(curr)
+        queue.extend(children.get(curr, []))
+      return tree
+    except Exception:
+      return []
+
+  def discover_target_pids(self, root_pid: int) -> int | list[int]:
+    if not isinstance(self.restorer, CudaCheckpointRestorer):
+      return root_pid
+    candidates = [root_pid, *self._get_descendants(root_pid)]
+    cuda_pids = [p for p in candidates if self._has_cuda(p)]
+    return sorted(set(cuda_pids)) if cuda_pids else []
 
   def clear_process(self, pid: int) -> None:
     if pid in self.waiting_pids:
@@ -97,27 +133,11 @@ class SnapshotAgent:
       if process is None:
         return {"ok": False, "error": f"pid {pid} is not registered"}
       if self.active_pid != pid:
-        if process.transferred_lock:
-          process.transferred_lock = False
-          return {"ok": True}
         return {"ok": False, "error": f"pid {pid} does not hold an active acquire"}
 
       await self.run_checkpoint(pid)
       process.checkpointed = True
       self.clear_process(pid)
-      self.condition.notify_all()
-      return {"ok": True}
-
-  async def transfer_lock(self, from_pid: int, to_pid: int) -> dict[str, Any]:
-    async with self.condition:
-      if self.active_pid != from_pid:
-        return {"ok": False, "error": f"from_pid {from_pid} does not hold an active acquire"}
-      if to_pid not in self.processes:
-        return {"ok": False, "error": f"to_pid {to_pid} is not registered"}
-
-      logger.info("Transferring active lock from pid %s to pid %s", from_pid, to_pid)
-      self.processes[from_pid].transferred_lock = True
-      self.active_pid = to_pid
       self.condition.notify_all()
       return {"ok": True}
 
@@ -151,8 +171,13 @@ class SnapshotAgent:
         logger.info("process pid %s is already dead, skipping checkpoint", pid)
         return
 
+    targets = self.discover_target_pids(pid)
+    if not targets:
+      logger.info("no CUDA target pids found for root pid %s, skipping checkpoint", pid)
+      return
+
     try:
-      await asyncio.to_thread(self.restorer.checkpoint, pid)
+      await asyncio.to_thread(self.restorer.checkpoint, targets)
       logger.info("checkpointed pid %s in %.2fs", pid, time.monotonic() - start)
     except Exception:
       if isinstance(self.restorer, CudaCheckpointRestorer):
@@ -178,8 +203,13 @@ class SnapshotAgent:
         logger.info("process pid %s is already dead, skipping restore", pid)
         return
 
+    targets = self.discover_target_pids(pid)
+    if not targets:
+      logger.info("no CUDA target pids found for root pid %s, skipping restore", pid)
+      return
+
     try:
-      await asyncio.to_thread(self.restorer.restore, pid)
+      await asyncio.to_thread(self.restorer.restore, targets)
       logger.info("restored pid %s in %.2fs", pid, time.monotonic() - start)
     except Exception:
       if isinstance(self.restorer, CudaCheckpointRestorer):
@@ -235,11 +265,6 @@ async def dispatch(agent: SnapshotAgent, line: bytes, connection_id: int) -> dic
       return await agent.acquire(pid)
     case "RELEASE":
       return await agent.release(pid)
-    case "TRANSFER_LOCK":
-      to_pid = payload.get("to_pid")
-      if to_pid is None:
-        return {"ok": False, "error": "to_pid is required for TRANSFER_LOCK"}
-      return await agent.transfer_lock(pid, int(to_pid))
     case "UNREGISTER":
       return await agent.unregister(pid)
     case _:

--- a/src/snapshot_agent/serve.py
+++ b/src/snapshot_agent/serve.py
@@ -5,8 +5,8 @@ import logging
 import os
 import subprocess
 import time
-from collections import deque
-from dataclasses import dataclass
+from collections import defaultdict, deque
+from dataclasses import dataclass, field
 from functools import partial
 from pathlib import Path
 from typing import Any
@@ -19,17 +19,36 @@ logger = logging.getLogger(__name__)
 @dataclass
 class ProcessRegistration:
   connection_id: int | None
+  group: str = "default"
   checkpointed: bool = False
   failed: bool = False
+
+
+class GroupCoordination:
+  def __init__(self):
+    self.waiting_pids: deque[int] = deque()
+    self.active_pid: int | None = None
+    self.condition: asyncio.Condition | None = None
+
+  def get_condition(self) -> asyncio.Condition:
+    if self.condition is None:
+      self.condition = asyncio.Condition()
+    return self.condition
 
 
 class SnapshotAgent:
   def __init__(self, restorer: CheckpointRestorer):
     self.restorer = restorer
     self.processes: dict[int, ProcessRegistration] = {}
-    self.waiting_pids: deque[int] = deque()
-    self.active_pid: int | None = None
-    self.condition = asyncio.Condition()
+    self.groups: dict[str, GroupCoordination] = defaultdict(GroupCoordination)
+
+  @property
+  def active_pid(self) -> int | None:
+    return self.groups["default"].active_pid
+
+  @property
+  def waiting_pids(self) -> deque[int]:
+    return self.groups["default"].waiting_pids
 
   def _is_zombie(self, pid: int) -> bool:
     try:
@@ -76,93 +95,109 @@ class SnapshotAgent:
     return sorted(set(cuda_pids)) if cuda_pids else []
 
   def clear_process(self, pid: int) -> None:
-    if pid in self.waiting_pids:
-      self.waiting_pids.remove(pid)
-    if self.active_pid == pid:
-      self.active_pid = None
+    proc = self.processes.get(pid)
+    if proc is None:
+      return
+    grp = self.groups[proc.group]
+    if pid in grp.waiting_pids:
+      grp.waiting_pids.remove(pid)
+    if grp.active_pid == pid:
+      grp.active_pid = None
 
-  async def register(self, pid: int, connection_id: int | None = None) -> dict[str, Any]:
-    async with self.condition:
-      process = self.processes.get(pid)
-
-      if process is not None:
+  async def register(self, pid: int, group: str = "default", connection_id: int | None = None) -> dict[str, Any]:
+    grp = self.groups[group]
+    cond = grp.get_condition()
+    async with cond:
+      if pid in self.processes:
         return {"ok": False, "error": f"pid {pid} is already registered"}
 
-      self.processes[pid] = ProcessRegistration(connection_id=connection_id)
-      self.condition.notify_all()
+      self.processes[pid] = ProcessRegistration(connection_id=connection_id, group=group)
+      cond.notify_all()
       return {"ok": True}
 
   async def acquire(self, pid: int) -> dict[str, Any]:
-    async with self.condition:
-      process = self.processes.get(pid)
-      if process is None:
-        return {"ok": False, "error": f"pid {pid} is not registered"}
-      if process.failed:
+    proc = self.processes.get(pid)
+    if proc is None:
+      return {"ok": False, "error": f"pid {pid} is not registered"}
+    group = proc.group
+    grp = self.groups[group]
+    cond = grp.get_condition()
+    async with cond:
+      if proc.failed:
         return {"ok": False, "error": f"pid {pid} is failed"}
-      if pid in self.waiting_pids or self.active_pid == pid:
+      if pid in grp.waiting_pids or grp.active_pid == pid:
         return {"ok": False, "error": f"pid {pid} already has a pending or active acquire"}
 
-      self.waiting_pids.append(pid)
+      grp.waiting_pids.append(pid)
       try:
-        while self.active_pid is not None or (pid in self.waiting_pids and self.waiting_pids[0] != pid):
-          await self.condition.wait()
+        while grp.active_pid is not None or (pid in grp.waiting_pids and grp.waiting_pids[0] != pid):
+          await cond.wait()
       except BaseException:
-        if pid in self.waiting_pids:
-          self.waiting_pids.remove(pid)
-        self.condition.notify_all()
+        if pid in grp.waiting_pids:
+          grp.waiting_pids.remove(pid)
+        cond.notify_all()
         raise
 
-      process = self.processes.get(pid)
-      if process is None or process.failed or pid not in self.waiting_pids:
+      proc = self.processes.get(pid)
+      if proc is None or proc.failed or pid not in grp.waiting_pids:
         self.clear_process(pid)
-        self.condition.notify_all()
+        cond.notify_all()
         return {"ok": False, "error": f"pid {pid} is not available"}
 
-      self.waiting_pids.popleft()
-      self.active_pid = pid
-      if process.checkpointed:
-        await self.run_restore(pid)
-        process.checkpointed = False
+      grp.waiting_pids.popleft()
+      grp.active_pid = pid
+      if proc.checkpointed:
+        await self.run_restore(pid, group=group)
+        proc.checkpointed = False
 
-      self.condition.notify_all()
+      cond.notify_all()
       return {"ok": True}
 
   async def release(self, pid: int) -> dict[str, Any]:
-    async with self.condition:
-      process = self.processes.get(pid)
-      if process is None:
-        return {"ok": False, "error": f"pid {pid} is not registered"}
-      if self.active_pid != pid:
+    proc = self.processes.get(pid)
+    if proc is None:
+      return {"ok": False, "error": f"pid {pid} is not registered"}
+    group = proc.group
+    grp = self.groups[group]
+    cond = grp.get_condition()
+    async with cond:
+      if grp.active_pid != pid:
         return {"ok": False, "error": f"pid {pid} does not hold an active acquire"}
 
-      await self.run_checkpoint(pid)
-      process.checkpointed = True
+      await self.run_checkpoint(pid, group=group)
+      proc.checkpointed = True
       self.clear_process(pid)
-      self.condition.notify_all()
+      cond.notify_all()
       return {"ok": True}
 
   async def unregister(self, pid: int) -> dict[str, Any]:
-    async with self.condition:
-      if pid not in self.processes:
-        return {"ok": False, "error": f"pid {pid} is not registered"}
-
+    proc = self.processes.get(pid)
+    if proc is None:
+      return {"ok": False, "error": f"pid {pid} is not registered"}
+    group = proc.group
+    grp = self.groups[group]
+    cond = grp.get_condition()
+    async with cond:
       self.clear_process(pid)
       del self.processes[pid]
-      self.condition.notify_all()
+      cond.notify_all()
       return {"ok": True}
 
   async def connection_closed(self, connection_id: int) -> None:
-    async with self.condition:
-      for pid, process in self.processes.items():
-        if process.connection_id != connection_id:
-          continue
+    for pid, proc in list(self.processes.items()):
+      if proc.connection_id != connection_id:
+        continue
+      group = proc.group
+      grp = self.groups[group]
+      cond = grp.get_condition()
+      async with cond:
         self.clear_process(pid)
-        process.failed = True
-        process.checkpointed = False
-        process.connection_id = None
-      self.condition.notify_all()
+        proc.failed = True
+        proc.checkpointed = False
+        proc.connection_id = None
+        cond.notify_all()
 
-  async def run_checkpoint(self, pid: int) -> None:
+  async def run_checkpoint(self, pid: int, group: str = "default") -> None:
     start = time.monotonic()
     if isinstance(self.restorer, CudaCheckpointRestorer):
       try:
@@ -178,7 +213,7 @@ class SnapshotAgent:
 
     try:
       await asyncio.to_thread(self.restorer.checkpoint, targets)
-      logger.info("checkpointed pid %s in %.2fs", pid, time.monotonic() - start)
+      logger.info("checkpointed pid %s (group %s) in %.2fs", pid, group, time.monotonic() - start)
     except Exception:
       if isinstance(self.restorer, CudaCheckpointRestorer):
         try:
@@ -194,7 +229,7 @@ class SnapshotAgent:
       )
       os._exit(1)
 
-  async def run_restore(self, pid: int) -> None:
+  async def run_restore(self, pid: int, group: str = "default") -> None:
     start = time.monotonic()
     if isinstance(self.restorer, CudaCheckpointRestorer):
       try:
@@ -210,7 +245,7 @@ class SnapshotAgent:
 
     try:
       await asyncio.to_thread(self.restorer.restore, targets)
-      logger.info("restored pid %s in %.2fs", pid, time.monotonic() - start)
+      logger.info("restored pid %s (group %s) in %.2fs", pid, group, time.monotonic() - start)
     except Exception:
       if isinstance(self.restorer, CudaCheckpointRestorer):
         try:
@@ -257,10 +292,11 @@ async def dispatch(agent: SnapshotAgent, line: bytes, connection_id: int) -> dic
 
   assert pid is not None, "pid is required"
   pid = int(pid)
+  group = payload.get("group", "default")
 
   match command:
     case "REGISTER":
-      return await agent.register(pid, connection_id=connection_id)
+      return await agent.register(pid, group=group, connection_id=connection_id)
     case "ACQUIRE":
       return await agent.acquire(pid)
     case "RELEASE":

--- a/src/snapshot_agent/serve.py
+++ b/src/snapshot_agent/serve.py
@@ -3,6 +3,7 @@ import asyncio
 import json
 import logging
 import os
+import subprocess
 import time
 from collections import deque
 from dataclasses import dataclass
@@ -20,6 +21,7 @@ class ProcessRegistration:
   connection_id: int | None
   checkpointed: bool = False
   failed: bool = False
+  transferred_lock: bool = False
 
 
 class SnapshotAgent:
@@ -29,6 +31,13 @@ class SnapshotAgent:
     self.waiting_pids: deque[int] = deque()
     self.active_pid: int | None = None
     self.condition = asyncio.Condition()
+
+  def _is_zombie(self, pid: int) -> bool:
+    try:
+      output = subprocess.check_output(["ps", "-p", str(pid), "-o", "state="], text=True)
+      return "Z" in output
+    except Exception:
+      return False
 
   def clear_process(self, pid: int) -> None:
     if pid in self.waiting_pids:
@@ -88,11 +97,27 @@ class SnapshotAgent:
       if process is None:
         return {"ok": False, "error": f"pid {pid} is not registered"}
       if self.active_pid != pid:
+        if process.transferred_lock:
+          process.transferred_lock = False
+          return {"ok": True}
         return {"ok": False, "error": f"pid {pid} does not hold an active acquire"}
 
       await self.run_checkpoint(pid)
       process.checkpointed = True
       self.clear_process(pid)
+      self.condition.notify_all()
+      return {"ok": True}
+
+  async def transfer_lock(self, from_pid: int, to_pid: int) -> dict[str, Any]:
+    async with self.condition:
+      if self.active_pid != from_pid:
+        return {"ok": False, "error": f"from_pid {from_pid} does not hold an active acquire"}
+      if to_pid not in self.processes:
+        return {"ok": False, "error": f"to_pid {to_pid} is not registered"}
+
+      logger.info("Transferring active lock from pid %s to pid %s", from_pid, to_pid)
+      self.processes[from_pid].transferred_lock = True
+      self.active_pid = to_pid
       self.condition.notify_all()
       return {"ok": True}
 
@@ -119,10 +144,26 @@ class SnapshotAgent:
 
   async def run_checkpoint(self, pid: int) -> None:
     start = time.monotonic()
+    if isinstance(self.restorer, CudaCheckpointRestorer):
+      try:
+        os.kill(pid, 0)
+      except OSError:
+        logger.info("process pid %s is already dead, skipping checkpoint", pid)
+        return
+
     try:
       await asyncio.to_thread(self.restorer.checkpoint, pid)
       logger.info("checkpointed pid %s in %.2fs", pid, time.monotonic() - start)
     except Exception:
+      if isinstance(self.restorer, CudaCheckpointRestorer):
+        try:
+          os.kill(pid, 0)
+          if self._is_zombie(pid):
+            logger.info("process pid %s is a zombie during checkpoint, skipping failure exit", pid)
+            return
+        except OSError:
+          logger.info("process pid %s died during checkpoint, skipping failure exit", pid)
+          return
       logger.critical(
         "checkpoint failed for pid %s after %.2fs; GPU state is unknown, killing snapshot agent", pid, time.monotonic() - start, exc_info=True
       )
@@ -130,10 +171,23 @@ class SnapshotAgent:
 
   async def run_restore(self, pid: int) -> None:
     start = time.monotonic()
+    if isinstance(self.restorer, CudaCheckpointRestorer):
+      try:
+        os.kill(pid, 0)
+      except OSError:
+        logger.info("process pid %s is already dead, skipping restore", pid)
+        return
+
     try:
       await asyncio.to_thread(self.restorer.restore, pid)
       logger.info("restored pid %s in %.2fs", pid, time.monotonic() - start)
     except Exception:
+      if isinstance(self.restorer, CudaCheckpointRestorer):
+        try:
+          os.kill(pid, 0)
+        except OSError:
+          logger.info("process pid %s died during restore, skipping failure exit", pid)
+          return
       logger.critical(
         "restore failed for pid %s after %.2fs; GPU state is unknown, killing snapshot agent", pid, time.monotonic() - start, exc_info=True
       )
@@ -181,6 +235,11 @@ async def dispatch(agent: SnapshotAgent, line: bytes, connection_id: int) -> dic
       return await agent.acquire(pid)
     case "RELEASE":
       return await agent.release(pid)
+    case "TRANSFER_LOCK":
+      to_pid = payload.get("to_pid")
+      if to_pid is None:
+        return {"ok": False, "error": "to_pid is required for TRANSFER_LOCK"}
+      return await agent.transfer_lock(pid, int(to_pid))
     case "UNREGISTER":
       return await agent.unregister(pid)
     case _:

--- a/src/snapshot_agent/serve.py
+++ b/src/snapshot_agent/serve.py
@@ -6,7 +6,7 @@ import os
 import subprocess
 import time
 from collections import defaultdict, deque
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from functools import partial
 from pathlib import Path
 from typing import Any

--- a/tests/test_trainer_optimizer_correctness.py
+++ b/tests/test_trainer_optimizer_correctness.py
@@ -179,20 +179,20 @@ class _SnapshotClientStub:
   def __init__(self):
     self.events = []
 
-  async def register(self, pid):
-    self.events.append(("register", pid))
+  async def register(self, pid, group="default"):
+    self.events.append(("register", pid, group))
     return {"ok": True}
 
   @asynccontextmanager
-  async def acquire(self, pid):
-    self.events.append(("acquire", pid))
+  async def acquire(self, pid, group="default"):
+    self.events.append(("acquire", pid, group))
     try:
       yield
     finally:
-      self.events.append(("release", pid))
+      self.events.append(("release", pid, group))
 
-  async def unregister(self, pid):
-    self.events.append(("unregister", pid))
+  async def unregister(self, pid, group="default"):
+    self.events.append(("unregister", pid, group))
     return {"ok": True}
 
   async def close(self):

--- a/tests/test_worker_manager.py
+++ b/tests/test_worker_manager.py
@@ -28,6 +28,12 @@ class WorkerManagerStub:
     if self.error is not None:
       raise self.error
 
+  def launch_trainer(self, model_id: str) -> None:
+    self.launch(model_id)
+
+  def launch_sampler(self, model_id: str) -> None:
+    self.launch(model_id)
+
   def shutdown(self, model_id: str) -> None:
     self.shutdown_model_ids.append(model_id)
 


### PR DESCRIPTION
### Executive Summary
This PR implements a complete, decoupled queue-based inference architecture for Full Fine-Tuning (FFT) Reinforcement Learning in the Open-RL framework. It adapts dedicated vLLM sampler processes per job to share a single GPU transparently via Snapshot Agent time-sliced multiplexing, adds extreme performance optimizations for preemption latency, coordinates startup serialization to prevent CUDA Out of Memory (OOM) errors, and integrates cleanly with the new `WorkerManager` / `K8sWorkerManager` lifecycle.

---

### Key Architectural Pillars & Features

#### 1. Decoupled On-Demand Worker Provisioning (`src/server/worker_manager.py`, `src/server/k8s_worker_manager.py`)
- **Control Plane Decoupling**: Extended `WorkerManager` to track trainer and sampler worker lifecycles independently (`launch_trainer` vs. `launch_sampler`).
- **On-Demand Sampler Provisioning**: 
  - PyTorch trainers are provisioned when a job initializes (`create_model`).
  - vLLM samplers are provisioned **on demand** precisely when weights are snapshotted and sampling clients are requested (`create_sampling_session` / `save_weights_for_sampler`).
  - The worker managers reuse running sampler subprocesses across iterative RL training steps via liveness checks, eliminating process churn.

#### 2. Redis Pull Sampler with Dynamic Weight Reloading (`src/server/vllm_sampler.py`, `src/server/store.py`)
- Replaces synchronous gateway push IPC with a headless pull loop draining tenant Redis data queues (`open_rl:sampler_queue:<model_id>`).
- Implements in-place weights reloading utilizing **vLLM Level 2 Sleep Mode**:
  1. Detects target checkpoint path updates (`weights_path`).
  2. Invokes `engine.sleep(level=2)` to discard active weights and KV caches, freeing ~85% of GPU memory.
  3. Reloads the Safetensors checkpoint in-place via `engine.collective_rpc("reload_weights")` and initializes a clean KV cache pool.

#### 3. Inter-Job GPU Multiplexing & 28x Preemption Speedup (`src/server/vllm_sampler.py`, `src/snapshot_agent/serve.py`)
- Coordinates turn-taking across concurrent jobs ($N \ge 2$) using isolated Snapshot Agent socket/TCP daemons (`trainers` vs `samplers`).
- **VRAM Pre-Release Optimization**:
  - Before yielding the GPU lock at the end of a request batch, the sampler calls `engine.sleep(level=2)` to purge active VRAM down to near 0 MiB.
  - Consequently, `cuda-checkpoint` preemption dump latency drops from **`~14.0s`** down to **`~0.5s`** (a 28x speedup).

#### 4. Coordinated Startup Serialization via `TRANSFER_LOCK` (`src/snapshot_agent/serve.py`, `src/snapshot_agent/client.py`)
- Prevents simultaneous initialization OOM crashes (where KV cache / CUDA graph captures allocate up to 70% VRAM):
  1. The Python parent worker acquires the GPU lock from the Snapshot Agent.
  2. Under the lock, it initializes the engine.
  3. Once initialized, it resolves the spawned child `EngineCore` PID and calls **`TRANSFER_LOCK`** to transfer active lock ownership to the child PID.
  4. The parent exits cleanly (treated as a successful no-op on the daemon), and the child is trigger-checkpointed (`RELEASE`) to free VRAM for concurrent waiting workers.

#### 5. Graceful Poison-Pill Teardown & Resiliency (`src/server/training_requests_processor.py`, `src/server/gateway.py`)
- **Poison Pill Sentinel**: When a model is deleted (`delete_model`), a `SHUTDOWN_SENTINEL` is pushed to data queues. Workers drain all pending batches before exiting.
- **Fail-Safe Process Termination**: Uses `os._exit()` inside worker loops to avoid native CUDA/PyTorch finalizer segfaults on exit.
- **Zombie Handling**: Modified Snapshot Agent daemons to check OS process liveness and ignore dead/zombie processes during teardowns without crashing.

---

### Verification & Test Results
- **Unit Tests**: Full suite passing across all worker managers, gateway routing, and Snapshot Agent TCP/socket modes (`python -m unittest discover tests`).
- **E2E Concurrent GPU Verification**: Executed concurrent `tiny-fft-rl-x2` scenarios (with 5 and 10 steps) on remote L4 targets (`b21`). Both jobs serialized startups cleanly, interleaved rollout/training steps across GPU boundaries, and shut down with **zero OOMs** and **zero deadlocks**.
- **Upstream Rebase**: Branch cleanly rebased onto latest `upstream/main` (incorporating upstream `#123`).
