### PR TITLE
Feat: add Gemma 4 and Qwen 4B RL e2e training support and Redis conne…

### DIFF
--- a/examples/autoresearch/recipes/math_rl/train_gemma.py
+++ b/examples/autoresearch/recipes/math_rl/train_gemma.py
@@ -1,0 +1,44 @@
+"""Wrapper around tinker_cookbook.recipes.math_rl.train that registers a Gemma4 renderer."""
+
+import asyncio
+
+import chz
+import tinker
+import tinker_cookbook.renderers as renderers
+from tinker_cookbook.recipes.math_rl.train import CLIConfig, cli_main
+from tinker_cookbook.renderers.base import Message, RenderContext, RenderedMessage, parse_response_for_stop_token
+
+
+class Gemma4Renderer(renderers.Renderer):
+  @property
+  def _bos_tokens(self) -> list[int]:
+    return self.tokenizer.encode("<bos>", add_special_tokens=False)
+
+  @property
+  def _end_message_token(self) -> int:
+    return self.tokenizer.encode("<turn|>", add_special_tokens=False)[0]
+
+  def get_stop_sequences(self) -> list[int]:
+    return [self._end_message_token]
+
+  def render_message(self, message: Message, ctx: RenderContext) -> RenderedMessage:
+    maybe_newline = "\n" if ctx.idx > 0 else ""
+    role_map = {"assistant": "model", "model": "model", "user": "user", "system": "user"}
+    role = role_map.get(message["role"], "user")
+    header_str = f"{maybe_newline}<|turn>{role}\n"
+    content = message["content"]
+    output_content = str(content) + "<turn|>" if content != "" else ""
+    header = tinker.types.EncodedTextChunk(tokens=self.tokenizer.encode(header_str, add_special_tokens=False))
+    output = [tinker.types.EncodedTextChunk(tokens=self.tokenizer.encode(output_content, add_special_tokens=False))] if output_content else []
+    return RenderedMessage(header=header, output=output)
+
+  def parse_response(self, response: list[int]):
+    return parse_response_for_stop_token(response, self.tokenizer, self._end_message_token)
+
+
+# Register into SDK global lookup dictionary at script startup
+renderers.register_renderer("gemma4", lambda tokenizer, img_proc=None: Gemma4Renderer(tokenizer))
+
+if __name__ == "__main__":
+  cli_config = chz.entrypoint(CLIConfig)
+  asyncio.run(cli_main(cli_config))

--- a/k8s/deploy/distributed-fft-timeslice/04-gateway.yaml
+++ b/k8s/deploy/distributed-fft-timeslice/04-gateway.yaml
@@ -44,7 +44,7 @@ spec:
               name: open-rl-config
               key: ENABLE_GCP_TRACE
         - name: REDIS_URL
-          value: "redis://redis-service:6379"
+          value: "redis://redis-service:6379?max_connections=500"
         # This cluster path assumes one base model per deployment.
         - name: BASE_MODEL
           valueFrom:

--- a/k8s/deploy/distributed-fft-timeslice/05-worker-pod-template.yaml
+++ b/k8s/deploy/distributed-fft-timeslice/05-worker-pod-template.yaml
@@ -26,7 +26,7 @@ data:
         command: ["uv", "run", "python", "-m", "server.training_requests_processor"]
         env:
         - name: REDIS_URL
-          value: "redis://redis-service:6379"
+          value: "redis://redis-service:6379?max_connections=500"
         - name: BASE_MODEL
           valueFrom:
             configMapKeyRef:

--- a/k8s/deploy/distributed-fft-timeslice/09-sampler-pod-template.yaml
+++ b/k8s/deploy/distributed-fft-timeslice/09-sampler-pod-template.yaml
@@ -20,7 +20,7 @@ data:
         command: ["uv", "run", "python", "-u", "-m", "server.vllm_sampler"]
         env:
         - name: REDIS_URL
-          value: "redis://redis-service:6379"
+          value: "redis://redis-service:6379?max_connections=500"
         - name: BASE_MODEL
           valueFrom:
             configMapKeyRef:

--- a/scripts/run_training_e2e.py
+++ b/scripts/run_training_e2e.py
@@ -518,20 +518,29 @@ def run_gsm8k_x2(config: RunConfig, base_url: str, watch: list[ManagedProcess]) 
   run_gsm8k_eval(config, eval_paths)
 
 
+def _math_rl_train_module_and_renderer(base_model: str) -> tuple[str, str]:
+  if "gemma" in base_model.lower():
+    return "recipes.math_rl.train_gemma", "gemma4"
+  if "Instruct" in base_model or "Qwen2.5" in base_model:
+    return "tinker_cookbook.recipes.math_rl.train", "qwen3_instruct"
+  return "tinker_cookbook.recipes.math_rl.train", "qwen3"
+
+
 def run_gsm8k_rl(config: RunConfig, base_url: str, watch: list[ManagedProcess]) -> None:
   log_path = str(open_rl_tmp_dir(config) / "fft_gsm8k_rl")
   if os.path.exists(log_path):
     shutil.rmtree(log_path)
+  module_name, renderer_name = _math_rl_train_module_and_renderer(config.base_model)
   args = [
     "env=gsm8k",
     f"model_name={config.base_model}",
-    "renderer_name=qwen3_instruct",
+    f"renderer_name={renderer_name}",
     f"max_steps={config.steps if config.steps is not None else 2}",
     f"base_url={base_url}",
     f"log_path={log_path}",
-    "group_size=2",
-    "groups_per_batch=1",
-    "max_tokens=64",
+    "group_size=4",
+    "groups_per_batch=16",
+    "max_tokens=512",
     "learning_rate=1e-5",
     "eval_every=0",
     "save_every=1",
@@ -539,7 +548,7 @@ def run_gsm8k_rl(config: RunConfig, base_url: str, watch: list[ManagedProcess]) 
   out = None
   try:
     out = run_command(
-      ["uv", "--project", "examples", "run", "python", "-m", "tinker_cookbook.recipes.math_rl.train", *args],
+      ["uv", "--project", "examples", "run", "python", "-m", module_name, *args],
       env=examples_env(config),
       watch=watch,
     )
@@ -557,23 +566,26 @@ def run_gsm8k_rl_x2(config: RunConfig, base_url: str, watch: list[ManagedProcess
       log_path = str(open_rl_tmp_dir(config) / f"fft_gsm8k_rl_{job}")
       if os.path.exists(log_path):
         shutil.rmtree(log_path)
+      module_name, renderer_name = _math_rl_train_module_and_renderer(config.base_model)
+      temp = "1.0"
       args = [
         "env=gsm8k",
         f"model_name={config.base_model}",
-        "renderer_name=qwen3_instruct",
+        f"renderer_name={renderer_name}",
         f"max_steps={config.steps if config.steps is not None else 2}",
         f"base_url={base_url}",
         f"log_path={log_path}",
-        "group_size=2",
-        "groups_per_batch=1",
-        "max_tokens=64",
+        "group_size=8",
+        "groups_per_batch=8",
+        "max_tokens=512",
         "learning_rate=1e-5",
+        f"temperature={temp}",
         "eval_every=0",
         "save_every=0",
         *shlex.split(config.extra),
       ]
       results[job] = run_command(
-        ["uv", "--project", "examples", "run", "python", "-m", "tinker_cookbook.recipes.math_rl.train", *args],
+        ["uv", "--project", "examples", "run", "python", "-m", module_name, *args],
         env=examples_env(config),
         watch=watch,
         prefix=f"[{job}] ",


### PR DESCRIPTION
…ction pooling

- Add dynamic renderer selection (`_math_rl_train_module_and_renderer`) in `scripts/run_training_e2e.py` supporting Gemma 4 and Qwen 3/2.5 families.
- Configure `group_size=8`, `groups_per_batch=8`, `max_tokens=512`, and unconditional sampling temperature `T=1.0` in `run_gsm8k_rl_x2` for concurrent consistency verification testing.
- Add `train_gemma.py` wrapper script defining `Gemma4Renderer` to format turns cleanly without trailing control syntax on empty message contents.
- Set `max_connections=500` on Redis URL in Kubernetes deployment manifests (`04-gateway.yaml`, `05-worker-pod-template.yaml`, `09-sampler-pod-template.yaml`) to prevent connection exhaustion during concurrent multi-model distributed fine-tuning.

TAG=agy
CONV=b2e30b80-03d6-4731-95e9-249fe4210408