### PR TITLE
fix(ci): pin GitHub Action SHAs and enforce permissions to satisfy zizmor

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -26,7 +26,9 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Free Disk Space
         run: |
@@ -36,17 +38,17 @@ jobs:
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -22,7 +22,9 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Free Disk Space
         run: |
@@ -32,10 +34,10 @@ jobs:
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
       - name: Build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}

--- a/.github/workflows/e2e-piglatin.yml
+++ b/.github/workflows/e2e-piglatin.yml
@@ -15,11 +15,15 @@ jobs:
     name: Qwen3-0.6B pig-latin SFT (CPU)
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@1edb52594c857e2b5b13128931090f0640537287 # v5.3.0
         with:
           enable-cache: true
 
@@ -27,7 +31,7 @@ jobs:
         run: uv python install 3.12
 
       - name: Cache Hugging Face hub
-        uses: actions/cache@v4
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
         with:
           path: ~/.cache/huggingface/hub
           key: hf-hub-${{ runner.os }}-qwen3-0.6b

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,11 +8,15 @@ on:
 jobs:
   ruff:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/ruff-action@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: astral-sh/ruff-action@f14634c415d3e63ffd4d550a22f037df4c734a60 # v3.1.0
         with:
           args: "check"
-      - uses: astral-sh/ruff-action@v3
+      - uses: astral-sh/ruff-action@f14634c415d3e63ffd4d550a22f037df4c734a60 # v3.1.0
         with:
           args: "format --check"


### PR DESCRIPTION
## Summary

  Fixes the zizmor-output security scan failure on the GitHub Actions Scan workflow by pinning all GitHub Action references across workflow files to full, immutable commit SHAs.

  ### Root Cause

  The gke-labs org-level security scanner (zizmor) flagged action references using version tags (@v4, @v3, @v5) with high-severity unpinned-uses policy errors.

  ### Changes Made

  • Action SHA Pinning: Updated all action references across workflow files to full commit SHAs while preserving human-readable release version comments (e.g. # v4.2.2).
      • .github/workflows/build-pr.yml: Pinned actions/checkout, docker/setup-buildx-action, and docker/build-push-action.
      • .github/workflows/build-and-push.yml: Pinned actions/checkout, docker/setup-buildx-action, docker/login-action, and docker/build-push-action.
      • .github/workflows/lint.yml: Pinned actions/checkout and astral-sh/ruff-action. Added explicit permissions: contents: read.
      • .github/workflows/e2e-piglatin.yml: Pinned actions/checkout, astral-sh/setup-uv, and actions/cache. Added explicit permissions: contents: read.
  • Security Best Practices: Added persist-credentials: false to all actions/checkout steps to prevent credential leaks.

  ### Verification

  • Zizmor Scan: Ran zizmor .github/workflows locally; returned No findings to report (Exit code 0).
  • Linter & Format: Ran make lint; all ruff checks and formatting passed.
  • Unit Tests: Ran make test; all 94 unit tests passed successfully.