### PR TITLE
k8s: deploy into dedicated openrl-system namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ deploy:
 	kubectl apply -k k8s/deploy/distributed-lustre/
 
 rollout:
-	kubectl rollout restart deployment redis-store open-rl-gateway open-rl-trainer-worker vllm-worker
+	kubectl rollout restart deployment redis-store open-rl-gateway open-rl-trainer-worker vllm-worker -n openrl-system
 
 # Local Redis (for testing distributed mode):
 #   sudo apt install redis-server && sudo service redis-server start

--- a/examples/autoresearch/recipes/math_rl/gke/kustomization.yaml
+++ b/examples/autoresearch/recipes/math_rl/gke/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+namespace: openrl-system
+
 resources:
 - ../../../../../k8s/deploy/distributed-shared
 - autoresearch

--- a/k8s/deploy/distributed-lustre/00-namespace.yaml
+++ b/k8s/deploy/distributed-lustre/00-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openrl-system

--- a/k8s/deploy/distributed-lustre/04-gateway.yaml
+++ b/k8s/deploy/distributed-lustre/04-gateway.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: open-rl-sa
-  namespace: default
 ---
 apiVersion: v1
 kind: Service

--- a/k8s/deploy/distributed-lustre/kustomization.yaml
+++ b/k8s/deploy/distributed-lustre/kustomization.yaml
@@ -1,7 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+namespace: openrl-system
+
 resources:
+  - 00-namespace.yaml
   - 01-lustre-pvc.yaml
   - 02-redis.yaml
   - 03-vllm.yaml

--- a/k8s/deploy/distributed-shared/00-namespace.yaml
+++ b/k8s/deploy/distributed-shared/00-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openrl-system

--- a/k8s/deploy/distributed-shared/04-gateway.yaml
+++ b/k8s/deploy/distributed-shared/04-gateway.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: open-rl-sa
-  namespace: default
 ---
 apiVersion: v1
 kind: Service

--- a/k8s/deploy/distributed-shared/kustomization.yaml
+++ b/k8s/deploy/distributed-shared/kustomization.yaml
@@ -1,7 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+namespace: openrl-system
+
 resources:
+  - 00-namespace.yaml
   - 01-shared-pvc.yaml
   - 02-redis.yaml
   - 03-vllm.yaml

--- a/k8s/deploy/single-process-gke/00-namespace.yaml
+++ b/k8s/deploy/single-process-gke/00-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openrl-system

--- a/k8s/deploy/single-process-gke/02-serviceaccount.yaml
+++ b/k8s/deploy/single-process-gke/02-serviceaccount.yaml
@@ -2,4 +2,3 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: open-rl-single-sa
-  namespace: default

--- a/k8s/deploy/single-process-gke/kustomization.yaml
+++ b/k8s/deploy/single-process-gke/kustomization.yaml
@@ -1,7 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+namespace: openrl-system
+
 resources:
+  - 00-namespace.yaml
   - 01-pvc.yaml
   - 02-serviceaccount.yaml
   - 03-service.yaml


### PR DESCRIPTION
Closes #86.

Moves the deploy stack out of the `default` namespace into a dedicated `openrl-system` namespace, as requested in #86.

## Changes

- Add a `Namespace` resource (`00-namespace.yaml`) to each deploy variant (`single-process-gke`, `distributed-shared`, `distributed-lustre`) and list it first, so `kubectl apply -k` creates the namespace before the resources that go into it.
- Set `namespace: openrl-system` in each variant's `kustomization.yaml`. Kustomize's namespace transformer scopes every workload into it and leaves the cluster-scoped `Namespace` object alone, so the existing manifests need no per-resource edits.
- Drop the now-redundant hardcoded `namespace: default` from the gateway and single-process service accounts.
- Point the `rollout` Makefile target at `-n openrl-system`.
- Set `namespace: openrl-system` on the `examples/autoresearch/recipes/math_rl/gke` overlay too. That overlay composes the `distributed-shared` base; without this, the base resources would move to `openrl-system` while the overlay's own resources stayed in `default`, splitting the example across namespaces and breaking the in-namespace service DNS it relies on (`http://open-rl-gateway-service:8000`, etc.).

## Verification

Rendered locally with `kustomize build` (v5.4.3):

- All three deploy variants: every workload carries `namespace: openrl-system`, the `Namespace` object is emitted first, and no resource remains in `default`.
- The `math_rl/gke` overlay: with the overlay namespace set, all namespaced resources (distributed-shared base plus the autoresearch resources) land in `openrl-system`; none stay in `default`.
- `grep 'namespace: default'` over the rendered output of all four targets is empty.
