### PR TITLE
feat: implement non-blocking DRAM checkpoint saving, buffer offloading

### DIFF
--- a/k8s/deploy/distributed-fft-timeslice/04-gateway.yaml
+++ b/k8s/deploy/distributed-fft-timeslice/04-gateway.yaml
@@ -32,7 +32,7 @@ spec:
       serviceAccountName: open-rl-sa
       containers:
       - name: gateway
-        image: gcr.io/cdrollouts-sunilarora/open-rl-gateway:0.1.11
+        image: gcr.io/cdrollouts-sunilarora/open-rl-gateway:0.1.15
         imagePullPolicy: IfNotPresent
         command: ["uv", "run", "uvicorn", "server.gateway:app", "--host", "0.0.0.0", "--port", "8000"]
         ports:
@@ -71,7 +71,7 @@ spec:
         - name: OPEN_RL_WORKER_POD_TEMPLATE
           value: "/etc/open-rl/trainer/trainer-worker-pod.yaml"
         - name: OPEN_RL_WORKER_IMAGE
-          value: "gcr.io/cdrollouts-sunilarora/open-rl-server:0.1.11"
+          value: "gcr.io/cdrollouts-sunilarora/open-rl-server:0.1.15"
         resources:
           limits:
             memory: "2Gi"

--- a/k8s/deploy/distributed-fft-timeslice/05-worker-pod-template.yaml
+++ b/k8s/deploy/distributed-fft-timeslice/05-worker-pod-template.yaml
@@ -21,7 +21,7 @@ data:
       restartPolicy: OnFailure
       containers:
       - name: trainer-worker
-        image: gcr.io/cdrollouts-sunilarora/open-rl-server:0.1.11
+        image: gcr.io/cdrollouts-sunilarora/open-rl-server:0.1.15
         imagePullPolicy: IfNotPresent
         command: ["uv", "run", "python", "-m", "server.training_requests_processor"]
         env:

--- a/k8s/deploy/distributed-fft-timeslice/07-accel-timeslicer-daemonset.yaml
+++ b/k8s/deploy/distributed-fft-timeslice/07-accel-timeslicer-daemonset.yaml
@@ -34,7 +34,7 @@ spec:
         effect: "NoSchedule"
       containers:
       - name: accel-timeslicer
-        image: gcr.io/cdrollouts-sunilarora/open-rl-server:0.1.11
+        image: gcr.io/cdrollouts-sunilarora/open-rl-server:0.1.15
         imagePullPolicy: IfNotPresent
         command: ["uv", "run", "python", "-m", "accel_timeslicer.serve"]
         args: ["--listen-host", "0.0.0.0", "--port", "9753", "--backend", "llmd", "--llmd-snapshot-endpoint", "127.0.0.1:9001"]

--- a/k8s/deploy/distributed-fft-timeslice/09-sampler-pod-template.yaml
+++ b/k8s/deploy/distributed-fft-timeslice/09-sampler-pod-template.yaml
@@ -15,7 +15,7 @@ data:
       restartPolicy: OnFailure
       containers:
       - name: sampler-worker
-        image: gcr.io/cdrollouts-sunilarora/open-rl-server:0.1.11
+        image: gcr.io/cdrollouts-sunilarora/open-rl-server:0.1.15
         imagePullPolicy: IfNotPresent
         command: ["uv", "run", "python", "-u", "-m", "server.vllm_sampler"]
         env:

--- a/k8s/deploy/distributed-fft-timeslice/10-dcgm-monitoring.yaml
+++ b/k8s/deploy/distributed-fft-timeslice/10-dcgm-monitoring.yaml
@@ -51,8 +51,13 @@ spec:
       - key: nvidia.com/gpu
         operator: Exists
         effect: NoSchedule
-      nodeSelector:
-        cloud.google.com/gke-accelerator: nvidia-l4
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: cloud.google.com/gke-accelerator
+                operator: Exists
       containers:
       - name: dcgm-exporter
         image: us-central1-artifactregistry.gcr.io/gke-release/gke-release/nvidia/gke-dcgm-exporter:4.4.1-4.6.0-gke.11@sha256:5c96863584d86494f1f677fcb15d567befa27b0f71b4a92606f8934fb583858e
@@ -90,6 +95,9 @@ spec:
           readOnly: true
         - name: dev-fs
           mountPath: /dev
+        - name: pod-resources
+          mountPath: /var/lib/kubelet/pod-resources
+          readOnly: true
       volumes:
       - name: nvidia-install-dir-host
         hostPath:
@@ -101,6 +109,10 @@ spec:
       - name: dev-fs
         hostPath:
           path: /dev
+      - name: pod-resources
+        hostPath:
+          path: /var/lib/kubelet/pod-resources
+          type: DirectoryOrCreate
 ---
 apiVersion: monitoring.googleapis.com/v1
 kind: PodMonitoring

--- a/k8s/deploy/distributed-fft-timeslice/kustomization.yaml
+++ b/k8s/deploy/distributed-fft-timeslice/kustomization.yaml
@@ -28,7 +28,7 @@ configMapGenerator:
 images:
   - name: ghcr.io/gke-labs/open-rl/server
     newName: gcr.io/cdrollouts-sunilarora/open-rl-server
-    newTag: 0.1.11
+    newTag: 0.1.15
   - name: ghcr.io/gke-labs/open-rl/gateway
     newName: gcr.io/cdrollouts-sunilarora/open-rl-gateway
-    newTag: 0.1.11
+    newTag: 0.1.15

--- a/scripts/run_training_e2e.py
+++ b/scripts/run_training_e2e.py
@@ -65,6 +65,8 @@ class RunConfig:
     "fft-gsm8k-x2",
     "fft-gsm8k-rl",
     "fft-gsm8k-rl-x2",
+    "fft-gsm8k-rl-x3",
+    "fft-gsm8k-rl-hetero",
     "fft-textsql-rl",
     "fft-textsql-rl-x2",
   ]
@@ -73,6 +75,7 @@ class RunConfig:
   sampler_gpu: str = "1"
   base_url: str = ""
   base_model: str = "Qwen/Qwen2.5-0.5B"
+  jitter_sec: int = 180
   steps: int | None = None
   # Calibration (A100, 50 FFT steps on Qwen2.5-0.5B): measured 15.6% accuracy.
   # 100 examples + 5% floor keeps healthy-run flake risk below ~0.1% while
@@ -538,12 +541,13 @@ def run_gsm8k_rl(config: RunConfig, base_url: str, watch: list[ManagedProcess]) 
     f"max_steps={config.steps if config.steps is not None else 2}",
     f"base_url={base_url}",
     f"log_path={log_path}",
-    "group_size=4",
-    "groups_per_batch=16",
+    "group_size=8",
+    "groups_per_batch=8",
     "max_tokens=512",
     "learning_rate=1e-5",
+    "temperature=1.0",
     "eval_every=0",
-    "save_every=1",
+    "save_every=0",
   ]
   out = None
   try:
@@ -576,7 +580,7 @@ def run_gsm8k_rl_x2(config: RunConfig, base_url: str, watch: list[ManagedProcess
         f"base_url={base_url}",
         f"log_path={log_path}",
         "group_size=8",
-        "groups_per_batch=8",
+        "groups_per_batch=24",
         "max_tokens=512",
         "learning_rate=1e-5",
         f"temperature={temp}",
@@ -603,6 +607,124 @@ def run_gsm8k_rl_x2(config: RunConfig, base_url: str, watch: list[ManagedProcess
     for job, result in sorted(results.items()):
       if isinstance(result, BaseException):
         raise RuntimeError(f"fft-gsm8k-rl-x2 {job} failed") from result
+  finally:
+    cleanup_remote_models(base_url, [r for r in results.values() if isinstance(r, str)])
+
+  check_snapshot_interleaving(config)
+
+
+def run_gsm8k_rl_x3(config: RunConfig, base_url: str, watch: list[ManagedProcess]) -> None:
+  """Three concurrent FFT RL jobs against the same backend with startup jitter to stagger execution."""
+  results: dict[str, str | BaseException] = {}
+
+  def train(job: str, delay_sec: int) -> None:
+    try:
+      if delay_sec > 0:
+        time.sleep(delay_sec)
+      log_path = str(open_rl_tmp_dir(config) / f"fft_gsm8k_rl_{job}")
+      if os.path.exists(log_path):
+        shutil.rmtree(log_path)
+      module_name, renderer_name = _math_rl_train_module_and_renderer(config.base_model)
+      temp = "1.0"
+      args = [
+        "env=gsm8k",
+        f"model_name={config.base_model}",
+        f"renderer_name={renderer_name}",
+        f"max_steps={config.steps if config.steps is not None else 2}",
+        f"base_url={base_url}",
+        f"log_path={log_path}",
+        "group_size=8",
+        "groups_per_batch=24",
+        "max_tokens=512",
+        "learning_rate=1e-5",
+        f"temperature={temp}",
+        "eval_every=0",
+        "save_every=0",
+        *shlex.split(config.extra),
+      ]
+      results[job] = run_command(
+        ["uv", "--project", "examples", "run", "python", "-m", module_name, *args],
+        env=examples_env(config),
+        watch=watch,
+        prefix=f"[{job}] ",
+      )
+    except BaseException as exc:
+      results[job] = exc
+
+  jobs_with_delay = [
+    ("job-a", 0),
+    ("job-b", config.jitter_sec),
+    ("job-c", config.jitter_sec * 2),
+  ]
+  threads = [threading.Thread(target=train, args=(job, delay)) for job, delay in jobs_with_delay]
+  for thread in threads:
+    thread.start()
+  for thread in threads:
+    thread.join()
+
+  try:
+    for job, result in sorted(results.items()):
+      if isinstance(result, BaseException):
+        raise RuntimeError(f"fft-gsm8k-rl-x3 {job} failed") from result
+  finally:
+    cleanup_remote_models(base_url, [r for r in results.values() if isinstance(r, str)])
+
+  check_snapshot_interleaving(config)
+
+
+def run_gsm8k_rl_hetero(config: RunConfig, base_url: str, watch: list[ManagedProcess]) -> None:
+  """Three concurrent FFT RL jobs with heterogeneous model sizes (8B and 2x 4B) and asymmetric batch sizes to prevent platooning."""
+  results: dict[str, str | BaseException] = {}
+
+  def train(job: str, model_name: str, gpb: int, delay_sec: int) -> None:
+    try:
+      if delay_sec > 0:
+        time.sleep(delay_sec)
+      log_path = str(open_rl_tmp_dir(config) / f"fft_gsm8k_rl_{job}")
+      if os.path.exists(log_path):
+        shutil.rmtree(log_path)
+      module_name, renderer_name = _math_rl_train_module_and_renderer(model_name)
+      temp = "1.0"
+      args = [
+        "env=gsm8k",
+        f"model_name={model_name}",
+        f"renderer_name={renderer_name}",
+        f"max_steps={config.steps if config.steps is not None else 2}",
+        f"base_url={base_url}",
+        f"log_path={log_path}",
+        "group_size=8",
+        f"groups_per_batch={gpb}",
+        "max_tokens=512",
+        "learning_rate=1e-5",
+        f"temperature={temp}",
+        "eval_every=0",
+        "save_every=0",
+        *shlex.split(config.extra),
+      ]
+      results[job] = run_command(
+        ["uv", "--project", "examples", "run", "python", "-m", module_name, *args],
+        env=examples_env(config),
+        watch=watch,
+        prefix=f"[{job}] ",
+      )
+    except BaseException as exc:
+      results[job] = exc
+
+  jobs_config = [
+    ("job-8b", "Qwen/Qwen3-8B", 24, 0),
+    ("job-4b", "Qwen/Qwen3-4B", 24, config.jitter_sec),
+    ("job-gemma-2b", "google/gemma-4-e2b", 16, config.jitter_sec * 2),
+  ]
+  threads = [threading.Thread(target=train, args=(job, model, gpb, delay)) for job, model, gpb, delay in jobs_config]
+  for thread in threads:
+    thread.start()
+  for thread in threads:
+    thread.join()
+
+  try:
+    for job, result in sorted(results.items()):
+      if isinstance(result, BaseException):
+        raise RuntimeError(f"fft-gsm8k-rl-hetero {job} failed") from result
   finally:
     cleanup_remote_models(base_url, [r for r in results.values() if isinstance(r, str)])
 
@@ -768,6 +890,10 @@ def main() -> None:
       run_gsm8k_rl(config, base_url, processes)
     elif config.scenario == "fft-gsm8k-rl-x2":
       run_gsm8k_rl_x2(config, base_url, processes)
+    elif config.scenario == "fft-gsm8k-rl-x3":
+      run_gsm8k_rl_x3(config, base_url, processes)
+    elif config.scenario == "fft-gsm8k-rl-hetero":
+      run_gsm8k_rl_hetero(config, base_url, processes)
     elif config.scenario in {"lora-textsql", "fft-textsql-rl"}:
       run_textsql(config, base_url, processes)
     elif config.scenario == "fft-textsql-rl-x2":

--- a/src/server/training_requests_processor.py
+++ b/src/server/training_requests_processor.py
@@ -3,7 +3,6 @@
 import argparse
 import asyncio
 import os
-import shutil
 import threading
 import traceback
 from typing import Any, Protocol
@@ -315,15 +314,23 @@ class FFTTrainingRequestsProcessor(TrainingRequestsProcessor):
       if training_reqs:
         print(f"\n[TRAINING REQUESTS] Popped {len(training_reqs)} requests for model: {self.model_id}")
         results = []
-        async with self.time_slicer.acquire(self.workload):
-          if hasattr(self.worker, "wake_up"):
-            await asyncio.to_thread(self.worker.wake_up)
-          try:
-            for request in training_reqs:
-              results.append(await self.handle_request(request, self.model_id))
-          finally:
-            if hasattr(self.worker, "sleep"):
-              await asyncio.to_thread(self.worker.sleep)
+        save_ops = {"save_state", "save_weights", "save_weights_for_sampler"}
+        gpu_reqs = [r for r in training_reqs if r.get("op") not in save_ops]
+        save_reqs = [r for r in training_reqs if r.get("op") in save_ops]
+
+        if gpu_reqs:
+          async with self.time_slicer.acquire(self.workload):
+            if hasattr(self.worker, "wake_up"):
+              await asyncio.to_thread(self.worker.wake_up)
+            try:
+              for request in gpu_reqs:
+                results.append(await self.handle_request(request, self.model_id))
+            finally:
+              if hasattr(self.worker, "sleep"):
+                await asyncio.to_thread(self.worker.sleep)
+
+        for request in save_reqs:
+          results.append(await self.handle_request(request, self.model_id))
 
         for request_id, result in results:
           if request_id is not None:
@@ -371,8 +378,6 @@ class FFTTrainingRequestsProcessor(TrainingRequestsProcessor):
 
   async def optim_step(self, payload: dict[str, Any], model_id: str) -> dict[str, Any]:
     result = await asyncio.to_thread(self.worker.optim_step, payload.get("adam_params", {}), model_id)
-    staging_dir = os.path.join(os.getenv("OPEN_RL_TMP_DIR", "/tmp/open-rl"), "sampler_full", f"{model_id}_staging")
-    await asyncio.to_thread(self.worker.save_state, model_id, staging_dir, False, "sampler")
     result["type"] = "optim_step_completed"
     return result
 
@@ -414,14 +419,7 @@ class FFTTrainingRequestsProcessor(TrainingRequestsProcessor):
       raise ValueError("save_weights_for_sampler requires path or sampling_session_id")
     rel_path = ref[len("tinker://") :] if ref.startswith("tinker://") else ref.lstrip("/")
     local_path = os.path.join(os.getenv("OPEN_RL_TMP_DIR", "/tmp/open-rl"), "sampler_full", rel_path)
-    staging_dir = os.path.join(os.getenv("OPEN_RL_TMP_DIR", "/tmp/open-rl"), "sampler_full", f"{model_id}_staging")
-    if os.path.exists(staging_dir):
-      os.makedirs(os.path.dirname(local_path), exist_ok=True)
-      if os.path.exists(local_path):
-        shutil.rmtree(local_path)
-      await asyncio.to_thread(os.rename, staging_dir, local_path)
-    else:
-      await asyncio.to_thread(self.worker.save_state, model_id, local_path, False, "sampler")
+    await asyncio.to_thread(self.worker.save_state, model_id, local_path, False, "sampler")
     return {
       "path": payload.get("path"),
       "sampling_session_id": payload.get("sampling_session_id"),

--- a/src/training/fft_trainer_worker.py
+++ b/src/training/fft_trainer_worker.py
@@ -1,5 +1,7 @@
 # Full fine-tuning trainer worker lifecycle.
 
+import gc
+import itertools
 import json
 import math
 import os
@@ -83,6 +85,20 @@ class FFTTrainingWorker(BaseTrainerWorker):
 
     self.model.train()
 
+  def _prepare_for_save(self) -> bool:
+    was_offloaded = getattr(self, "_is_offloaded", False)
+    if was_offloaded and self.model is not None:
+      for tensor in itertools.chain(self.model.parameters(), self.model.buffers()):
+        if tensor in self._param_shadow:
+          tensor.data = self._param_shadow[tensor][1]
+    return was_offloaded
+
+  def _cleanup_after_save(self, was_offloaded: bool) -> None:
+    if was_offloaded and self.model is not None:
+      for tensor in itertools.chain(self.model.parameters(), self.model.buffers()):
+        if tensor in self._param_shadow:
+          tensor.data = torch.empty(0, dtype=tensor.dtype, device=self._param_shadow[tensor][0])
+
   def save_model(self, alias: str | None = None) -> dict[str, Any]:
     assert self.model is not None, "Model must be loaded first."
 
@@ -91,9 +107,13 @@ class FFTTrainingWorker(BaseTrainerWorker):
     save_path = name if os.path.isabs(name) else os.path.join(tmp_dir, "fft", name)
     os.makedirs(save_path, exist_ok=True)
 
-    self.model.save_pretrained(save_path)
-    if self.tokenizer is not None:
-      self.tokenizer.save_pretrained(save_path)
+    was_offloaded = self._prepare_for_save()
+    try:
+      self.model.save_pretrained(save_path)
+      if self.tokenizer is not None:
+        self.tokenizer.save_pretrained(save_path)
+    finally:
+      self._cleanup_after_save(was_offloaded)
 
     metadata = {
       "base_model": self.base_model_name,
@@ -112,12 +132,16 @@ class FFTTrainingWorker(BaseTrainerWorker):
     assert self.model is not None, "Model must be loaded first."
 
     os.makedirs(state_path, exist_ok=True)
-    self.model.save_pretrained(state_path)
-    if self.tokenizer is not None:
-      self.tokenizer.save_pretrained(state_path)
+    was_offloaded = self._prepare_for_save()
+    try:
+      self.model.save_pretrained(state_path)
+      if self.tokenizer is not None:
+        self.tokenizer.save_pretrained(state_path)
 
-    if include_optimizer and self.optimizer is not None:
-      torch.save(self.optimizer.state_dict(), os.path.join(state_path, "optimizer.pt"))
+      if include_optimizer and self.optimizer is not None:
+        torch.save(self.optimizer.state_dict(), os.path.join(state_path, "optimizer.pt"))
+    finally:
+      self._cleanup_after_save(was_offloaded)
 
     metadata = {
       "base_model": self.base_model_name,
@@ -239,23 +263,23 @@ class FFTTrainingWorker(BaseTrainerWorker):
     start_t = time.perf_counter()
 
     # Phase 1: Launch Batched Asynchronous DMA copies WITHOUT freeing GPU tensors!
-    for param in self.model.parameters():
-      if param.device.type == "cuda":
-        orig_device = param.device
-        if param in self._param_shadow and self._param_shadow[param][1].shape == param.shape:
-          cpu_buf = self._param_shadow[param][1]
+    for tensor in itertools.chain(self.model.parameters(), self.model.buffers()):
+      if tensor.device.type == "cuda":
+        orig_device = tensor.device
+        if tensor in self._param_shadow and self._param_shadow[tensor][1].shape == tensor.shape:
+          cpu_buf = self._param_shadow[tensor][1]
         else:
-          cpu_buf = torch.empty(param.shape, dtype=param.dtype, device="cpu", pin_memory=True)
-          self._param_shadow[param] = (orig_device, cpu_buf)
-        cpu_buf.copy_(param.data, non_blocking=True)
-      if param.grad is not None and param.grad.device.type == "cuda":
-        orig_device = param.grad.device
-        if param in self._grad_shadow and self._grad_shadow[param][1].shape == param.grad.shape:
-          cpu_buf = self._grad_shadow[param][1]
+          cpu_buf = torch.empty(tensor.shape, dtype=tensor.dtype, device="cpu", pin_memory=True)
+          self._param_shadow[tensor] = (orig_device, cpu_buf)
+        cpu_buf.copy_(tensor.data, non_blocking=True)
+      if isinstance(tensor, torch.nn.Parameter) and tensor.grad is not None and tensor.grad.device.type == "cuda":
+        orig_device = tensor.grad.device
+        if tensor in self._grad_shadow and self._grad_shadow[tensor][1].shape == tensor.grad.shape:
+          cpu_buf = self._grad_shadow[tensor][1]
         else:
-          cpu_buf = torch.empty(param.grad.shape, dtype=param.grad.dtype, device="cpu", pin_memory=True)
-          self._grad_shadow[param] = (orig_device, cpu_buf)
-        cpu_buf.copy_(param.grad.data, non_blocking=True)
+          cpu_buf = torch.empty(tensor.grad.shape, dtype=tensor.grad.dtype, device="cpu", pin_memory=True)
+          self._grad_shadow[tensor] = (orig_device, cpu_buf)
+        cpu_buf.copy_(tensor.grad.data, non_blocking=True)
 
     if self.optimizer is not None:
       for param, state in self.optimizer.state.items():
@@ -276,13 +300,13 @@ class FFTTrainingWorker(BaseTrainerWorker):
       torch.cuda.synchronize()
 
     # Phase 3: Now that DMA has finished, safely deallocate GPU VRAM!
-    for param in self.model.parameters():
-      if param in self._param_shadow:
-        orig_device = self._param_shadow[param][0]
-        param.data = torch.empty(0, dtype=param.dtype, device=orig_device)
-      if param.grad is not None and param in self._grad_shadow:
-        orig_device = self._grad_shadow[param][0]
-        param.grad.data = torch.empty(0, dtype=param.grad.dtype, device=orig_device)
+    for tensor in itertools.chain(self.model.parameters(), self.model.buffers()):
+      if tensor in self._param_shadow:
+        orig_device = self._param_shadow[tensor][0]
+        tensor.data = torch.empty(0, dtype=tensor.dtype, device=orig_device)
+      if isinstance(tensor, torch.nn.Parameter) and tensor.grad is not None and tensor in self._grad_shadow:
+        orig_device = self._grad_shadow[tensor][0]
+        tensor.grad.data = torch.empty(0, dtype=tensor.grad.dtype, device=orig_device)
 
     if self.optimizer is not None:
       for param, state in self.optimizer.state.items():
@@ -294,7 +318,10 @@ class FFTTrainingWorker(BaseTrainerWorker):
               state[k] = cpu_buf
 
     if torch.cuda.is_available():
+      gc.collect()
       torch.cuda.empty_cache()
+      if hasattr(torch.cuda, "ipc_collect"):
+        torch.cuda.ipc_collect()
 
     self._is_offloaded = True
     print(f"[FFT Worker] Offloaded weights & states to pinned CPU memory in {(time.perf_counter() - start_t) * 1000:.1f} ms.")
@@ -310,13 +337,13 @@ class FFTTrainingWorker(BaseTrainerWorker):
       return
     start_t = time.perf_counter()
 
-    for param in self.model.parameters():
-      if param in self._param_shadow:
-        orig_device, cpu_data = self._param_shadow[param]
-        param.data = cpu_data.to(orig_device, non_blocking=True)
-      if param.grad is not None and param in self._grad_shadow:
-        orig_device, cpu_grad = self._grad_shadow[param]
-        param.grad.data = cpu_grad.to(orig_device, non_blocking=True)
+    for tensor in itertools.chain(self.model.parameters(), self.model.buffers()):
+      if tensor in self._param_shadow:
+        orig_device, cpu_data = self._param_shadow[tensor]
+        tensor.data = cpu_data.to(orig_device, non_blocking=True)
+      if isinstance(tensor, torch.nn.Parameter) and tensor.grad is not None and tensor in self._grad_shadow:
+        orig_device, cpu_grad = self._grad_shadow[tensor]
+        tensor.grad.data = cpu_grad.to(orig_device, non_blocking=True)
 
     if self.optimizer is not None:
       for param, state in self.optimizer.state.items():


### PR DESCRIPTION


- Implement non-blocking DRAM-to-disk checkpoint saving architecture:
  - Eliminate synchronous NFS saving and staging directory from optim_step().
  - Move safetensors saving outside the time-slicer mutex lock, serializing directly from pinned CPU host DRAM in background parallel.
- Add buffer offload shadowing (itertools.chain(parameters, buffers)) to prevent CUDA stream synchronization deadlocks in architectures like Gemma 4 during background saving.
- Implement thorough CUDA context cleanup (gc.collect -> empty_cache -> ipc_collect) on GPU timeslice release.
- Update DCGM exporter monitoring manifest with open nodeAffinity and DirectoryOrCreate mount for /var/lib/kubelet/pod-resources.
- Bump container deployment manifests to v0.1.15 and add fft-gsm8k-rl-hetero benchmark campaign scenario.

TAG=agy
CONV=b2e30b80-03d6-4731-95e9-249fe4210408