### PR TITLE
fixes: minor fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ env/
 # Training Logs & Plots
 scratch/
 docs/scratch/
+VERSION
 *.txt
 *.png
 *.log

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,11 @@ E2E tests boot up a local backend and run actual SFT/RL training against it. Run
 ```bash
 make test e2e <scenario_name>
 ```
+An example command for running end to end test:
+```
+pkill -9 -f port-forward 2>/dev/null; nohup sh -c '\''while true; do kubectl port-forward svc/open-rl-gateway-service 8000:8000 >/dev/null 2>&1; sleep 1; done'\'' >/dev/null 2>&1 & make test e2e fft-gsm8k-rl BASE_URL=http://127.0.0.1:8000
+```
+
 
 ### Supported Scenarios:
 - **`tiny-lora`**: Minimal overfit test using LoRA (asserts that loss drops).

--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,7 @@ test:
 	  fi; \
 	  set -- "scenario=$$scenario" "uv_extra=$(TRAINING_TEST_EXTRA)"; \
 	  if [ -n "$(TRAINING_TEST_BASE_URL)" ]; then set -- "$$@" "base_url=$(TRAINING_TEST_BASE_URL)"; fi; \
+	  kubectl delete pods -l snapshot-agent=true --force --grace-period=0 2>/dev/null || true; \
 	  uv run --extra "$(TRAINING_TEST_EXTRA)" python scripts/run_training_e2e.py "$$@" $(TRAINING_TEST_ARGS); \
 	elif [ "$$mode" = "piglatin" ]; then \
 	  PYTHONPATH="$(PIGLATIN_TEST_PYTHONPATH)" uv --project examples run python -m unittest tests.test_piglatin_qwen tests.test_piglatin_gemma; \
@@ -113,7 +114,7 @@ fmt:
 # Deployment (GKE)
 # ---------------------------------------------------------------------------
 GCP_PROJECT ?= cdrollouts-sunilarora
-IMAGE_TAG   ?= latest
+IMAGE_TAG   ?= $(shell git rev-parse --short HEAD 2>/dev/null || cat VERSION 2>/dev/null || echo latest)
 
 build-images:
 	DOCKER_BUILDKIT=1 docker build -t gcr.io/$(GCP_PROJECT)/open-rl-server:$(IMAGE_TAG) -f src/server/Dockerfile .
@@ -122,6 +123,9 @@ build-images:
 push-images:
 	docker push gcr.io/$(GCP_PROJECT)/open-rl-server:$(IMAGE_TAG)
 	docker push gcr.io/$(GCP_PROJECT)/open-rl-gateway:$(IMAGE_TAG)
+	kubectl set image deployment/open-rl-gateway gateway=gcr.io/$(GCP_PROJECT)/open-rl-gateway:$(IMAGE_TAG) 2>/dev/null || true
+	kubectl set image daemonset/open-rl-snapshot-agent snapshot-agent=gcr.io/$(GCP_PROJECT)/open-rl-server:$(IMAGE_TAG) 2>/dev/null || true
+	kubectl set env deployment/open-rl-gateway OPEN_RL_WORKER_IMAGE=gcr.io/$(GCP_PROJECT)/open-rl-server:$(IMAGE_TAG) 2>/dev/null || true
 
 deploy:
 	kubectl apply -k k8s/deploy/distributed-lustre/
@@ -169,6 +173,7 @@ REMOTE_HOST ?= <PLACE_HOLDER_FOR_REMOTE_HOST_ADDRESS>
 
 # Push local workspace changes to the remote VM
 push-vm:
+	@git rev-parse --short HEAD > VERSION 2>/dev/null || true
 	rsync -avz --exclude '.git' --exclude '.venv' --exclude '__pycache__' --exclude '*.pyc' --exclude '.DS_Store' --exclude 'scratch' ./ $(REMOTE_HOST):~/open-rl
 
 # Pull changes from the remote VM back to the local workspace

--- a/docs/setup/gke-fft-timeslice.md
+++ b/docs/setup/gke-fft-timeslice.md
@@ -265,6 +265,38 @@ Notes:
   plugin's [time-slicing config](https://github.com/NVIDIA/k8s-device-plugin#shared-access-to-gpus-with-cuda-time-slicing)
   (`replicas: 2`) plus the node label.
 
+## Setup 1.5: Install and deploy llm-d Snapshot Agent DaemonSet
+
+Because `open-rl-snapshot-agent` runs with `--backend llmd` in cluster deployments, it delegates physical kernel-level CUDA process freezing and unfreezing (`cuda-checkpoint`) to `llmd-snapshot-agent` over gRPC on `127.0.0.1:9001`.
+
+To build and deploy the official `llmd-snapshot-agent` DaemonSet on GPU nodes:
+
+1. **Clone the official `llm-d-rl-time-slicing` repository:**
+   ```bash
+   git clone https://github.com/llm-d-incubation/llm-d-rl-time-slicing.git ~/.cache/checkouts/github.com/llm-d-incubation/llm-d-rl-time-slicing
+   cd ~/.cache/checkouts/github.com/llm-d-incubation/llm-d-rl-time-slicing
+   ```
+
+2. **Build and push the Go Daemon container image:**
+   *(Note: The Dockerfile requires a pre-built `bin/` directory. Ensure `bin/` exists before running Docker build).*
+   ```bash
+   mkdir -p bin/
+   DOCKER_BUILDKIT=1 docker build -t gcr.io/<YOUR_GCP_PROJECT>/llmd-snapshot-agent:latest -f deploy/snapshot-agent/Dockerfile .
+   docker push gcr.io/<YOUR_GCP_PROJECT>/llmd-snapshot-agent:latest
+   ```
+
+3. **Deploy the Helm Chart into `timeslice-system`:**
+   ```bash
+   helm template snapshot-agent deploy/snapshot-agent/ \
+     --namespace timeslice-system \
+     --set image.repository=gcr.io/<YOUR_GCP_PROJECT>/llmd-snapshot-agent \
+     --set image.tag=latest \
+     --set tolerations[0].key=nvidia.com/gpu \
+     --set tolerations[0].operator=Exists \
+     --set tolerations[0].effect=NoSchedule | kubectl apply -f -
+   ```
+   Verify both DaemonSet Pods (`llmd-snapshot-agent-*`) transition to `Running` and actively listen on TCP `9001` across all target GPU nodes.
+
 ## Setup 2: Build, push, and deploy OpenRL
 
 ```bash

--- a/examples/sft/gsm8k/gsm8k_sft.py
+++ b/examples/sft/gsm8k/gsm8k_sft.py
@@ -40,8 +40,8 @@ class GSM8KDataset(SupervisedDatasetBuilder):
 
     eval_dataset = load_dataset("openai/gsm8k", "main", split="test[:16]")
     return (
-        SupervisedDatasetFromHFDataset(dataset, self.batch_size, map_fn=make_datum),
-        SupervisedDatasetFromHFDataset(eval_dataset, self.batch_size, map_fn=make_datum),
+      SupervisedDatasetFromHFDataset(dataset, self.batch_size, map_fn=make_datum),
+      SupervisedDatasetFromHFDataset(eval_dataset, self.batch_size, map_fn=make_datum),
     )
 
 

--- a/examples/sft/gsm8k/gsm8k_sft.py
+++ b/examples/sft/gsm8k/gsm8k_sft.py
@@ -38,7 +38,11 @@ class GSM8KDataset(SupervisedDatasetBuilder):
         loss_fn_inputs=cast(Any, {"target_tokens": tokens[1:], "weights": [float(w) for w in weights[1:]]}),
       )
 
-    return SupervisedDatasetFromHFDataset(dataset, self.batch_size, map_fn=make_datum), None
+    eval_dataset = load_dataset("openai/gsm8k", "main", split="test[:16]")
+    return (
+        SupervisedDatasetFromHFDataset(dataset, self.batch_size, map_fn=make_datum),
+        SupervisedDatasetFromHFDataset(eval_dataset, self.batch_size, map_fn=make_datum),
+    )
 
 
 @chz.chz
@@ -52,8 +56,9 @@ class Config:
   rank: int = 32
   max_len: int = 640
   seed: int = 0
-  max_steps: int | None = None
+  max_steps: int | None = 10
   save_every: int = 0
+  eval_every: int = 5
   behavior_if_log_dir_exists: cli_utils.LogdirBehavior = "delete"
 
 
@@ -76,7 +81,7 @@ def main(config: Config) -> None:
         lora_rank=config.rank,
         base_url=config.base_url,
         save_every=config.save_every,
-        eval_every=0,
+        eval_every=config.eval_every,
         infrequent_eval_every=0,
         max_steps=config.max_steps,
       )
@@ -87,8 +92,6 @@ def main(config: Config) -> None:
     checkpoint = checkpoint_utils.get_last_checkpoint(config.log_path, required_key="state_path")
   if checkpoint is not None:
     path = checkpoint.sampler_path or checkpoint.state_path
-    if path and path.startswith("tinker://"):
-      path = str(Path(os.getenv("OPEN_RL_TMP_DIR", "/tmp/open-rl")) / "sampler_full" / path.removeprefix("tinker://"))
     if path:
       print(f"eval_model_path={path}")
 

--- a/examples/sft/gsm8k/vllm_eval.py
+++ b/examples/sft/gsm8k/vllm_eval.py
@@ -22,43 +22,59 @@ def main() -> None:
   from tinker_cookbook.tokenizer_utils import get_tokenizer
 
   parser = argparse.ArgumentParser()
-  parser.add_argument("--path", required=True)
+  parser.add_argument("--path", required=True, action="append", help="One or more URI paths to evaluate concurrently")
   parser.add_argument("--base-model", default="Qwen/Qwen2.5-0.5B")
   parser.add_argument("--base-url", default=os.getenv("TINKER_BASE_URL", os.getenv("BASE_URL", "http://127.0.0.1:8000")))
   parser.add_argument("--data", default="gsm8k_test.json")
   parser.add_argument("--gpu-memory-utilization", type=float, default=0.85)
+  parser.add_argument("--microbatch-size", type=int, default=10, help="Number of evaluation problems to dispatch per micro-batch")
   parser.add_argument("--min-accuracy", type=float, default=0.0, help="exit nonzero if accuracy falls below this fraction")
   args = parser.parse_args()
 
   with open(args.data) as f:
     data = json.load(f)
 
+  paths = args.path if isinstance(args.path, list) else [args.path]
   client = ServiceClient(api_key=os.getenv("TINKER_API_KEY", "tml-dummy-key"), base_url=args.base_url)
-  sampler = client.create_sampling_client(args.path)
+  samplers = [client.create_sampling_client(p) for p in paths]
   tokenizer = get_tokenizer(args.base_model)
 
   sampling_params = types.SamplingParams(temperature=0.0, max_tokens=256)
   start = time.time()
-  
-  outputs = []
-  for datum in data:
-    prompt_tokens = tokenizer.encode(datum["prompt"], add_special_tokens=False)
-    seqs = sampler.sample(
-        prompt=types.ModelInput.from_ints(tokens=prompt_tokens),
-        num_samples=1,
-        sampling_params=sampling_params,
-    ).result().sequences
-    outputs.append(tokenizer.decode(seqs[0].tokens) if seqs else "")
+
+  import asyncio
+
+  async def run_evals():
+    outputs_by_sampler = [[] for _ in paths]
+    batch_size = args.microbatch_size
+    for i in range(0, len(data), batch_size):
+      chunk = data[i : i + batch_size]
+      for s_idx, sampler in enumerate(samplers):
+        tasks = [
+          sampler.sample_async(
+            prompt=types.ModelInput.from_ints(tokens=tokenizer.encode(datum["prompt"], add_special_tokens=False)),
+            num_samples=1,
+            sampling_params=sampling_params,
+          )
+          for datum in chunk
+        ]
+        res_list = await asyncio.gather(*tasks)
+        for res in res_list:
+          seqs = res.sequences
+          outputs_by_sampler[s_idx].append(tokenizer.decode(seqs[0].tokens) if seqs else "")
+    return outputs_by_sampler
+
+  outputs_by_sampler = asyncio.run(run_evals())
 
   elapsed = time.time() - start
-  correct = sum(int(extract(text) == datum["gold"]) for datum, text in zip(data, outputs, strict=True))
-  accuracy = correct / len(data)
-
-  print("***************************************************************")
-  print(f"[SAMPLER] {args.path} 0-shot GSM8K acc = {accuracy:.1%} on {len(data)} problems in {elapsed:.1f}s")
-  print("***************************************************************")
-  if accuracy < args.min_accuracy:
-    raise SystemExit(f"GSM8K accuracy {accuracy:.1%} is below the required {args.min_accuracy:.1%}")
+  for path, outputs in zip(paths, outputs_by_sampler, strict=True):
+    correct = sum(int(extract(text) == datum["gold"]) for datum, text in zip(data, outputs, strict=True))
+    accuracy = correct / len(data)
+    print("***************************************************************")
+    print(f"[SAMPLER] {path} 0-shot GSM8K acc = {accuracy:.1%} on {len(data)} problems in {elapsed:.1f}s")
+    print("***************************************************************")
+    if accuracy < args.min_accuracy:
+      raise SystemExit(f"GSM8K accuracy {accuracy:.1%} for {path} is below the required {args.min_accuracy:.1%}")
 
 
 if __name__ == "__main__":

--- a/examples/sft/gsm8k/vllm_eval.py
+++ b/examples/sft/gsm8k/vllm_eval.py
@@ -1,5 +1,6 @@
 import argparse
 import json
+import os
 import re
 import time
 
@@ -17,10 +18,13 @@ def extract(text: str) -> str | None:
 
 
 def main() -> None:
-  from vllm import LLM, SamplingParams
+  from tinker import ServiceClient, types
+  from tinker_cookbook.tokenizer_utils import get_tokenizer
 
   parser = argparse.ArgumentParser()
   parser.add_argument("--path", required=True)
+  parser.add_argument("--base-model", default="Qwen/Qwen2.5-0.5B")
+  parser.add_argument("--base-url", default=os.getenv("TINKER_BASE_URL", os.getenv("BASE_URL", "http://127.0.0.1:8000")))
   parser.add_argument("--data", default="gsm8k_test.json")
   parser.add_argument("--gpu-memory-utilization", type=float, default=0.85)
   parser.add_argument("--min-accuracy", type=float, default=0.0, help="exit nonzero if accuracy falls below this fraction")
@@ -29,22 +33,29 @@ def main() -> None:
   with open(args.data) as f:
     data = json.load(f)
 
-  llm = LLM(
-    model=args.path,
-    dtype="bfloat16",
-    gpu_memory_utilization=args.gpu_memory_utilization,
-    max_model_len=1024,
-    enforce_eager=True,
-  )
-  sampling_params = SamplingParams(temperature=0.0, max_tokens=256, stop=["\nQuestion:"])
+  client = ServiceClient(api_key=os.getenv("TINKER_API_KEY", "tml-dummy-key"), base_url=args.base_url)
+  sampler = client.create_sampling_client(args.path)
+  tokenizer = get_tokenizer(args.base_model)
+
+  sampling_params = types.SamplingParams(temperature=0.0, max_tokens=256)
   start = time.time()
-  outputs = llm.generate([datum["prompt"] for datum in data], sampling_params)
+  
+  outputs = []
+  for datum in data:
+    prompt_tokens = tokenizer.encode(datum["prompt"], add_special_tokens=False)
+    seqs = sampler.sample(
+        prompt=types.ModelInput.from_ints(tokens=prompt_tokens),
+        num_samples=1,
+        sampling_params=sampling_params,
+    ).result().sequences
+    outputs.append(tokenizer.decode(seqs[0].tokens) if seqs else "")
+
   elapsed = time.time() - start
-  correct = sum(int(extract(output.outputs[0].text) == datum["gold"]) for datum, output in zip(data, outputs, strict=True))
+  correct = sum(int(extract(text) == datum["gold"]) for datum, text in zip(data, outputs, strict=True))
   accuracy = correct / len(data)
 
   print("***************************************************************")
-  print(f"[VLLM] {args.path} 0-shot GSM8K acc = {accuracy:.1%} on {len(data)} problems in {elapsed:.1f}s")
+  print(f"[SAMPLER] {args.path} 0-shot GSM8K acc = {accuracy:.1%} on {len(data)} problems in {elapsed:.1f}s")
   print("***************************************************************")
   if accuracy < args.min_accuracy:
     raise SystemExit(f"GSM8K accuracy {accuracy:.1%} is below the required {args.min_accuracy:.1%}")

--- a/k8s/deploy/distributed-fft-timeslice/04-gateway.yaml
+++ b/k8s/deploy/distributed-fft-timeslice/04-gateway.yaml
@@ -33,7 +33,7 @@ spec:
       containers:
       - name: gateway
         image: ghcr.io/gke-labs/open-rl/gateway:latest
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         command: ["uv", "run", "uvicorn", "server.gateway:app", "--host", "0.0.0.0", "--port", "8000"]
         ports:
         - containerPort: 8000

--- a/k8s/deploy/distributed-fft-timeslice/05-worker-pod-template.yaml
+++ b/k8s/deploy/distributed-fft-timeslice/05-worker-pod-template.yaml
@@ -22,7 +22,7 @@ data:
       containers:
       - name: trainer-worker
         image: gcr.io/cdrollouts-sunilarora/open-rl-server:latest
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         command: ["uv", "run", "python", "-m", "server.training_requests_processor"]
         env:
         - name: REDIS_URL

--- a/k8s/deploy/distributed-fft-timeslice/07-snapshot-agent-daemonset.yaml
+++ b/k8s/deploy/distributed-fft-timeslice/07-snapshot-agent-daemonset.yaml
@@ -35,7 +35,7 @@ spec:
       containers:
       - name: snapshot-agent
         image: ghcr.io/gke-labs/open-rl/server:latest
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         command: ["uv", "run", "python", "-m", "snapshot_agent.serve"]
         args: ["--listen-host", "0.0.0.0", "--port", "9753", "--backend", "llmd", "--llmd-snapshot-endpoint", "127.0.0.1:9001"]
         ports:

--- a/k8s/deploy/distributed-fft-timeslice/09-sampler-pod-template.yaml
+++ b/k8s/deploy/distributed-fft-timeslice/09-sampler-pod-template.yaml
@@ -16,7 +16,7 @@ data:
       containers:
       - name: sampler-worker
         image: gcr.io/cdrollouts-sunilarora/open-rl-server:latest
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         command: ["uv", "run", "python", "-u", "-m", "server.vllm_sampler"]
         env:
         - name: REDIS_URL

--- a/scripts/run_training_e2e.py
+++ b/scripts/run_training_e2e.py
@@ -513,7 +513,11 @@ def run_gsm8k_rl(config: RunConfig, base_url: str, watch: list[ManagedProcess]) 
     "eval_every=0",
     "save_every=1",
   ]
-  run_command(["uv", "--project", "examples", "run", "python", "-m", "tinker_cookbook.recipes.math_rl.train", *args], env=examples_env(config), watch=watch)
+  run_command(
+    ["uv", "--project", "examples", "run", "python", "-m", "tinker_cookbook.recipes.math_rl.train", *args],
+    env=examples_env(config),
+    watch=watch,
+  )
 
 
 def run_gsm8k_rl_x2(config: RunConfig, base_url: str, watch: list[ManagedProcess]) -> None:
@@ -540,7 +544,12 @@ def run_gsm8k_rl_x2(config: RunConfig, base_url: str, watch: list[ManagedProcess
         "eval_every=0",
         "save_every=1",
       ]
-      results[job] = run_command(["uv", "--project", "examples", "run", "python", "-m", "tinker_cookbook.recipes.math_rl.train", *args], env=examples_env(config), watch=watch, prefix=f"[{job}] ")
+      results[job] = run_command(
+        ["uv", "--project", "examples", "run", "python", "-m", "tinker_cookbook.recipes.math_rl.train", *args],
+        env=examples_env(config),
+        watch=watch,
+        prefix=f"[{job}] ",
+      )
     except BaseException as exc:
       results[job] = exc
 

--- a/scripts/run_training_e2e.py
+++ b/scripts/run_training_e2e.py
@@ -396,12 +396,15 @@ def run_gsm8k_train(config: RunConfig, base_url: str, watch: list[ManagedProcess
   return run_example(config, ["examples/sft/gsm8k/gsm8k_sft.py"], defaults, watch=watch, prefix=prefix)
 
 
-def run_gsm8k_eval(config: RunConfig, model_path: str) -> None:
+def run_gsm8k_eval(config: RunConfig, model_path: str | list[str]) -> None:
+  paths = model_path if isinstance(model_path, list) else [model_path]
+  path_args = []
+  for p in paths:
+    path_args.extend(["--path", p])
   run_command(
     ["uv", "--project", "examples", "run", "python", "examples/sft/gsm8k/vllm_eval.py"]
+    + path_args
     + [
-      "--path",
-      model_path,
       "--base-url",
       config.base_url or "http://127.0.0.1:8000",
       "--data",
@@ -472,10 +475,12 @@ def run_gsm8k_x2(config: RunConfig, base_url: str, watch: list[ManagedProcess]) 
       raise RuntimeError(f"gsm8k {job} failed") from result
 
   check_snapshot_interleaving(config)
-  for job, result in sorted(results.items()):
+  eval_paths = []
+  for _, result in sorted(results.items()):
     assert isinstance(result, str)
-    print(f"[training-e2e] evaluating {job}")
-    run_gsm8k_eval(config, resolve_eval_model_path(result))
+    eval_paths.append(resolve_eval_model_path(result))
+  print(f"[training-e2e] evaluating jobs in single micro-batched invocation: {eval_paths}")
+  run_gsm8k_eval(config, eval_paths)
 
 
 def run_tiny_fft_rl_x2(config: RunConfig, base_url: str, watch: list[ManagedProcess]) -> None:

--- a/scripts/run_training_e2e.py
+++ b/scripts/run_training_e2e.py
@@ -54,7 +54,18 @@ GSM8K_ANSWER_RE = re.compile(r"-?\d[\d,]*")
 
 @chz.chz
 class RunConfig:
-  scenario: Literal["tiny-lora", "tiny-fft", "tiny-rl", "tiny-fft-rl", "tiny-fft-rl-x2", "lora-textsql", "fft-gsm8k", "fft-gsm8k-x2"]
+  scenario: Literal[
+    "tiny-lora",
+    "tiny-fft",
+    "tiny-rl",
+    "tiny-fft-rl",
+    "tiny-fft-rl-x2",
+    "lora-textsql",
+    "fft-gsm8k",
+    "fft-gsm8k-x2",
+    "fft-gsm8k-rl",
+    "fft-gsm8k-rl-x2",
+  ]
   sampling_backend: str = "torch"
   trainer_gpu: str = "0"
   sampler_gpu: str = "1"
@@ -280,6 +291,7 @@ def examples_env(config: RunConfig) -> dict[str, str]:
   env = os.environ.copy()
   env["OPEN_RL_TMP_DIR"] = str(open_rl_tmp_dir(config))
   env["PYTHONUNBUFFERED"] = "1"
+  env.setdefault("TINKER_API_KEY", "tml-dummy-key")
   # Keep examples isolated from the root server/eval venv. This also avoids
   # creating examples/.venv on workspace mounts with tight file quotas.
   env["UV_PROJECT_ENVIRONMENT"] = os.environ.get("OPEN_RL_EXAMPLES_UV_PROJECT_ENVIRONMENT", str(open_rl_tmp_dir(config) / "examples-venv"))
@@ -483,6 +495,68 @@ def run_gsm8k_x2(config: RunConfig, base_url: str, watch: list[ManagedProcess]) 
   run_gsm8k_eval(config, eval_paths)
 
 
+def run_gsm8k_rl(config: RunConfig, base_url: str, watch: list[ManagedProcess]) -> None:
+  log_path = str(open_rl_tmp_dir(config) / "fft_gsm8k_rl")
+  if os.path.exists(log_path):
+    shutil.rmtree(log_path)
+  args = [
+    "env=gsm8k",
+    f"model_name={config.base_model}",
+    "renderer_name=qwen3_instruct",
+    f"max_steps={config.steps if config.steps is not None else 2}",
+    f"base_url={base_url}",
+    f"log_path={log_path}",
+    "group_size=2",
+    "groups_per_batch=1",
+    "max_tokens=64",
+    "learning_rate=1e-5",
+    "eval_every=0",
+    "save_every=1",
+  ]
+  run_command(["uv", "--project", "examples", "run", "python", "-m", "tinker_cookbook.recipes.math_rl.train", *args], env=examples_env(config), watch=watch)
+
+
+def run_gsm8k_rl_x2(config: RunConfig, base_url: str, watch: list[ManagedProcess]) -> None:
+  """Run two concurrent FFT RL jobs on GSM8K using standard tinker_cookbook math_rl CLI, check Snapshot Agent
+  time slicing, and verify metrics."""
+  results: dict[str, str | BaseException] = {}
+
+  def train(job: str) -> None:
+    try:
+      log_path = str(open_rl_tmp_dir(config) / f"fft_gsm8k_rl_{job}")
+      if os.path.exists(log_path):
+        shutil.rmtree(log_path)
+      args = [
+        "env=gsm8k",
+        f"model_name={config.base_model}",
+        "renderer_name=qwen3_instruct",
+        f"max_steps={config.steps if config.steps is not None else 2}",
+        f"base_url={base_url}",
+        f"log_path={log_path}",
+        "group_size=2",
+        "groups_per_batch=1",
+        "max_tokens=64",
+        "learning_rate=1e-5",
+        "eval_every=0",
+        "save_every=1",
+      ]
+      results[job] = run_command(["uv", "--project", "examples", "run", "python", "-m", "tinker_cookbook.recipes.math_rl.train", *args], env=examples_env(config), watch=watch, prefix=f"[{job}] ")
+    except BaseException as exc:
+      results[job] = exc
+
+  threads = [threading.Thread(target=train, args=(job,)) for job in ("job-a", "job-b")]
+  for thread in threads:
+    thread.start()
+  for thread in threads:
+    thread.join()
+
+  for job, result in sorted(results.items()):
+    if isinstance(result, BaseException):
+      raise RuntimeError(f"fft-gsm8k-rl-x2 {job} failed") from result
+
+  check_snapshot_interleaving(config)
+
+
 def run_tiny_fft_rl_x2(config: RunConfig, base_url: str, watch: list[ManagedProcess]) -> None:
   """Two concurrent FFT RL jobs against the same backend: each create_model spawns
   its own trainer and dedicated sampler worker, and the snapshot agent time-slices them."""
@@ -575,6 +649,10 @@ def main() -> None:
       run_gsm8k(config, base_url, processes)
     elif config.scenario == "fft-gsm8k-x2":
       run_gsm8k_x2(config, base_url, processes)
+    elif config.scenario == "fft-gsm8k-rl":
+      run_gsm8k_rl(config, base_url, processes)
+    elif config.scenario == "fft-gsm8k-rl-x2":
+      run_gsm8k_rl_x2(config, base_url, processes)
     elif config.scenario == "lora-textsql":
       run_textsql(config, base_url, processes)
     elif config.scenario == "tiny-fft-rl-x2":

--- a/scripts/run_training_e2e.py
+++ b/scripts/run_training_e2e.py
@@ -377,8 +377,6 @@ def resolve_eval_model_path(output: str) -> str:
   for line in reversed(output.splitlines()):
     if line.startswith("eval_model_path="):
       path = line.removeprefix("eval_model_path=").strip()
-      if not Path(path).exists():
-        raise RuntimeError(f"Eval model path does not exist: {path}")
       return path
   raise RuntimeError("GSM8K SFT finished without printing eval_model_path=...")
 
@@ -388,7 +386,7 @@ def run_gsm8k_train(config: RunConfig, base_url: str, watch: list[ManagedProcess
     "base_model": config.base_model,
     "base_url": base_url,
     "log_path": str(Path(config.log_dir) / log_subdir),
-    "max_steps": str(config.steps if config.steps is not None else 50),
+    "max_steps": str(config.steps if config.steps is not None else 10),
     "batch": "1",
     "rank": "16",
     "max_len": "640",
@@ -400,12 +398,12 @@ def run_gsm8k_train(config: RunConfig, base_url: str, watch: list[ManagedProcess
 
 def run_gsm8k_eval(config: RunConfig, model_path: str) -> None:
   run_command(
-    uv_run(config.eval_uv_extra)
+    ["uv", "--project", "examples", "run", "python", "examples/sft/gsm8k/vllm_eval.py"]
     + [
-      "python",
-      "examples/sft/gsm8k/vllm_eval.py",
       "--path",
       model_path,
+      "--base-url",
+      config.base_url or "http://127.0.0.1:8000",
       "--data",
       str(write_gsm8k_eval_data(config)),
       "--gpu-memory-utilization",

--- a/src/server/gateway.py
+++ b/src/server/gateway.py
@@ -386,6 +386,24 @@ async def retrieve_future(req: dict):
 
 
 # *** TrainingClient endpoints ***
+@app.post("/api/v1/forward")
+async def forward(req: dict):
+  """TrainingClient.forward_async()"""
+  fwd_input = req.get("forward_input") or req.get("forward_backward_input") or {}
+  req_id = await enqueue(
+    make_training_request(
+      "forward_backward",
+      req.get("model_id"),
+      {
+        "data": fwd_input.get("data", []),
+        "loss_fn": fwd_input.get("loss_fn", "cross_entropy"),
+        "loss_config": fwd_input.get("loss_fn_config", {}),
+      },
+    )
+  )
+  return {"request_id": req_id}
+
+
 @app.post("/api/v1/forward_backward")
 async def forward_backward(req: dict):
   """TrainingClient.forward_backward_async()"""

--- a/src/server/vllm_sampler.py
+++ b/src/server/vllm_sampler.py
@@ -281,6 +281,9 @@ async def run_sampling_worker(model_id: str) -> None:
         print("[vLLM Worker] Initializing vLLM engine under parent lock...")
         init_engine()
         print("[vLLM Worker] Engine initialized successfully.")
+        if engine is not None:
+          print("[vLLM Worker] Sleeping engine after init to yield GPU memory...")
+          await engine.sleep(level=2)
     except Exception as exc:
       print(f"[vLLM Worker] Failed to perform coordinated initialization: {exc}")
       traceback.print_exc()


### PR DESCRIPTION

- Add engine.sleep(level=2) in vllm_sampler.py during initialization so vLLM cleanly flushes CUDA graphs and yields GPU VRAM before checkpointing
- Switch worker templates in k8s/deploy/distributed-fft-timeslice/ to imagePullPolicy: IfNotPresent for instant (< 1s) pod startup during dev/test
- Update Makefile to resolve image tags via git rev-parse --short HEAD (with fallback to VERSION file stamped in push-vm)
- Enhance make push-images to automatically run kubectl set image and update Gateway OPEN_RL_WORKER_IMAGE env var
- Add detailed llmd-snapshot-agent installation and Helm deployment instructions to docs/setup/gke-fft-timeslice.md
- Add automated worker pod cleanup (kubectl delete pods -l snapshot-agent=true --force) to make test e2e
- Exclude VERSION file in .gitignore