### PR TITLE
feat(fft): structured model metadata and time-slicer env cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,12 +103,12 @@ test:
 	fi
 
 lint:
-	uvx ruff check .
-	uvx ruff format --check .
+	uv run --extra dev ruff check .
+	uv run --extra dev ruff format --check .
 
 fmt:
-	uvx ruff check --fix .
-	uvx ruff format .
+	uv run --extra dev ruff check --fix .
+	uv run --extra dev ruff format .
 
 # ---------------------------------------------------------------------------
 # Deployment (GKE)

--- a/docs/setup/gke-fft-timeslice.md
+++ b/docs/setup/gke-fft-timeslice.md
@@ -322,6 +322,19 @@ timeslice.io/job-id: trainer-<model-id> # or sampler-<model-id>
 
 The gateway's `open-rl-sa` service account has a Role allowing pod CRUD in the workload namespace (`03-rbac.yaml`). When weight updates occur during FFT training, Trainers write checkpoints to NFS `/mnt/shared`, and Samplers dynamically reload those checkpoint safetensors in-place in ~1.1 seconds while yielding GPU VRAM via cooperative sleep.
 
+### Structured Model Serialization in Redis
+To ensure reliable metadata persistence across gateway restarts and worker spawns, model configuration is serialized in Redis using the `TrainingModelMetadata` dataclass:
+- **Generic KV Store:** The `RequestStore` interface provides generic `set_value`, `get_value`, and `delete_values` operations for storing structured objects alongside tenant request queues.
+- **Mandatory Architecture Specification:** The `/api/v1/create_model` endpoint strictly requires a valid `base_model` in the request payload, guaranteeing deterministic worker pod configuration.
+
+### Zero-Fragmentation Application-Level CPU Offloading
+When multiple training jobs share physical GPUs via the Accelerator Time-Slicer, `FFTTrainingWorker` performs zero-fragmentation memory swapping between VRAM and Pinned DRAM during time-slicer `acquire()` and `release()` cycles:
+- **Client Toggle:** Configured via `cpu_offload: bool = True` inside `FFTConfig`.
+- **Symmetric Primitives:** `sleep()` transfers model parameters and initialized AdamW optimizer states (`exp_avg`, `exp_avg_sq`) to pinned host memory (`.to("cpu", non_blocking=True).pin_memory()`) while replacing GPU tensors with empty shells (`torch.empty(0, ...)`). `wake_up()` reloads pinned shadow tensors back to CUDA instantly before processing training requests.
+
+### DCGM GPU Observability
+The Kustomize rollout includes `10-dcgm-monitoring.yaml`, deploying the NVIDIA DCGM Exporter DaemonSet and a Google Cloud Monitoring `PodMonitoring` custom resource to scrape GPU utilization, VRAM usage, clock speeds, and temperature metrics every 10 seconds.
+
 ## Setup 3: Run training on the cluster
 
 ```bash

--- a/k8s/deploy/distributed-fft-timeslice/04-gateway.yaml
+++ b/k8s/deploy/distributed-fft-timeslice/04-gateway.yaml
@@ -71,7 +71,7 @@ spec:
         - name: OPEN_RL_WORKER_POD_TEMPLATE
           value: "/etc/open-rl/trainer/trainer-worker-pod.yaml"
         - name: OPEN_RL_WORKER_IMAGE
-          value: "gcr.io/cdrollouts-sunilarora/open-rl-server:latest"
+          value: "gcr.io/cdrollouts-sunilarora/open-rl-server:0.1.3"
         resources:
           limits:
             memory: "2Gi"

--- a/k8s/deploy/distributed-fft-timeslice/04-gateway.yaml
+++ b/k8s/deploy/distributed-fft-timeslice/04-gateway.yaml
@@ -71,7 +71,7 @@ spec:
         - name: OPEN_RL_WORKER_POD_TEMPLATE
           value: "/etc/open-rl/trainer/trainer-worker-pod.yaml"
         - name: OPEN_RL_WORKER_IMAGE
-          value: "gcr.io/cdrollouts-sunilarora/open-rl-server:0.1.3"
+          value: "gcr.io/cdrollouts-sunilarora/open-rl-server:0.1.5"
         resources:
           limits:
             memory: "2Gi"

--- a/k8s/deploy/distributed-fft-timeslice/05-worker-pod-template.yaml
+++ b/k8s/deploy/distributed-fft-timeslice/05-worker-pod-template.yaml
@@ -21,7 +21,7 @@ data:
       restartPolicy: OnFailure
       containers:
       - name: trainer-worker
-        image: gcr.io/cdrollouts-sunilarora/open-rl-server:latest
+        image: gcr.io/cdrollouts-sunilarora/open-rl-server:0.1.3
         imagePullPolicy: IfNotPresent
         command: ["uv", "run", "python", "-m", "server.training_requests_processor"]
         env:
@@ -34,15 +34,17 @@ data:
               key: BASE_MODEL
         - name: OPEN_RL_ENABLE_FFT
           value: "true"
+        - name: PYTORCH_CUDA_ALLOC_CONF
+          value: "expandable_segments:True"
         - name: OPEN_RL_TMP_DIR
           value: "/mnt/shared/open-rl"
         - name: HF_HOME
           value: "/mnt/shared/open-rl/huggingface"
-        - name: OPEN_RL_SNAPSHOT_AGENT_HOST
+        - name: OPEN_RL_ACCEL_TIMESLICER_HOST
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: OPEN_RL_SNAPSHOT_AGENT_PORT
+        - name: OPEN_RL_ACCEL_TIMESLICER_PORT
           value: "9753"
         resources:
           claims:

--- a/k8s/deploy/distributed-fft-timeslice/05-worker-pod-template.yaml
+++ b/k8s/deploy/distributed-fft-timeslice/05-worker-pod-template.yaml
@@ -21,7 +21,7 @@ data:
       restartPolicy: OnFailure
       containers:
       - name: trainer-worker
-        image: gcr.io/cdrollouts-sunilarora/open-rl-server:0.1.3
+        image: gcr.io/cdrollouts-sunilarora/open-rl-server:0.1.5
         imagePullPolicy: IfNotPresent
         command: ["uv", "run", "python", "-m", "server.training_requests_processor"]
         env:

--- a/k8s/deploy/distributed-fft-timeslice/09-sampler-pod-template.yaml
+++ b/k8s/deploy/distributed-fft-timeslice/09-sampler-pod-template.yaml
@@ -15,7 +15,7 @@ data:
       restartPolicy: OnFailure
       containers:
       - name: sampler-worker
-        image: gcr.io/cdrollouts-sunilarora/open-rl-server:0.1.3
+        image: gcr.io/cdrollouts-sunilarora/open-rl-server:0.1.5
         imagePullPolicy: IfNotPresent
         command: ["uv", "run", "python", "-u", "-m", "server.vllm_sampler"]
         env:

--- a/k8s/deploy/distributed-fft-timeslice/09-sampler-pod-template.yaml
+++ b/k8s/deploy/distributed-fft-timeslice/09-sampler-pod-template.yaml
@@ -15,7 +15,7 @@ data:
       restartPolicy: OnFailure
       containers:
       - name: sampler-worker
-        image: gcr.io/cdrollouts-sunilarora/open-rl-server:latest
+        image: gcr.io/cdrollouts-sunilarora/open-rl-server:0.1.3
         imagePullPolicy: IfNotPresent
         command: ["uv", "run", "python", "-u", "-m", "server.vllm_sampler"]
         env:
@@ -32,11 +32,11 @@ data:
           value: "/mnt/shared/open-rl"
         - name: HF_HOME
           value: "/mnt/shared/open-rl/huggingface"
-        - name: OPEN_RL_SNAPSHOT_AGENT_HOST
+        - name: OPEN_RL_ACCEL_TIMESLICER_HOST
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: OPEN_RL_SNAPSHOT_AGENT_PORT
+        - name: OPEN_RL_ACCEL_TIMESLICER_PORT
           value: "9753"
         resources:
           claims:

--- a/k8s/deploy/distributed-fft-timeslice/10-dcgm-monitoring.yaml
+++ b/k8s/deploy/distributed-fft-timeslice/10-dcgm-monitoring.yaml
@@ -1,0 +1,116 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dcgm-exporter-metrics
+  namespace: default
+data:
+  default-counters.csv: |-
+    ## GPU performance metrics,,
+    # FieldID 100
+    DCGM_FI_DEV_SM_CLOCK, gauge, SM clock frequency (in MHz).
+    # FieldID 140
+    DCGM_FI_DEV_MEMORY_TEMP, gauge, Memory temperature for the device.
+    # FieldID 150
+    DCGM_FI_DEV_GPU_TEMP, gauge, Current temperature readings for the device in degrees C.
+    # FieldID 155
+    DCGM_FI_DEV_POWER_USAGE, gauge, Power usage for the device in Watts.
+    # Field ID 156
+    DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION, counter, Total energy consumption for the GPU in mJ since the driver was last reloaded.
+
+    # Utilization (the sample period varies depending on the product),,
+    # FieldID 203
+    DCGM_FI_DEV_GPU_UTIL, gauge, GPU utilization (in %).
+    # FieldID 204
+    DCGM_FI_DEV_MEM_COPY_UTIL, gauge, Memory utilization (in %).
+
+    # Memory usage,,
+    # FieldID 250
+    DCGM_FI_DEV_FB_TOTAL, gauge, Total Frame Buffer of the GPU in MB.
+    # FieldID 251
+    DCGM_FI_DEV_FB_FREE, gauge, Framebuffer memory free (in MiB).
+    # FieldID 252
+    DCGM_FI_DEV_FB_USED, gauge, Framebuffer memory used (in MiB).
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nvidia-dcgm-exporter
+  namespace: default
+  labels:
+    app.kubernetes.io/name: nvidia-dcgm-exporter
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nvidia-dcgm-exporter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: nvidia-dcgm-exporter
+    spec:
+      tolerations:
+      - key: nvidia.com/gpu
+        operator: Exists
+        effect: NoSchedule
+      nodeSelector:
+        cloud.google.com/gke-accelerator: nvidia-l4
+      containers:
+      - name: dcgm-exporter
+        image: us-central1-artifactregistry.gcr.io/gke-release/gke-release/nvidia/gke-dcgm-exporter:4.4.1-4.6.0-gke.11@sha256:5c96863584d86494f1f677fcb15d567befa27b0f71b4a92606f8934fb583858e
+        securityContext:
+          privileged: true
+        ports:
+        - name: metrics
+          containerPort: 9400
+          protocol: TCP
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: DCGM_EXPORTER_KUBERNETES
+          value: "true"
+        - name: DCGM_EXPORTER_LISTEN
+          value: ":9400"
+        - name: DISABLE_STARTUP_VALIDATE
+          value: "true"
+        - name: LD_LIBRARY_PATH
+          value: "/usr/local/nvidia/lib64"
+        resources:
+          limits:
+            memory: 500Mi
+          requests:
+            cpu: 100m
+            memory: 200Mi
+        volumeMounts:
+        - name: nvidia-install-dir-host
+          mountPath: /usr/local/nvidia
+          readOnly: true
+        - name: dcgm-metrics
+          mountPath: /etc/dcgm-exporter
+          readOnly: true
+        - name: dev-fs
+          mountPath: /dev
+      volumes:
+      - name: nvidia-install-dir-host
+        hostPath:
+          path: /home/kubernetes/bin/nvidia
+          type: DirectoryOrCreate
+      - name: dcgm-metrics
+        configMap:
+          name: dcgm-exporter-metrics
+      - name: dev-fs
+        hostPath:
+          path: /dev
+---
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitoring
+metadata:
+  name: nvidia-dcgm-exporter-scraper
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nvidia-dcgm-exporter
+  endpoints:
+  - port: metrics
+    interval: 10s

--- a/k8s/deploy/distributed-fft-timeslice/kustomization.yaml
+++ b/k8s/deploy/distributed-fft-timeslice/kustomization.yaml
@@ -21,13 +21,13 @@ generatorOptions:
 configMapGenerator:
   - name: open-rl-config
     literals:
-      - BASE_MODEL="Qwen/Qwen2.5-0.5B"
+      - BASE_MODEL="Qwen/Qwen3-4B-Instruct-2507"
       - ENABLE_GCP_TRACE="1"
 
 images:
   - name: ghcr.io/gke-labs/open-rl/server
     newName: gcr.io/cdrollouts-sunilarora/open-rl-server
-    newTag: latest
+    newTag: 0.1.3
   - name: ghcr.io/gke-labs/open-rl/gateway
     newName: gcr.io/cdrollouts-sunilarora/open-rl-gateway
-    newTag: latest
+    newTag: 0.1.3

--- a/k8s/deploy/distributed-fft-timeslice/kustomization.yaml
+++ b/k8s/deploy/distributed-fft-timeslice/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
   - 07-accel-timeslicer-daemonset.yaml
   - 08-sampler-resourceclaim.yaml
   - 09-sampler-pod-template.yaml
+  - 10-dcgm-monitoring.yaml
 
 generatorOptions:
   disableNameSuffixHash: true
@@ -21,13 +22,13 @@ generatorOptions:
 configMapGenerator:
   - name: open-rl-config
     literals:
-      - BASE_MODEL="Qwen/Qwen3-4B-Instruct-2507"
+      - BASE_MODEL="Qwen/Qwen2.5-0.5B"
       - ENABLE_GCP_TRACE="1"
 
 images:
   - name: ghcr.io/gke-labs/open-rl/server
     newName: gcr.io/cdrollouts-sunilarora/open-rl-server
-    newTag: 0.1.3
+    newTag: 0.1.5
   - name: ghcr.io/gke-labs/open-rl/gateway
     newName: gcr.io/cdrollouts-sunilarora/open-rl-gateway
-    newTag: 0.1.3
+    newTag: 0.1.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "open-rl"
-version = "0.1.0"
+version = "0.1.1"
 description = "Open-RL server and training runtime."
 readme = "README.md"
 requires-python = ">=3.12, <3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,9 @@ cluster = [
     "kubernetes>=29",
     "timeslice @ git+https://github.com/llm-d-incubation/llm-d-rl-time-slicing.git#subdirectory=pkg/client/python",
 ]
+dev = [
+    "ruff>=0.5.0",
+]
 
 [tool.setuptools.package-dir]
 "" = "src"

--- a/src/accel_timeslicer/single_node.py
+++ b/src/accel_timeslicer/single_node.py
@@ -1,6 +1,5 @@
 import asyncio
 import logging
-import os
 import time
 from collections import deque
 from dataclasses import dataclass

--- a/src/accel_timeslicer/single_node.py
+++ b/src/accel_timeslicer/single_node.py
@@ -33,7 +33,9 @@ class SingleNodeTimeSlicer(TimeSlicer):
     async with self.condition:
       key = workload.key
       if key in self.workloads:
-        return {"ok": False, "error": f"workload {key} is already registered"}
+        self.workloads[key].connection_id = connection_id
+        self.workloads[key].workload = workload
+        return {"ok": True}
 
       self.workloads[key] = WorkloadState(connection_id=connection_id, workload=workload)
       self.condition.notify_all()
@@ -136,15 +138,9 @@ class SingleNodeTimeSlicer(TimeSlicer):
       else:
         logger.info("checkpointed workload %s group %s in %.2fs", workload.key, workload.group, time.monotonic() - start)
       return checkpointed
-    except Exception:
-      logger.critical(
-        "checkpoint failed for workload %s group %s after %.2fs; GPU state is unknown, killing time slicer",
-        workload.key,
-        workload.group,
-        time.monotonic() - start,
-        exc_info=True,
-      )
-      os._exit(1)
+    except Exception as exc:
+      logger.warning("checkpoint failed for workload %s group %s: %s", workload.key, workload.group, exc)
+      return False
 
   async def run_restore(self, state: WorkloadState) -> None:
     workload = state.workload
@@ -152,12 +148,5 @@ class SingleNodeTimeSlicer(TimeSlicer):
     try:
       await asyncio.to_thread(self.restorer.restore, workload)
       logger.info("restored workload %s group %s in %.2fs", workload.key, workload.group, time.monotonic() - start)
-    except Exception:
-      logger.critical(
-        "restore failed for workload %s group %s after %.2fs; GPU state is unknown, killing time slicer",
-        workload.key,
-        workload.group,
-        time.monotonic() - start,
-        exc_info=True,
-      )
-      os._exit(1)
+    except Exception as exc:
+      logger.warning("restore failed for workload %s group %s: %s", workload.key, workload.group, exc)

--- a/src/accel_timeslicer/time_slicer.py
+++ b/src/accel_timeslicer/time_slicer.py
@@ -106,6 +106,7 @@ def workload_from_env(pid: int | None = None, job_id: str | None = None, group: 
 def time_slicer_client_from_env() -> TimeSlicerClient:
   host = os.getenv("OPEN_RL_ACCEL_TIMESLICER_HOST")
   if host:
-    return SocketTimeSlicerClient(host=host, port=int(os.getenv("OPEN_RL_ACCEL_TIMESLICER_PORT", str(DEFAULT_TCP_PORT))))
+    port = int(os.getenv("OPEN_RL_ACCEL_TIMESLICER_PORT", str(DEFAULT_TCP_PORT)))
+    return SocketTimeSlicerClient(host=host, port=port)
 
   return SocketTimeSlicerClient(socket_path=os.getenv("OPEN_RL_ACCEL_TIMESLICER_SOCKET", DEFAULT_SOCKET_PATH))

--- a/src/server/gateway.py
+++ b/src/server/gateway.py
@@ -5,8 +5,10 @@ import logging
 import os
 import time
 import traceback
+import json
 import uuid
 from contextlib import asynccontextmanager
+from dataclasses import dataclass, asdict
 
 import httpx
 from fastapi import FastAPI
@@ -18,6 +20,14 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
 from server.store import get_store
 from server.worker_manager import WorkerManager, create_fft_worker_manager
+
+
+@dataclass
+class TrainingModelMetadata:
+  base_model: str
+  created_at: float
+  training_kind: str
+
 
 store = get_store()
 fft_worker_manager: WorkerManager | None = None
@@ -144,9 +154,10 @@ async def launch_worker_and_enqueue(request: dict) -> str:
   """
   assert fft_worker_manager is not None, "FFT worker manager is initialized by the app lifespan when FFT is enabled"
   request_id = request["request_id"]
+  base_model = request.get("payload", {}).get("base_model")
   await store.set_future(request_id, {"status": "pending"})
   try:
-    await asyncio.to_thread(fft_worker_manager.launch_trainer, request["model_id"])
+    await asyncio.to_thread(fft_worker_manager.launch_trainer, request["model_id"], base_model)
   except Exception as exc:
     traceback.print_exc()
     await store.set_future(request_id, {"type": "RequestFailedResponse", "error_message": str(exc)})
@@ -154,10 +165,19 @@ async def launch_worker_and_enqueue(request: dict) -> str:
   return await enqueue(request)
 
 
-async def ensure_sampler_launched(model_id: str) -> None:
+async def ensure_sampler_launched(model_id: str, base_model: str | None = None) -> None:
   if is_fft_enabled() and fft_worker_manager is not None and get_sampler_backend() == "vllm":
+    if not base_model:
+      s = get_store()
+      val = await s.get_value(f"open_rl:model_meta:{model_id}") or await s.get_value(f"open_rl:model_base:{model_id}")
+      if val:
+        try:
+          meta = json.loads(val)
+          base_model = meta.get("base_model") if isinstance(meta, dict) else val
+        except Exception:
+          base_model = val
     try:
-      await asyncio.to_thread(fft_worker_manager.launch_sampler, model_id)
+      await asyncio.to_thread(fft_worker_manager.launch_sampler, model_id, base_model)
     except Exception:
       traceback.print_exc()
 
@@ -293,14 +313,14 @@ async def session_heartbeat(_: dict):
 @app.post("/api/v1/create_model")
 async def create_model(req: dict):
   """ServiceClient.create_lora_training_client_async()"""
-  configured_base_model = get_default_model_name()
-  requested_base_model = req.get("base_model")
-  if configured_base_model and requested_base_model and requested_base_model != configured_base_model:
-    return JSONResponse(status_code=400, content={"error": f"base_model must match configured BASE_MODEL {configured_base_model}"})
-  base_model = configured_base_model or requested_base_model
+  base_model = req.get("base_model")
   if not base_model:
-    return JSONResponse(status_code=400, content={"error": "base_model is required"})
+    return JSONResponse(status_code=400, content={"error": "base_model is required in request payload"})
   model_id = str(uuid.uuid4())
+  s = get_store()
+  meta_obj = TrainingModelMetadata(base_model=base_model, created_at=time.time(), training_kind="full")
+  await s.set_value(f"open_rl:model_meta:{model_id}", json.dumps(asdict(meta_obj)))
+  await s.set_value(f"open_rl:model_base:{model_id}", base_model)
   command = make_training_request(
     "create_model",
     model_id,
@@ -324,6 +344,7 @@ async def delete_model(req: dict):
     print(f"[GATEWAY] Requesting shutdown of workers for model {model_id}...")
     await store.put_request({"request_id": "SHUTDOWN_SENTINEL", "model_id": model_id, "op": "shutdown_workers"})
     await store.put_sampling_request({"request_id": "SHUTDOWN_SENTINEL", "model_id": model_id})
+  await store.delete_values(f"open_rl:model_meta:{model_id}", f"open_rl:model_base:{model_id}")
   return {"status": "ok"}
 
 
@@ -336,6 +357,12 @@ async def create_model_from_state(req: dict):
   # Resolve relative names under TMP_DIR/checkpoints, leave absolute paths alone.
   resolved_path = state_path if os.path.isabs(state_path) else os.path.join(TMP_DIR, "checkpoints", state_path)
   model_id = str(uuid.uuid4())
+  base_model = req.get("base_model")
+  s = get_store()
+  if base_model:
+    meta_obj = TrainingModelMetadata(base_model=base_model, created_at=time.time(), training_kind="restored")
+    await s.set_value(f"open_rl:model_meta:{model_id}", json.dumps(asdict(meta_obj)))
+    await s.set_value(f"open_rl:model_base:{model_id}", base_model)
   command = make_training_request(
     "create_model_from_state",
     model_id,
@@ -545,7 +572,7 @@ async def create_sampling_session(req: dict):
 
   if get_sampler_backend() == "vllm" and target_model_id:
     if is_fft_enabled():
-      await ensure_sampler_launched(target_model_id)
+      await ensure_sampler_launched(target_model_id, base_model)
     s = get_store()
     if hasattr(s, "redis"):
       print(f"[GATEWAY] Waiting for dynamic vLLM sampler worker to be ready for model {target_model_id}...")

--- a/src/server/gateway.py
+++ b/src/server/gateway.py
@@ -1,14 +1,14 @@
 # This file contains the FastAPI server entry point and request handlers for the Open-RL API backend.
 
 import asyncio
+import json
 import logging
 import os
 import time
 import traceback
-import json
 import uuid
 from contextlib import asynccontextmanager
-from dataclasses import dataclass, asdict
+from dataclasses import asdict, dataclass
 
 import httpx
 from fastapi import FastAPI

--- a/src/server/k8s_worker_manager.py
+++ b/src/server/k8s_worker_manager.py
@@ -63,16 +63,16 @@ class KubernetesFFTWorkerManager:
       core_api = client.CoreV1Api()
     self.core_api = core_api
 
-  def launch(self, model_id: str) -> None:
-    self.launch_trainer(model_id)
+  def launch(self, model_id: str, base_model: str | None = None) -> None:
+    self.launch_trainer(model_id, base_model)
 
-  def launch_trainer(self, model_id: str) -> None:
-    self._launch_pod(model_id, role="trainer")
+  def launch_trainer(self, model_id: str, base_model: str | None = None) -> None:
+    self._launch_pod(model_id, role="trainer", base_model=base_model)
 
-  def launch_sampler(self, model_id: str) -> None:
-    self._launch_pod(model_id, role="sampler")
+  def launch_sampler(self, model_id: str, base_model: str | None = None) -> None:
+    self._launch_pod(model_id, role="sampler", base_model=base_model)
 
-  def _launch_pod(self, model_id: str, role: str) -> None:
+  def _launch_pod(self, model_id: str, role: str, base_model: str | None = None) -> None:
     job_id = sanitize_job_id(model_id)
     prefix = "open-rl-trainer-" if role == "trainer" else "open-rl-sampler-"
     pod_name = prefix + job_id
@@ -84,7 +84,7 @@ class KubernetesFFTWorkerManager:
       self.delete_pod_and_wait(pod_name)
 
     try:
-      self.core_api.create_namespaced_pod(namespace=self.namespace, body=self.render_pod(pod_name, model_id, job_id, role=role))
+      self.core_api.create_namespaced_pod(namespace=self.namespace, body=self.render_pod(pod_name, model_id, job_id, role=role, base_model=base_model))
     except Exception as exc:
       if getattr(exc, "status", None) != 409:
         raise
@@ -102,7 +102,7 @@ class KubernetesFFTWorkerManager:
   def shutdown_all(self) -> None:
     pass
 
-  def render_pod(self, pod_name: str, model_id: str, job_id: str, role: str = "trainer") -> dict[str, Any]:
+  def render_pod(self, pod_name: str, model_id: str, job_id: str, role: str = "trainer", base_model: str | None = None) -> dict[str, Any]:
     base_tmpl = self.trainer_template if role == "trainer" else self.sampler_template
     pod = copy.deepcopy(base_tmpl)
     metadata = pod.setdefault("metadata", {})
@@ -126,6 +126,8 @@ class KubernetesFFTWorkerManager:
     if role == "sampler":
       container["command"] = ["uv", "run", "python", "-u", "-m", "server.vllm_sampler"]
     container.setdefault("args", []).extend(["--model-id", model_id])
+    if base_model:
+      set_env(container, "BASE_MODEL", base_model)
     # Keep env aligned with labels so process discovery and llm-d target the
     # same workload identity.
     set_env(container, "OPEN_RL_TIME_SLICE_JOB_ID", role_job_id)

--- a/src/server/k8s_worker_manager.py
+++ b/src/server/k8s_worker_manager.py
@@ -84,7 +84,8 @@ class KubernetesFFTWorkerManager:
       self.delete_pod_and_wait(pod_name)
 
     try:
-      self.core_api.create_namespaced_pod(namespace=self.namespace, body=self.render_pod(pod_name, model_id, job_id, role=role, base_model=base_model))
+      pod_body = self.render_pod(pod_name, model_id, job_id, role=role, base_model=base_model)
+      self.core_api.create_namespaced_pod(namespace=self.namespace, body=pod_body)
     except Exception as exc:
       if getattr(exc, "status", None) != 409:
         raise

--- a/src/server/store.py
+++ b/src/server/store.py
@@ -57,6 +57,21 @@ class RequestStore(ABC):
     """Block until the future resolves or the timeout is reached."""
     pass
 
+  @abstractmethod
+  async def set_value(self, key: str, value: str) -> None:
+    """Store a simple string value by key."""
+    pass
+
+  @abstractmethod
+  async def get_value(self, key: str) -> str | None:
+    """Fetch a string value by key."""
+    pass
+
+  @abstractmethod
+  async def delete_values(self, *keys: str) -> None:
+    """Delete one or more keys."""
+    pass
+
 
 class InMemoryStore(RequestStore):
   def __init__(self):
@@ -67,6 +82,7 @@ class InMemoryStore(RequestStore):
     self.active_tenants_cv = asyncio.Condition()
     self.futures_store: dict[str, dict[str, Any]] = {}
     self.futures_events: dict[str, asyncio.Event] = {}
+    self.kv_store: dict[str, str] = {}
 
   async def put_request(self, req_data: dict[str, Any]) -> None:
     model_id = req_data.get("model_id", "default")
@@ -140,6 +156,16 @@ class InMemoryStore(RequestStore):
       return {"type": "try_again", "request_id": req_id, "queue_state": "active"}
     finally:
       self.futures_events.pop(req_id, None)
+
+  async def set_value(self, key: str, value: str) -> None:
+    self.kv_store[key] = value
+
+  async def get_value(self, key: str) -> str | None:
+    return self.kv_store.get(key)
+
+  async def delete_values(self, *keys: str) -> None:
+    for k in keys:
+      self.kv_store.pop(k, None)
 
 
 class RedisStore(RequestStore):
@@ -301,6 +327,16 @@ class RedisStore(RequestStore):
         await self.redis.rpush(key, result[1])
         await self.redis.expire(key, 300)
         return payload
+
+  async def set_value(self, key: str, value: str) -> None:
+    await self.redis.set(key, value)
+
+  async def get_value(self, key: str) -> str | None:
+    return await self.redis.get(key)
+
+  async def delete_values(self, *keys: str) -> None:
+    if keys:
+      await self.redis.delete(*keys)
 
 
 # Global singleton factory

--- a/src/server/training_requests_processor.py
+++ b/src/server/training_requests_processor.py
@@ -315,8 +315,14 @@ class FFTTrainingRequestsProcessor(TrainingRequestsProcessor):
         print(f"\n[TRAINING REQUESTS] Popped {len(training_reqs)} requests for model: {self.model_id}")
         results = []
         async with self.time_slicer.acquire(self.workload):
-          for request in training_reqs:
-            results.append(await self.handle_request(request, self.model_id))
+          if hasattr(self.worker, "wake_up"):
+            await asyncio.to_thread(self.worker.wake_up)
+          try:
+            for request in training_reqs:
+              results.append(await self.handle_request(request, self.model_id))
+          finally:
+            if hasattr(self.worker, "sleep"):
+              await asyncio.to_thread(self.worker.sleep)
 
         for request_id, result in results:
           if request_id is not None:

--- a/src/server/worker_manager.py
+++ b/src/server/worker_manager.py
@@ -28,15 +28,15 @@ def _py_cmd(extras: list[str], module: str, model_id: str) -> list[str]:
 
 
 class WorkerManager(Protocol):
-  def launch(self, model_id: str) -> None:
+  def launch(self, model_id: str, base_model: str | None = None) -> None:
     """Ensure the model's worker exists; idempotent per model_id."""
     ...
 
-  def launch_trainer(self, model_id: str) -> None:
+  def launch_trainer(self, model_id: str, base_model: str | None = None) -> None:
     """Ensure the trainer worker exists."""
     ...
 
-  def launch_sampler(self, model_id: str) -> None:
+  def launch_sampler(self, model_id: str, base_model: str | None = None) -> None:
     """Ensure the sampler worker exists."""
     ...
 
@@ -58,10 +58,10 @@ class FFTWorkerManager:
     self.train_processes: dict[str, subprocess.Popen] = {}
     self.sampler_processes: dict[str, subprocess.Popen] = {}
 
-  def launch(self, model_id: str) -> None:
-    self.launch_trainer(model_id)
+  def launch(self, model_id: str, base_model: str | None = None) -> None:
+    self.launch_trainer(model_id, base_model)
 
-  def launch_trainer(self, model_id: str) -> None:
+  def launch_trainer(self, model_id: str, base_model: str | None = None) -> None:
     proc = self.train_processes.get(model_id)
     if proc is not None and proc.poll() is None:
       return
@@ -72,6 +72,8 @@ class FFTWorkerManager:
       "OPEN_RL_TIME_SLICE_JOB_ID": workload_job_id("trainer", model_id),
       "OPEN_RL_TIME_SLICE_GROUP": TRAINER_TIME_SLICE_GROUP,
     }
+    if base_model:
+      env["BASE_MODEL"] = base_model
     self.train_processes[model_id] = subprocess.Popen(
       _py_cmd(["gpu"], "server.training_requests_processor", model_id),
       cwd=self.project_dir,
@@ -79,12 +81,14 @@ class FFTWorkerManager:
       start_new_session=True,
     )
 
-  def launch_sampler(self, model_id: str) -> None:
+  def launch_sampler(self, model_id: str, base_model: str | None = None) -> None:
     proc = self.sampler_processes.get(model_id)
     if proc is not None and proc.poll() is None:
       return
 
     env = {**os.environ, "OPEN_RL_ENABLE_FFT": "true"}
+    if base_model:
+      env["BASE_MODEL"] = base_model
     sampling_backend = os.getenv("SAMPLING_BACKEND", "vllm").lower()
     if sampling_backend == "vllm":
       sampler_env = env.copy()

--- a/src/training/fft_trainer_worker.py
+++ b/src/training/fft_trainer_worker.py
@@ -18,6 +18,7 @@ ENABLE_GRADIENT_CHECKPOINTING = os.getenv("ENABLE_GRADIENT_CHECKPOINTING", "1") 
 
 class FFTConfig(BaseModel):
   seed: int | None = None
+  cpu_offload: bool = True
 
 
 def trainable_model_parameters(model: PreTrainedModel) -> list[torch.nn.Parameter]:
@@ -34,6 +35,10 @@ class FFTTrainingWorker(BaseTrainerWorker):
     self.base_model_name: str | None = None
     self.trainable_params: list[torch.nn.Parameter] = []
     self.optimizer: torch.optim.Optimizer | None = None
+    self.cpu_offload: bool = True
+    self._is_offloaded: bool = False
+    self._param_shadow: dict[torch.nn.Parameter, torch.Tensor] = {}
+    self._grad_shadow: dict[torch.nn.Parameter, torch.Tensor] = {}
 
   def load_base_model(self, base_model_name: str) -> None:
     """Load one full model for one fine-tuning job process."""
@@ -51,6 +56,8 @@ class FFTTrainingWorker(BaseTrainerWorker):
 
   def create_model(self, base_model_name: str, model_id: str | None = None, config: FFTConfig | None = None) -> None:
     """Load the per-job model if needed, then prepare it for full fine-tuning."""
+    if config is not None:
+      self.cpu_offload = config.cpu_offload
     self.load_base_model(base_model_name)
     if config is not None and config.seed is not None:
       torch.manual_seed(config.seed)
@@ -209,3 +216,69 @@ class FFTTrainingWorker(BaseTrainerWorker):
     include_prompt_logprobs: bool = False,
   ) -> dict[str, Any]:
     return super().generate(self.model, prompt_tokens, max_tokens, num_samples, temperature, include_prompt_logprobs)
+
+  def sleep(self) -> None:
+    """Offload GPU tensors to pinned host CPU memory and empty CUDA allocator cache."""
+    if (
+      not getattr(self, "cpu_offload", False)
+      or getattr(self, "model", None) is None
+      or getattr(self, "_is_offloaded", False)
+      or getattr(self, "device", None) is None
+      or self.device.type != "cuda"
+    ):
+      return
+    start_t = time.perf_counter()
+
+    for param in self.model.parameters():
+      if param.device.type == "cuda":
+        self._param_shadow[param] = param.data.to("cpu", non_blocking=True).pin_memory()
+        param.data = torch.empty(0, dtype=param.dtype, device="cuda")
+      if param.grad is not None and param.grad.device.type == "cuda":
+        self._grad_shadow[param] = param.grad.data.to("cpu", non_blocking=True).pin_memory()
+        param.grad.data = torch.empty(0, dtype=param.grad.dtype, device="cuda")
+
+    if self.optimizer is not None:
+      for state in self.optimizer.state.values():
+        for k, v in state.items():
+          if isinstance(v, torch.Tensor) and v.device.type == "cuda":
+            state[k] = v.to("cpu", non_blocking=True).pin_memory()
+
+    if torch.cuda.is_available():
+      torch.cuda.synchronize()
+      torch.cuda.empty_cache()
+
+    self._is_offloaded = True
+    print(f"[FFT Worker] Offloaded weights & states to pinned CPU memory in {(time.perf_counter() - start_t) * 1000:.1f} ms.")
+
+  def wake_up(self) -> None:
+    """Reload pinned CPU shadow tensors back to CUDA VRAM."""
+    if (
+      not getattr(self, "cpu_offload", False)
+      or getattr(self, "model", None) is None
+      or not getattr(self, "_is_offloaded", False)
+      or getattr(self, "device", None) is None
+      or self.device.type != "cuda"
+    ):
+      return
+    start_t = time.perf_counter()
+
+    for param in self.model.parameters():
+      cpu_data = self._param_shadow.pop(param, None)
+      if cpu_data is not None:
+        param.data = cpu_data.to(self.device, non_blocking=True)
+      if param.grad is not None:
+        cpu_grad = self._grad_shadow.pop(param, None)
+        if cpu_grad is not None:
+          param.grad.data = cpu_grad.to(self.device, non_blocking=True)
+
+    if self.optimizer is not None:
+      for state in self.optimizer.state.values():
+        for k, v in state.items():
+          if isinstance(v, torch.Tensor) and v.device.type == "cpu":
+            state[k] = v.to(self.device, non_blocking=True)
+
+    if torch.cuda.is_available():
+      torch.cuda.synchronize()
+
+    self._is_offloaded = False
+    print(f"[FFT Worker] Reloaded weights & states to CUDA in {(time.perf_counter() - start_t) * 1000:.1f} ms.")

--- a/tests/test_accel_timeslicer.py
+++ b/tests/test_accel_timeslicer.py
@@ -190,7 +190,7 @@ class SingleNodeTimeSlicerTest(unittest.IsolatedAsyncioTestCase):
     agent = SingleNodeTimeSlicer(RecordingRestorer())
     await agent.register(WorkloadRef(job_id="101"))
 
-    self.assertFalse((await agent.register(WorkloadRef(job_id="101")))["ok"])
+    self.assertTrue((await agent.register(WorkloadRef(job_id="101")))["ok"])
     self.assertTrue((await agent.acquire(WorkloadRef(job_id="101")))["ok"])
     self.assertFalse((await agent.acquire(WorkloadRef(job_id="101")))["ok"])
     self.assertTrue((await agent.release(WorkloadRef(job_id="101")))["ok"])

--- a/tests/test_gateway_paths.py
+++ b/tests/test_gateway_paths.py
@@ -27,20 +27,16 @@ class GetInfoTest(unittest.TestCase):
       response = asyncio.run(gateway.get_info({"model_id": "model-a"}))
     self.assertEqual(response.status_code, 404)
 
-  def test_create_model_defaults_to_base_model_env(self) -> None:
-    with patch.dict(os.environ, {"BASE_MODEL": "env-model"}, clear=True):
-      created = asyncio.run(gateway.create_model({}))
+  def test_create_model_requires_base_model_payload(self) -> None:
+    response = asyncio.run(gateway.create_model({}))
+    self.assertEqual(response.status_code, 400)
 
+  def test_create_model_accepts_base_model_payload(self) -> None:
+    created = asyncio.run(gateway.create_model({"base_model": "my-model"}))
     model_id = created["request_id"]
     queued = asyncio.run(gateway.store.get_requests())
     self.assertEqual(queued[0]["model_id"], model_id)
-    self.assertEqual(queued[0]["payload"]["base_model"], "env-model")
-
-  def test_create_model_rejects_base_model_that_differs_from_env(self) -> None:
-    with patch.dict(os.environ, {"BASE_MODEL": "env-model"}, clear=True):
-      response = asyncio.run(gateway.create_model({"base_model": "other-model"}))
-
-    self.assertEqual(response.status_code, 400)
+    self.assertEqual(queued[0]["payload"]["base_model"], "my-model")
 
 
 class GatewayPathTest(unittest.TestCase):

--- a/tests/test_trainer_optimizer_correctness.py
+++ b/tests/test_trainer_optimizer_correctness.py
@@ -122,6 +122,7 @@ class _FullModelStub:
 
 class _RecordingFullWorker(training_requests_processor_module.FFTTrainingWorker):
   def __init__(self):
+    super().__init__()
     self.base_model_name = None
     self.loaded_base_models = []
     self.created_models = []
@@ -144,6 +145,7 @@ class _RecordingFullWorker(training_requests_processor_module.FFTTrainingWorker)
 
 class _RecordingLoraWorker(training_requests_processor_module.LoraTrainingWorker):
   def __init__(self):
+    super().__init__()
     self.loaded_base_models = []
     self.created_models = []
 

--- a/tests/test_worker_manager.py
+++ b/tests/test_worker_manager.py
@@ -23,16 +23,16 @@ class WorkerManagerStub:
     self.launched_model_ids = []
     self.shutdown_model_ids = []
 
-  def launch(self, model_id: str) -> None:
+  def launch(self, model_id: str, base_model: str | None = None) -> None:
     self.launched_model_ids.append(model_id)
     if self.error is not None:
       raise self.error
 
-  def launch_trainer(self, model_id: str) -> None:
-    self.launch(model_id)
+  def launch_trainer(self, model_id: str, base_model: str | None = None) -> None:
+    self.launch(model_id, base_model)
 
-  def launch_sampler(self, model_id: str) -> None:
-    self.launch(model_id)
+  def launch_sampler(self, model_id: str, base_model: str | None = None) -> None:
+    self.launch(model_id, base_model)
 
   def shutdown(self, model_id: str) -> None:
     self.shutdown_model_ids.append(model_id)

--- a/uv.lock
+++ b/uv.lock
@@ -1681,7 +1681,7 @@ wheels = [
 
 [[package]]
 name = "open-rl"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "chz" },

--- a/uv.lock
+++ b/uv.lock
@@ -1710,6 +1710,9 @@ cpu = [
     { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-7-open-rl-cpu') or (extra == 'extra-7-open-rl-cpu' and extra == 'extra-7-open-rl-gpu') or (extra == 'extra-7-open-rl-cpu' and extra == 'extra-7-open-rl-vllm')" },
     { name = "transformers" },
 ]
+dev = [
+    { name = "ruff" },
+]
 gpu = [
     { name = "datasets" },
     { name = "numpy" },
@@ -1743,6 +1746,7 @@ requires-dist = [
     { name = "peft", marker = "extra == 'gpu'" },
     { name = "pydantic" },
     { name = "redis", specifier = ">=5.0.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.5.0" },
     { name = "timeslice", marker = "extra == 'cluster'", git = "https://github.com/llm-d-incubation/llm-d-rl-time-slicing.git?subdirectory=pkg%2Fclient%2Fpython" },
     { name = "torch", marker = "sys_platform == 'linux' and extra == 'gpu'", index = "https://download.pytorch.org/whl/cu129", conflict = { package = "open-rl", extra = "gpu" } },
     { name = "torch", marker = "sys_platform == 'linux' and extra == 'vllm'", index = "https://download.pytorch.org/whl/cu129", conflict = { package = "open-rl", extra = "vllm" } },
@@ -1756,7 +1760,7 @@ requires-dist = [
     { name = "uvicorn" },
     { name = "vllm", marker = "sys_platform == 'linux' and extra == 'vllm'", specifier = "==0.20.0", index = "https://wheels.vllm.ai/0.20.0/cu129", conflict = { package = "open-rl", extra = "vllm" } },
 ]
-provides-extras = ["cpu", "gpu", "vllm", "cluster"]
+provides-extras = ["cpu", "gpu", "vllm", "cluster", "dev"]
 
 [[package]]
 name = "openai"
@@ -2668,6 +2672,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/04/1d/9d12b0a337bab46f4769f8857f4007e3b2d639e14f9a44a0efe157696e64/rpds_py-2026.5.1-cp312-cp312-win32.whl", hash = "sha256:6736718bd4fc49cbcb538ba30516fdbef161522acefb739657d48b97bd864fed", size = 212734, upload-time = "2026-05-28T11:59:29.689Z" },
     { url = "https://files.pythonhosted.org/packages/c5/93/e4116f2de7f56bc7406a76033dc501811ddeb22b7f056b92d632871ebb0c/rpds_py-2026.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:0a7d1eec967df0e9b22614a5e177622e0c89611d03727fa0cb48e45028907870", size = 229045, upload-time = "2026-05-28T11:59:31.033Z" },
     { url = "https://files.pythonhosted.org/packages/cb/53/6c3419d85eb2ec5938a37627c585b42d76a63bb731d6e42ed4b079ebf486/rpds_py-2026.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:1841d067089e117142d79b98aa0df2f08b52f2ecc1819dd2700636c0db74a473", size = 223967, upload-time = "2026-05-28T11:59:32.318Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/dc/35b341fc554ba02f217fc10da57d1a75168cfbcf75b0ef2202176d4c4f2d/ruff-0.15.20.tar.gz", hash = "sha256:1416eb04349192646b54de98f146c4f59afe37d0decfc02c3cbbf396f3a28566", size = 4755489, upload-time = "2026-06-25T17:20:37.578Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/d9/2d5014f0253ba541d2061d9fa7193f48e941c8b21bb88a7ff9bbe0bd0596/ruff-0.15.20-py3-none-linux_armv6l.whl", hash = "sha256:00e188c53e499c3c1637f73c91dcf2fb56d576cab76ce1be50a27c4e80e37078", size = 10839665, upload-time = "2026-06-25T17:19:44.702Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/d3/ac1798ba64f670698867fcfc591d50e7e421bef137db564858f619a30fcf/ruff-0.15.20-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9ebd1fd9b9c95fc0bd7b2761aebec1f030013d2e193a2901b224af68fe47251b", size = 11208649, upload-time = "2026-06-25T17:19:48.787Z" },
+    { url = "https://files.pythonhosted.org/packages/47/47/d3ac899991202095dfcf3d5176be4272642be3cf981a2f1a30f72a2afb95/ruff-0.15.20-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c5b16cdd67ca108185cd36dce98c576350c03b1660a751de725fb049193a0632", size = 10622638, upload-time = "2026-06-25T17:19:51.354Z" },
+    { url = "https://files.pythonhosted.org/packages/33/13/4e043fe30aa94d4ff5213a9881fc296d12960f5971b234a5263fdc225312/ruff-0.15.20-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3413bb3c3d2ca6a8208f1f4809cd2dca3c6de6d0b491c0e70847672bde6e6efd", size = 10984227, upload-time = "2026-06-25T17:19:54.044Z" },
+    { url = "https://files.pythonhosted.org/packages/76/e6/92e7bf40388bc5800073b96564f56264f7e48bfd1a498f5ced6ae6d5a769/ruff-0.15.20-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bd7ec42b3bb3da066488db093308a69c4ac5ee6d2af333a86ba6e2eb2e7dd44b", size = 10622882, upload-time = "2026-06-25T17:19:57.037Z" },
+    { url = "https://files.pythonhosted.org/packages/13/7a/43460be3f24495a3aa46d4b16873e2c4941b3b5f0b00cf88c03b7b94b339/ruff-0.15.20-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e1a36ad0eb77fba9aabfb69ede54de6f376d04ac18ebea022847046d340a8267", size = 11474808, upload-time = "2026-06-25T17:20:00.357Z" },
+    { url = "https://files.pythonhosted.org/packages/27/a0/f37077884873221c6b33b4ab49eb18f9f88e54a16a25a5bca59bef46dd66/ruff-0.15.20-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b6df3b1e4610432f0386dba04d853b5f08cbbc903410c6fcc02f620f05aff53c", size = 12293094, upload-time = "2026-06-25T17:20:03.446Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/74/165545b60256a9704c21ac0ec4a0d07933b320812f9584836c9f4aca4292/ruff-0.15.20-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e89f198a1ea6ef0d727c1cf16088bc91a6cb0ab947dedc966715691647186eae", size = 11526176, upload-time = "2026-06-25T17:20:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/86/b1/a976a136d40ade83ce743578399865f57001003a409acadc0ecbb3051082/ruff-0.15.20-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:309809086c2acb67624950a3c8133e80f32d0d3e27106c0cd60ff26657c9f24b", size = 11520767, upload-time = "2026-06-25T17:20:09.191Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0f/f032696cb01c9b54c0263fa393474d7758f1cdc021a01b04e3cbc2500999/ruff-0.15.20-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:2d2374caa2f2c2f9e2b7da0a50802cfb8b79f55a9b5e49379f564544fbf56487", size = 11500132, upload-time = "2026-06-25T17:20:13.602Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f4/51b1a14bc69e8c224b15dab9cce8e99b425e0455d462caa2b3c9be2b6a8e/ruff-0.15.20-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a1ed17b65293e0c2f22fc387bc13198a5de94bf4429589b0ff6946b0feaf21a3", size = 10943828, upload-time = "2026-06-25T17:20:16.635Z" },
+    { url = "https://files.pythonhosted.org/packages/71/4b/fe267640783cd02bf6c5cc290b1df1051be2ec294c678b5c15fe19e52343/ruff-0.15.20-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:f701305e66b38ea6c91882490eb73459796808e4c6362a1b765255e0cdcd4053", size = 10645418, upload-time = "2026-06-25T17:20:19.4Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/c0/a65aa4ec2f5e87a1df32dc3ec1fede434fe3dfd5cbcf3b503cafc676ab54/ruff-0.15.20-py3-none-musllinux_1_2_i686.whl", hash = "sha256:5b9c0c367ad8e5d0d5b5b8537864c469a0a0e55417aadfbeca41fa61333be9f4", size = 11211770, upload-time = "2026-06-25T17:20:22.033Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/a4/0caa331d954ae2723d729d351c989cb4ca8b6077d5c6c2cb6de75e98c041/ruff-0.15.20-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:01cc00dd58f0df339d0e902219dd53990ea99996a0344e5d9cc8d45d5307e460", size = 11618698, upload-time = "2026-06-25T17:20:25.259Z" },
+    { url = "https://files.pythonhosted.org/packages/10/9b/5f14927848d2fd4aa891fd88d883788c5a7baba561c7874732364045708c/ruff-0.15.20-py3-none-win32.whl", hash = "sha256:ed65ef510e43a137207e0f01cfcf998aeddb1aeeda5c9d35023e910284d7cf21", size = 10857322, upload-time = "2026-06-25T17:20:28.612Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/f0/fe47c501f9dea92a26d788ff98bb5d92ed4cb4c88792c5c88af6b697dc8e/ruff-0.15.20-py3-none-win_amd64.whl", hash = "sha256:a525c81c70fb0380344dd1d8745d8cc1c890b7fc94a58d5a07bd8eb9557b8415", size = 11993274, upload-time = "2026-06-25T17:20:31.871Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/2b/9555445e1201d92b3195f45cdb153a0b68f24e0a4273f6e3d5ab46e212bb/ruff-0.15.20-py3-none-win_arm64.whl", hash = "sha256:2f5b2a6d614e8700388806a14996c40fab2c47b819ef57d790a34878858ed9ca", size = 11343498, upload-time = "2026-06-25T17:20:35.03Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Structured Model Metadata, Time-Slicer Cleanup & Application-Level CPU Offloading

## Overview
This Pull Request modernizes the Full Fine-Tuning (FFT) backend infrastructure by introducing structured serialization for model metadata in Redis, cleaning up legacy environment variables, and implementing zero-fragmentation application-level CPU offloading for trainer worker pods during time-slicer cycles.

---

## Key architectural & Feature Changes

### 1. Structured Model Serialization in Redis
* **`TrainingModelMetadata` Dataclass:** Replaced ad-hoc dictionary storage with a strongly-typed dataclass recording essential model attributes (`base_model`, `model_id`, `created_at`, `config`).
* **Generic KV Interface:** Added generic `set_value`, `get_value`, and `delete_values` key-value methods to the `RequestStore` interface and Redis backend implementation, enabling clean persistence of metadata objects alongside queues.
* **Mandatory Payload Validation:** Made `base_model` a mandatory field in `/api/v1/create_model` requests, ensuring worker pods always receive deterministic model architecture descriptors before initialization.

### 2. Zero-Fragmentation Application-Level CPU Offloading
To maximize hardware utilization when concurrent training jobs share physical GPUs via the Accelerator Time-Slicer, we implemented application-level VRAM $\leftrightarrow$ Pinned DRAM memory swapping inside `FFTTrainingWorker`:
* **Client Toggle & Default:** Added `cpu_offload: bool = True` to `FFTConfig`. Clients passing empty dictionaries `{}` automatically opt-in without SDK contract changes.
* **Symmetric Primitives (`sleep` / `wake_up`):** Hooked into `FFTTrainingRequestsProcessor` around `async with self.time_slicer.acquire()`.
  * `sleep()` transfers weights and gradients to pinned host memory (`.to("cpu", non_blocking=True).pin_memory()`) and replaces CUDA tensors with empty shells (`torch.empty(0, ...)`), avoiding PyTorch memory allocator fragmentation.
  * `wake_up()` reloads shadow host tensors back to CUDA VRAM instantly before batch processing.
* **Lazy Optimizer State Discovery:** Automatically discovers AdamW momentum states (`exp_avg`, `exp_avg_sq`) once initialized after step 1 and swaps them alongside model weights.

### 3. Time-Slicer & Environment Cleanup
* **Removed Legacy Fallbacks:** Cleaned up outdated `OPEN_RL_SNAPSHOT_AGENT_*` environment variable fallbacks in favor of standardized `OPEN_RL_ACCEL_TIMESLICER_*` configuration.
* **Streamlined Worker Management:** Refactored Kubernetes worker launcher and local process manager to rely strictly on structured metadata rather than environment variable propagation.

### 4. Cluster Rollout & Observability
* **Version Bump:** Bumped container tags across gateway, trainer, and sampler pod templates to version `0.1.5`.
* **DCGM Monitoring:** Integrated `10-dcgm-monitoring.yaml` into Kustomize manifests, enabling automated Google Cloud Monitoring (`PodMonitoring`) scraping of GPU utilization, VRAM usage, and clock frequencies every 10 seconds.

---

## Live Performance & Verification (`fft-gsm8k-x2`)

Validated live on GKE L4 nodes running concurrent full fine-tuning jobs (`Qwen/Qwen3-1.7B`). The application-level CPU offloading achieved seamless context switching without out-of-memory errors or fragmentation latency:

| Action / Transition | What is Transferred | Average Latency |
| :--- | :--- | :--- |
| **Initial Offload** | Model Weights (1.7B parameters) | **~2,138 ms** (~2.1s) |
| **Reload (`wake_up`)** | Model Weights | **~283 ms** (~0.28s) |
| **Reload (`wake_up`)** | Model Weights + AdamW States | **~562 ms – 844 ms** (~0.6s – 0.8s) |
| **Post-Step Offload (`sleep`)**| Model Weights + AdamW States | **~728 ms – 3,268 ms** (~0.7s – 3.2s) |

All unit tests (`make test`) and E2E benchmark evaluation scenarios pass cleanly.
