### PR TITLE
docs: add project governance and community health files

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,38 @@
+# Code of Conduct
+
+The OpenRL project follows the [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
+
+We are committed to providing a friendly, safe, and welcoming environment for everyone,
+regardless of level of experience, gender identity and expression, sexual orientation,
+disability, personal appearance, body size, race, ethnicity, age, religion, nationality,
+or other similar characteristic.
+
+## Scope
+
+This Code of Conduct applies within all project spaces — the GitHub repository, issues,
+pull requests, discussions, and any project meetings or communication channels — and also
+applies when an individual is officially representing the project in public spaces.
+
+## Reporting
+
+If you experience or witness unacceptable behavior, please report it to the maintainers.
+
+<!-- TODO: Set up a private maintainer mailing list (e.g. openrl-maintainers@googlegroups.com)
+     and list it here as the reporting address. Until then, reports should be sent privately
+     to an individual maintainer listed in MAINTAINERS.md. -->
+
+Until a dedicated reporting address is set up, please contact any of the maintainers listed
+in [MAINTAINERS.md](MAINTAINERS.md) directly and privately.
+
+All reports will be reviewed and investigated promptly and fairly. Maintainers are obligated
+to respect the privacy and security of the reporter of any incident. Maintainers who do not
+follow or enforce the Code of Conduct in good faith may face temporary or permanent
+repercussions as determined by the rest of the maintainer council.
+
+Code of Conduct reports are handled as described in [GOVERNANCE.md](GOVERNANCE.md). If a
+maintainer is directly involved in a report, that maintainer is recused from handling it.
+
+## Enforcement Guidelines
+
+Maintainers will follow the [Contributor Covenant Enforcement Guidelines](https://www.contributor-covenant.org/version/2/1/code_of_conduct/#enforcement-guidelines)
+in determining the consequences for any action they deem in violation of this Code of Conduct.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,165 @@
+# Contributing Guide
+
+* [Ways to Contribute](#ways-to-contribute)
+* [Find an Issue](#find-an-issue)
+* [Ask for Help](#ask-for-help)
+* [Development Environment Setup](#development-environment-setup)
+* [Pull Request Lifecycle](#pull-request-lifecycle)
+* [Sign Your Commits](#sign-your-commits)
+* [Pull Request Checklist](#pull-request-checklist)
+
+Welcome! We are glad that you want to contribute to OpenRL. 💖
+
+As you get started, you are in the best position to give us feedback on areas of the project
+that we need help with, including:
+
+* Problems found while setting up a new development environment
+* Gaps in the Quick Start or documentation
+* Bugs in our automation scripts
+
+If anything doesn't make sense, or doesn't work when you run it, please
+[open an issue](https://github.com/gke-labs/open-rl/issues/new) and let us know.
+
+Please note that this project has a [Code of Conduct](CODE_OF_CONDUCT.md) that all
+contributors are expected to follow.
+
+## Ways to Contribute
+
+We welcome many different types of contributions, including:
+
+* New features
+* Bug fixes
+* Builds and CI/CD
+* Documentation, guides, and example recipes
+* Issue triage
+* Answering questions from other users
+* Release management
+
+Not everything happens through a GitHub pull request. If you would like to discuss an idea
+before writing code, open a [GitHub issue](https://github.com/gke-labs/open-rl/issues) and
+let's talk it through.
+
+<!-- TODO: OpenRL does not yet have a public developer meeting, mailing list, or chat
+     channel. Once these exist, add them here and in the README. -->
+
+## Find an Issue
+
+Issues labelled [`good first issue`](https://github.com/gke-labs/open-rl/labels/good%20first%20issue)
+have extra context to help you make your first contribution.
+[`help wanted`](https://github.com/gke-labs/open-rl/labels/help%20wanted) issues are suitable
+for anyone who isn't a core maintainer and are a good next step after your first pull request.
+
+Sometimes there won't be any issues with these labels. That's OK — there is likely still
+something for you to work on. If you want to contribute but can't find a suitable issue, open
+an issue describing what you would like to work on and a maintainer will help you scope it.
+
+Once you find an issue you'd like to work on, please comment on it saying so, to avoid
+duplicate effort.
+
+## Ask for Help
+
+The best way to reach us with a question is to comment on the relevant GitHub issue or pull
+request. If there isn't one yet, open a new issue.
+
+## Development Environment Setup
+
+OpenRL uses [`uv`](https://docs.astral.sh/uv/) for environment isolation. There are two
+primary environments:
+
+* **Server** (`src/server`) — the gateway server and worker controllers.
+* **Client / examples** (`examples`) — recipes, client SDK compatibility checks, and
+  end-to-end integration test scripts.
+
+Most tasks are driven through the `Makefile`, which invokes `uv` under the hood. Make sure
+`uv` is on your `PATH` (typically `~/.local/bin`):
+
+```bash
+export PATH=$PATH:$HOME/.local/bin
+```
+
+Run `make help` to see the available targets and their default knobs.
+
+### Running the server locally
+
+```bash
+make server                                   # defaults to SAMPLING_BACKEND=torch on port 9003
+make server SAMPLING_BACKEND=vllm             # use vLLM for sampling
+```
+
+### Running tests
+
+```bash
+make test                                     # fast unit tests
+make test piglatin                            # pig-latin example end-to-end tests
+```
+
+End-to-end GPU integration tests boot a real backend and run actual SFT/RL training. They
+require a GPU and use the `gpu` extra:
+
+```bash
+make test e2e tiny-lora                       # minimal LoRA overfit test
+make test e2e tiny-fft                        # full fine-tuning (requires redis-server)
+make test e2e tiny-rl                         # sample -> reward -> train loop
+```
+
+Most contributors develop on a machine without a local NVIDIA GPU and use a remote GPU VM as
+the test target. `make push-vm REMOTE_HOST=<host>` and `make pull-vm REMOTE_HOST=<host>` sync
+your workspace to and from that host. On a fresh GPU VM you may also need `redis-server` and
+`python3-dev` installed.
+
+### Linting and formatting
+
+The project uses [Ruff](https://docs.astral.sh/ruff/) for both linting and formatting, and
+CI enforces both on every pull request:
+
+```bash
+make lint
+make fmt
+```
+
+You can have this run automatically on every commit by installing the pre-commit hooks:
+
+```bash
+pre-commit install
+```
+
+## Pull Request Lifecycle
+
+1. Open an issue first for anything larger than a small fix, so the approach can be agreed on
+   before you invest time in it.
+2. Fork the repository and create a branch for your change.
+3. Make your change, including tests and documentation updates.
+4. Run `make lint` and `make test` locally.
+5. Open a pull request against `main`. Describe what changed and why, and link the issue it
+   addresses.
+6. A maintainer will review your pull request. All submissions, including those from project
+   members, require review. Expect a first response within a few business days; feel free to
+   ping the pull request if it goes quiet.
+7. Address review feedback by pushing additional commits to your branch. Once approved and
+   with CI green, a maintainer will merge it.
+
+## Sign Your Commits
+
+Contributions to this project must be accompanied by a
+[Contributor License Agreement](https://cla.developers.google.com/about) (CLA). You (or your
+employer) retain the copyright to your contribution; the CLA simply gives us permission to use
+and redistribute your contributions as part of the project.
+
+If you or your current employer have already signed the Google CLA (even if it was for a
+different project), you probably don't need to do it again.
+
+Visit <https://cla.developers.google.com/> to see your current agreements or to sign a new one.
+
+## Pull Request Checklist
+
+When you submit your pull request, our automated systems will run checks on your code. We
+require that your pull request passes these checks. Before submitting, please check the
+following locally:
+
+* [ ] You have signed the [CLA](https://cla.developers.google.com/).
+* [ ] `make lint` passes (Ruff lint and format checks).
+* [ ] `make test` passes.
+* [ ] New code has tests covering it.
+* [ ] Documentation under `docs/` or `examples/` is updated if behavior changed.
+* [ ] The pull request description explains what changed and why, and links the related issue.
+* [ ] Commits are scoped and have clear messages.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,180 @@
+# OpenRL Project Governance
+
+The OpenRL project is dedicated to providing a self-hosted, Tinker-compatible API for
+fine-tuning language models on your own infrastructure. This governance explains how the
+project is run.
+
+- [Values](#values)
+- [Maintainers](#maintainers)
+- [Becoming a Maintainer](#becoming-a-maintainer)
+- [Removing a Maintainer](#removing-a-maintainer)
+- [Emeritus Maintainers](#emeritus-maintainers)
+- [Meetings](#meetings)
+- [Code of Conduct](#code-of-conduct)
+- [Security Response Team](#security-response-team)
+- [Voting](#voting)
+- [When to Evolve This Governance](#when-to-evolve-this-governance)
+- [Modifying this Charter](#modifying-this-charter)
+
+## Values
+
+The OpenRL project and its leadership embrace the following values:
+
+* **Openness**: Communication and decision-making happens in the open and is discoverable
+  for future reference. As much as possible, all discussions and work take place in public
+  forums and open repositories.
+
+* **Fairness**: All stakeholders have the opportunity to provide feedback and submit
+  contributions, which will be considered on their merits.
+
+* **Community over Product or Company**: Sustaining and growing our community takes priority
+  over shipping code or sponsors' organizational goals. Each contributor participates in the
+  project as an individual.
+
+* **Vendor Neutrality**: The project direction and decisions are not controlled by any single
+  organization. Maintainer selection, roadmap prioritization, and release decisions are made
+  based on project merit, not employer affiliation.
+
+* **Inclusivity**: We innovate through different perspectives and skill sets, which can only
+  be accomplished in a welcoming and respectful environment.
+
+* **Participation**: Responsibilities within the project are earned through participation,
+  and there is a clear path up the contributor ladder into leadership positions.
+
+## Maintainers
+
+OpenRL Maintainers have write access to the [project GitHub repository](https://github.com/gke-labs/open-rl).
+They can merge their own patches or patches from others. The current maintainers can be found
+in [MAINTAINERS.md](MAINTAINERS.md). Maintainers collectively manage the project's resources
+and contributors.
+
+This privilege is granted with some expectation of responsibility: maintainers are people who
+care about the OpenRL project and want to help it grow and improve. A maintainer is not just
+someone who can make changes, but someone who has demonstrated their ability to collaborate
+with the team, get the most knowledgeable people to review code and docs, contribute
+high-quality code, and follow through to fix issues (in code or tests).
+
+A maintainer is a contributor to the project's success and a citizen helping the project
+succeed.
+
+The collective team of all Maintainers is known as the Maintainer Council, which is the
+governing body for the project.
+
+### Becoming a Maintainer
+
+To become a Maintainer you need to demonstrate the following:
+
+* commitment to the project:
+  * participate in discussions, contributions, code and documentation reviews for **3 months**
+    or more,
+  * perform reviews for **5** non-trivial pull requests,
+  * contribute **5** non-trivial pull requests and have them merged,
+* ability to write quality code and/or documentation,
+* ability to collaborate with the team,
+* understanding of how the team works (policies, processes for testing and code review, etc),
+* understanding of the project's code base and coding and documentation style.
+
+<!-- TODO: OpenRL does not yet have a public developer mailing list. Once one exists,
+     nominations should be sent there instead of to a GitHub issue, and this section
+     should be updated with the list address. -->
+
+A new Maintainer must be proposed by an existing maintainer by opening a GitHub issue in the
+project repository. A simple majority vote of existing Maintainers approves the application.
+Maintainer nominations will be evaluated without prejudice to employer or demographics and
+should consider the organizational diversity of the maintainer group.
+
+Maintainers who are selected will be granted the necessary GitHub rights.
+
+### Removing a Maintainer
+
+Maintainers may resign at any time if they feel that they will not be able to continue
+fulfilling their project duties.
+
+Maintainers may also be removed after being inactive, failure to fulfill their Maintainer
+responsibilities, violating the Code of Conduct, or other reasons. Inactivity is defined as a
+period of very low or no activity in the project for **6 months** or more, with no definite
+schedule to return to full Maintainer activity.
+
+A Maintainer may be removed at any time by a 2/3 vote of the remaining maintainers.
+
+### Emeritus Maintainers
+
+Depending on the reason for removal or resignation, a Maintainer may be converted to Emeritus
+status. Emeritus Maintainers are recognized for their past contributions and may still be
+consulted on project matters, but do not have voting rights or merge access. Emeritus
+Maintainers are listed in [MAINTAINERS.md](MAINTAINERS.md) under a separate Emeritus section.
+
+An Emeritus Maintainer may be reinstated to active Maintainer status by a simple majority vote
+of existing Maintainers, provided they meet the current Maintainer requirements and can commit
+to ongoing participation.
+
+## Meetings
+
+<!-- TODO: OpenRL does not yet have a regular public developer meeting. Once one is
+     scheduled, add the cadence, joining details, and notes/recording location here,
+     and update CONTRIBUTING.md and the README to point to it. -->
+
+Time zones permitting, Maintainers are expected to participate in the public developer
+meeting. A regular public developer meeting has not yet been established for OpenRL; until
+one is, project discussion happens in GitHub issues and pull requests.
+
+Maintainers will also have closed meetings in order to discuss security reports or Code of
+Conduct violations. Such meetings should be scheduled by any Maintainer on receipt of a
+security issue or CoC report. All current Maintainers must be invited to such closed meetings,
+except for any Maintainer who is accused of a CoC violation.
+
+## Code of Conduct
+
+[Code of Conduct](CODE_OF_CONDUCT.md) violations by community members will be discussed and
+resolved privately by the Maintainer Council. If a Maintainer is directly involved in the
+report, the remaining Maintainers will designate two Maintainers to resolve it, and the
+Maintainer named in the report is recused from the discussion.
+
+## Security Response Team
+
+The Maintainers will appoint a Security Response Team to handle security reports. This
+committee may simply consist of the Maintainer Council themselves. If this responsibility is
+delegated, the Maintainers will appoint a team of at least two contributors to handle it. The
+Maintainers will review who is assigned to this at least once a year.
+
+The Security Response Team is responsible for handling all reports of security holes and
+breaches according to the [security policy](SECURITY.md).
+
+## Voting
+
+While most business in OpenRL is conducted by
+"[lazy consensus](https://community.apache.org/committers/lazyConsensus.html)", periodically
+the Maintainers may need to vote on specific actions or changes. A vote can be taken in a
+GitHub issue in the project repository, or privately among Maintainers for security or conduct
+matters. Any Maintainer may demand a vote be taken.
+
+Most votes require a simple majority of all Maintainers to succeed, except where otherwise
+noted. Two-thirds majority votes mean at least two-thirds of all existing maintainers.
+
+## When to Evolve This Governance
+
+The Maintainer Council model works well for focused projects with a small, cohesive group of
+contributors. As the project grows, watch for these signals that a governance transition may
+be needed:
+
+* **Decisions stall.** When the maintainer group is too large for lazy consensus to work, or
+  when decisions affect subgroups differently, a delegation structure (working groups, SIGs)
+  helps.
+* **New contributors cannot find a path in.** If the only path to influence is "become a
+  maintainer," the project needs intermediate roles (reviewer, approver). Projects with
+  intermediate roles produce more diverse maintainer pools because they give external
+  contributors a visible progression path.
+* **A single organization dominates.** All current OpenRL maintainers are employed by Google.
+  As the project attracts contributors from other organizations, the Maintainers should
+  actively grow the maintainer group beyond a single employer and consider adding an
+  org-balanced voting clause (for example, capping any one organization at 1/3 of the total
+  votes on a decision).
+* **Subprojects diverge.** When parts of the project develop their own contributor communities
+  or release cadences, consider a federated subproject governance model.
+
+These transitions are a sign of project growth, not governance failure.
+
+## Modifying this Charter
+
+Changes to this Governance and its supporting documents may be approved by a 2/3 vote of the
+Maintainers.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,37 @@
+# Maintainers
+
+The current maintainers of the OpenRL project are listed below.
+
+| Name | GitHub ID | Company/Organization |
+| ---- | --------- | -------------------- |
+| Sunil Arora | [@droot](https://github.com/droot) | Google |
+| Shuby Mishra | [@ShubyM](https://github.com/ShubyM) | Google |
+| Chuang Wang | [@chuangw6](https://github.com/chuangw6) | Google |
+| Justin Santa Barbara | [@justinsb](https://github.com/justinsb) | Google |
+| Hoda Mohammadi | [@hodaaaaaaaaaa](https://github.com/hodaaaaaaaaaa) | Google |
+
+## Emeritus Maintainers
+
+Maintainers who have stepped back from active participation are recognized here. Emeritus
+maintainers do not have voting rights or merge access but are recognized for their
+contributions and may be consulted on project matters.
+
+An emeritus maintainer may return to active status through the normal maintainer nomination
+process. See [GOVERNANCE.md](GOVERNANCE.md) for the full maintainer lifecycle.
+
+_None at this time._
+
+## Security Response Team
+
+Security reports are handled by the full maintainer council. See [SECURITY.md](SECURITY.md)
+for the reporting process and [GOVERNANCE.md](GOVERNANCE.md) for how this team is appointed
+and reviewed.
+
+## Maintainer Affiliation Updates
+
+Maintainer affiliations (Company/Organization column) must be kept current. When a maintainer
+changes employers, they should update this file within 30 days.
+
+---
+
+See [GOVERNANCE.md](GOVERNANCE.md) for how maintainers are selected, replaced, and removed.

--- a/README.md
+++ b/README.md
@@ -91,11 +91,25 @@ Detailed guides and runnable examples are structured under `docs/` and `examples
 
 ## Contributing
 
+We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for how to set up a
+development environment, find an issue to work on, and open a pull request.
+
+Participation in this project is governed by our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Community
+
+<!-- TODO: Add a developer mailing list, chat channel, and public developer meeting once
+     these are set up. -->
+
+- **Questions and discussion**: [GitHub Issues](https://github.com/gke-labs/open-rl/issues)
+- **Reporting a vulnerability**: see our [Security Policy](SECURITY.md) — please do not open a
+  public issue for security reports
+- **How the project is run**: [GOVERNANCE.md](GOVERNANCE.md)
+- **Who maintains it**: [MAINTAINERS.md](MAINTAINERS.md)
+
+## License
+
 This project is licensed under the [Apache 2.0 License](LICENSE).
-
-We welcome contributions! Please see [docs/contributing.md](docs/contributing.md) for more information.
-
-We follow [Google's Open Source Community Guidelines](https://opensource.google.com/conduct/).
 
 ## Disclaimer
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,73 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in OpenRL, please report it responsibly.
+**Do not open a public GitHub issue.**
+
+To report a vulnerability, use GitHub Private Vulnerability Reporting:
+
+* **[Report a vulnerability](https://github.com/gke-labs/open-rl/security/advisories/new)**
+
+<!-- TODO: Set up a project security email (e.g. openrl-security@googlegroups.com) and
+     add it here as an alternative reporting channel for reporters who cannot or prefer
+     not to use GitHub. -->
+
+Please include in your report:
+
+* Description of the vulnerability
+* Steps to reproduce the issue
+* Affected versions
+* Any potential impact you have identified
+
+## Response Timeline
+
+The OpenRL security response team will acknowledge receipt of your report within
+**3 business days** and will provide an estimated timeline for a fix within
+**10 business days**.
+
+The team will keep you informed of progress toward a fix and may ask for additional
+information.
+
+## Supported Versions
+
+OpenRL has not yet cut a tagged release. Until the first release, only the `main` branch is
+supported and security fixes land there.
+
+| Version | Supported |
+| ------- | --------- |
+| `main`  | Yes       |
+
+<!-- TODO: Replace this table with a real supported-versions matrix once the project
+     starts cutting tagged releases. -->
+
+## Disclosure Policy
+
+When a security issue is confirmed, the OpenRL maintainers will:
+
+1. Develop and test a fix
+2. Assign a CVE identifier if appropriate
+3. Release a patched version
+4. Publish a security advisory via
+   [GitHub Security Advisories](https://github.com/gke-labs/open-rl/security/advisories)
+
+## Security Response Team
+
+The security response team handles all reports of security vulnerabilities according to this
+policy. See [GOVERNANCE.md](GOVERNANCE.md) for how the security response team is appointed and
+maintained, and [MAINTAINERS.md](MAINTAINERS.md) for the current members.
+
+## Security Practices
+
+The project maintains the following security practices:
+
+* Automated dependency updates via Dependabot
+* Linting and build checks on every pull request
+
+<!-- TODO: As the project matures, consider adding an OpenSSF Best Practices badge,
+     signed releases, and a published SBOM. -->
+
+## Disclaimer
+
+This is not an officially supported Google product. This project is not eligible for the
+Google Open Source Software Vulnerability Rewards Program.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,33 +1,3 @@
 # How to contribute
 
-We'd love to accept your patches and contributions to this project.
-
-## Before you begin
-
-### Sign our Contributor License Agreement
-
-Contributions to this project must be accompanied by a
-[Contributor License Agreement](https://cla.developers.google.com/about) (CLA).
-You (or your employer) retain the copyright to your contribution; this simply
-gives us permission to use and redistribute your contributions as part of the
-project.
-
-If you or your current employer have already signed the Google CLA (even if it
-was for a different project), you probably don't need to do it again.
-
-Visit <https://cla.developers.google.com/> to see your current agreements or to
-sign a new one.
-
-### Review our community guidelines
-
-This project follows
-[Google's Open Source Community Guidelines](https://opensource.google/conduct/).
-
-## Contribution process
-
-### Code reviews
-
-All submissions, including submissions by project members, require review. We
-use GitHub pull requests for this purpose. Consult
-[GitHub Help](https://help.github.com/articles/about-pull-requests/) for more
-information on using pull requests.
+This guide has moved to [CONTRIBUTING.md](../CONTRIBUTING.md) in the repository root.


### PR DESCRIPTION
Adds the standard set of open source project files, modeled on the CNCF project template, so the project has documented governance, maintainership, and a security reporting path.

- CODE_OF_CONDUCT.md: Contributor Covenant v2.1
- CONTRIBUTING.md: moved to repo root, expanded with development environment setup, PR lifecycle, and a PR checklist. Retains the existing Google CLA requirement.
- GOVERNANCE.md: maintainer council model
- MAINTAINERS.md: current maintainers and affiliations
- SECURITY.md: GitHub private vulnerability reporting and disclosure policy
- README.md: link the above from a new Community section

docs/contributing.md is reduced to a pointer at the root file.

TODOs are left inline for items that are still unset: a private maintainer mailing list, a security email, developer communication channels, and a supported-versions matrix (no tagged releases yet).