### PR TITLE
Persist Tinker sessions and refresh heartbeat TTLs

### DIFF
--- a/src/server/gateway.py
+++ b/src/server/gateway.py
@@ -16,6 +16,7 @@ from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
+from server.protocol import ClientSession, CreateSessionRequest, SessionHeartbeatRequest
 from server.store import get_store
 from server.worker_launch_processor import (
   FFTWorkerManager,
@@ -50,6 +51,7 @@ logging.getLogger("uvicorn.access").addFilter(FilterNoisyEndpoints())
 
 TMP_DIR = os.getenv("OPEN_RL_TMP_DIR", "/tmp/open-rl")
 VLLM_URL = os.getenv("VLLM_URL", "http://127.0.0.1:8001")
+SESSION_KEY_PREFIX = "open_rl:session:"
 
 
 # *** Helpers ***
@@ -85,6 +87,30 @@ def checkpoint_state_path(model_id: str, name: str) -> str:
   if os.path.isabs(name):
     return name
   return os.path.join(TMP_DIR, "checkpoints", model_id, "weights", name)
+
+
+def session_ttl_seconds() -> int:
+  raw_ttl = os.getenv("OPEN_RL_SESSION_TTL_SECONDS", "300")
+  try:
+    ttl_seconds = int(raw_ttl)
+  except ValueError as exc:
+    raise ValueError("OPEN_RL_SESSION_TTL_SECONDS must be a positive integer") from exc
+  if ttl_seconds < 1:
+    raise ValueError("OPEN_RL_SESSION_TTL_SECONDS must be a positive integer")
+  return ttl_seconds
+
+
+def session_key(session_id: str) -> str:
+  return f"{SESSION_KEY_PREFIX}{session_id}"
+
+
+async def put_session(session: ClientSession, ttl_seconds: int) -> None:
+  await store.set_value(session_key(session.session_id), session.model_dump_json(), expires_seconds=ttl_seconds)
+
+
+async def get_session(session_id: str) -> ClientSession | None:
+  value = await store.get_value(session_key(session_id))
+  return ClientSession.model_validate_json(value) if value is not None else None
 
 
 def base_model_id_from_sampling_ref(model_id: str | None) -> str | None:
@@ -269,12 +295,38 @@ async def client_config(_: dict):
 
 
 @app.post("/api/v1/create_session")
-async def create_session(_: dict):
-  return {"session_id": "sess-real-123", "type": "create_session"}
+async def create_session(req: CreateSessionRequest):
+  try:
+    ttl_seconds = session_ttl_seconds()
+  except ValueError as exc:
+    return JSONResponse(status_code=500, content={"error": str(exc)})
+
+  now = time.time()
+  session = ClientSession(
+    session_id=f"sess-{uuid.uuid4().hex}",
+    created_at=now,
+    last_heartbeat=now,
+    tags=req.tags,
+    user_metadata=req.user_metadata,
+    sdk_version=req.sdk_version,
+    project_id=req.project_id,
+  )
+  await put_session(session, ttl_seconds)
+  return {"session_id": session.session_id, "type": "create_session"}
 
 
 @app.post("/api/v1/session_heartbeat")
-async def session_heartbeat(_: dict):
+async def session_heartbeat(req: SessionHeartbeatRequest):
+  try:
+    ttl_seconds = session_ttl_seconds()
+  except ValueError as exc:
+    return JSONResponse(status_code=500, content={"error": str(exc)})
+
+  session = await get_session(req.session_id)
+  if session is None:
+    return JSONResponse(status_code=404, content={"error": "session not found or expired"})
+  session.last_heartbeat = time.time()
+  await put_session(session, ttl_seconds)
   return {"type": "session_heartbeat"}
 
 

--- a/src/server/protocol.py
+++ b/src/server/protocol.py
@@ -1,0 +1,30 @@
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class CreateSessionRequest(BaseModel):
+  model_config = ConfigDict(extra="ignore")
+
+  tags: list[str] = Field(default_factory=list)
+  user_metadata: dict[str, Any] | None = None
+  sdk_version: str | None = None
+  project_id: str | None = None
+
+
+class SessionHeartbeatRequest(BaseModel):
+  model_config = ConfigDict(extra="ignore")
+
+  session_id: str = Field(min_length=1)
+
+
+class ClientSession(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  session_id: str
+  created_at: float
+  last_heartbeat: float
+  tags: list[str] = Field(default_factory=list)
+  user_metadata: dict[str, Any] | None = None
+  sdk_version: str | None = None
+  project_id: str | None = None

--- a/src/server/store.py
+++ b/src/server/store.py
@@ -47,6 +47,16 @@ class RequestStore(ABC):
     """Block until the future resolves or the timeout is reached."""
     pass
 
+  @abstractmethod
+  async def set_value(self, key: str, value: str, expires_seconds: int | None = None) -> None:
+    """Store a string value by key, optionally with a time to live."""
+    pass
+
+  @abstractmethod
+  async def get_value(self, key: str) -> str | None:
+    """Fetch a string value by key, returning None when absent or expired."""
+    pass
+
 
 class InMemoryStore(RequestStore):
   def __init__(self):
@@ -57,6 +67,8 @@ class InMemoryStore(RequestStore):
     self.active_tenants_cv = asyncio.Condition()
     self.futures_store: dict[str, dict[str, Any]] = {}
     self.futures_events: dict[str, asyncio.Event] = {}
+    self.kv_store: dict[str, str] = {}
+    self.kv_expirations: dict[str, float] = {}
 
   async def put_request(self, req_data: dict[str, Any]) -> None:
     model_id = req_data.get("model_id", "default")
@@ -124,6 +136,20 @@ class InMemoryStore(RequestStore):
       return {"type": "try_again", "request_id": req_id, "queue_state": "active"}
     finally:
       self.futures_events.pop(req_id, None)
+
+  async def set_value(self, key: str, value: str, expires_seconds: int | None = None) -> None:
+    self.kv_store[key] = value
+    if expires_seconds is None:
+      self.kv_expirations.pop(key, None)
+    else:
+      self.kv_expirations[key] = time.monotonic() + expires_seconds
+
+  async def get_value(self, key: str) -> str | None:
+    expires_at = self.kv_expirations.get(key)
+    if expires_at is not None and expires_at <= time.monotonic():
+      self.kv_store.pop(key, None)
+      self.kv_expirations.pop(key, None)
+    return self.kv_store.get(key)
 
 
 class RedisStore(RequestStore):
@@ -260,6 +286,12 @@ class RedisStore(RequestStore):
         await self.redis.rpush(key, result[1])
         await self.redis.expire(key, 300)
         return payload
+
+  async def set_value(self, key: str, value: str, expires_seconds: int | None = None) -> None:
+    await self.redis.set(key, value, ex=expires_seconds)
+
+  async def get_value(self, key: str) -> str | None:
+    return await self.redis.get(key)
 
 
 # Global singleton factory

--- a/tests/test_session_lifecycle.py
+++ b/tests/test_session_lifecycle.py
@@ -1,0 +1,134 @@
+import json
+import os
+import unittest
+from unittest.mock import AsyncMock, patch
+
+import httpx
+
+from server import gateway
+from server.protocol import ClientSession, CreateSessionRequest, SessionHeartbeatRequest
+from server.store import InMemoryStore, RedisStore
+
+
+class GatewaySessionLifecycleTest(unittest.IsolatedAsyncioTestCase):
+  def setUp(self) -> None:
+    self.store = InMemoryStore()
+    self.old_store = gateway.store
+    gateway.store = self.store
+    self.env_patch = patch.dict(os.environ, {"OPEN_RL_SESSION_TTL_SECONDS": "10"})
+    self.env_patch.start()
+
+  def tearDown(self) -> None:
+    self.env_patch.stop()
+    gateway.store = self.old_store
+
+  async def create_session(self, **overrides):
+    request = CreateSessionRequest(
+      tags=overrides.get("tags", []),
+      user_metadata=overrides.get("user_metadata"),
+      sdk_version=overrides.get("sdk_version"),
+      project_id=overrides.get("project_id"),
+    )
+    return await gateway.create_session(request)
+
+  async def test_create_session_returns_unique_tinker_responses(self) -> None:
+    first = await self.create_session()
+    second = await self.create_session()
+
+    self.assertEqual(first["type"], "create_session")
+    self.assertEqual(second["type"], "create_session")
+    self.assertTrue(first["session_id"].startswith("sess-"))
+    self.assertNotEqual(first["session_id"], second["session_id"])
+
+  async def test_create_session_persists_sdk_metadata(self) -> None:
+    response = await self.create_session(
+      tags=["test", "gpu"],
+      user_metadata={"job": "smoke", "attempt": 2},
+      sdk_version="0.18.2",
+      project_id="project-a",
+    )
+
+    raw_session = await self.store.get_value(gateway.session_key(response["session_id"]))
+    session = ClientSession.model_validate_json(raw_session)
+    self.assertEqual(session.tags, ["test", "gpu"])
+    self.assertEqual(session.user_metadata, {"job": "smoke", "attempt": 2})
+    self.assertEqual(session.sdk_version, "0.18.2")
+    self.assertEqual(session.project_id, "project-a")
+
+  async def test_heartbeat_updates_session_and_refreshes_ttl(self) -> None:
+    with patch("server.store.time.monotonic", return_value=100):
+      created = await self.create_session()
+    key = gateway.session_key(created["session_id"])
+    self.assertEqual(self.store.kv_expirations[key], 110)
+
+    with (
+      patch("server.store.time.monotonic", return_value=105),
+      patch("server.gateway.time.time", return_value=1234),
+    ):
+      response = await gateway.session_heartbeat(SessionHeartbeatRequest(session_id=created["session_id"]))
+
+    self.assertEqual(response, {"type": "session_heartbeat"})
+    self.assertEqual(self.store.kv_expirations[key], 115)
+    session = ClientSession.model_validate_json(self.store.kv_store[key])
+    self.assertEqual(session.last_heartbeat, 1234)
+
+  async def test_unknown_and_expired_sessions_return_not_found(self) -> None:
+    unknown = await gateway.session_heartbeat(SessionHeartbeatRequest(session_id="sess-unknown"))
+    self.assertEqual(unknown.status_code, 404)
+    self.assertEqual(json.loads(unknown.body), {"error": "session not found or expired"})
+
+    with patch("server.store.time.monotonic", return_value=100):
+      created = await self.create_session()
+    with patch("server.store.time.monotonic", return_value=110):
+      expired = await gateway.session_heartbeat(SessionHeartbeatRequest(session_id=created["session_id"]))
+
+    self.assertEqual(expired.status_code, 404)
+    self.assertEqual(json.loads(expired.body), {"error": "session not found or expired"})
+
+  async def test_missing_and_blank_session_ids_are_rejected(self) -> None:
+    transport = httpx.ASGITransport(app=gateway.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+      missing = await client.post("/api/v1/session_heartbeat", json={})
+      blank = await client.post("/api/v1/session_heartbeat", json={"session_id": ""})
+
+    self.assertEqual(missing.status_code, 422)
+    self.assertEqual(blank.status_code, 422)
+
+  async def test_non_positive_session_ttl_is_rejected_clearly(self) -> None:
+    with patch.dict(os.environ, {"OPEN_RL_SESSION_TTL_SECONDS": "0"}):
+      response = await self.create_session()
+
+    self.assertEqual(response.status_code, 500)
+    self.assertEqual(json.loads(response.body), {"error": "OPEN_RL_SESSION_TTL_SECONDS must be a positive integer"})
+
+
+class InMemoryStoreExpirationTest(unittest.IsolatedAsyncioTestCase):
+  async def test_values_expire_and_can_be_replaced_without_a_ttl(self) -> None:
+    store = InMemoryStore()
+    with patch("server.store.time.monotonic", return_value=10):
+      await store.set_value("key", "old", expires_seconds=5)
+    with patch("server.store.time.monotonic", return_value=15):
+      self.assertIsNone(await store.get_value("key"))
+
+    await store.set_value("key", "new")
+    with patch("server.store.time.monotonic", return_value=1000):
+      self.assertEqual(await store.get_value("key"), "new")
+
+
+class RedisStoreValueTest(unittest.IsolatedAsyncioTestCase):
+  async def test_set_and_get_use_native_redis_expiration_semantics(self) -> None:
+    store = RedisStore("redis://unused")
+    redis = AsyncMock()
+    redis.get.return_value = "payload"
+    store.redis = redis
+
+    await store.set_value("open_rl:session:sess-a", "payload", expires_seconds=17)
+    value = await store.get_value("open_rl:session:sess-a")
+
+    redis.set.assert_awaited_once_with("open_rl:session:sess-a", "payload", ex=17)
+    redis.get.assert_awaited_once_with("open_rl:session:sess-a")
+    self.assertEqual(value, "payload")
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
## What changed

- replace the fixed session ID and unconditional heartbeat with persisted client sessions
- preserve Tinker create/heartbeat response shapes while validating request bodies
- add optional TTL support to the generic `RequestStore` value API for in-memory and Redis backends
- refresh session metadata and expiration on heartbeat, with clear missing/expired errors
- cover unique IDs, SDK metadata, refresh/expiry behavior, and Redis command semantics

## Why

The gateway previously returned one fake session ID and acknowledged every heartbeat, so it could not distinguish active clients from missing or expired sessions. A shared store-backed lifecycle gives both LoRA and FFT modes the same behavior without trainer-specific branching.

## Validation

- `uv run --frozen --extra cpu --with pytest pytest -q tests/test_session_lifecycle.py` (8 passed)
- `uv run --frozen --extra cpu --with pytest pytest -q tests --ignore=tests/test_piglatin_gemma.py --ignore=tests/test_piglatin_qwen.py` (49 passed, 7 subtests passed)
- `make test` (41 passed)
- `uvx ruff check .`
- `uvx ruff format --check .`

The separate Qwen pig-latin model test passed and the gated Gemma test skipped. The aggregate `make test piglatin` target still exits nonzero because it discovers server tests inside the examples-only environment, where server dependencies are unavailable; this is unrelated to the session changes.
