### PR TITLE
fix: weight-sync and sizing fixes for FFT

### DIFF
--- a/src/server/k8s_worker_manager.py
+++ b/src/server/k8s_worker_manager.py
@@ -377,7 +377,9 @@ class KubernetesWorkerManager:
     limits = resources.setdefault("limits", {})
     requests = resources.setdefault("requests", {})
     if memory_tier == "80gb":
-      limits["memory"] = "110Gi"
+      # 7B-class FFT peaks near 110Gi (pinned optimizer+weight shadow ~75Gi
+      # plus reload buffers) — one OOMKill observed at 110Gi; give headroom.
+      limits["memory"] = "200Gi"
       requests["memory"] = "90Gi"
       requests["cpu"] = "12"
     else:

--- a/src/server/worker_manager.py
+++ b/src/server/worker_manager.py
@@ -63,11 +63,12 @@ def estimate_memory_tier(base_model: str, fine_tuning_type: str = "lora") -> str
   """
   model_lower = (base_model or "").lower()
 
-  # Full fine-tuning 7B/8B+ requires H100 (80gb)
+  # Full fine-tuning always maps to the 80gb tier: FFT of any
+  # multi-billion-param model (bf16 params + grads + AdamW states +
+  # pinned-DRAM shadow) exceeds the 24gb tier, and name-based size
+  # sniffing misses many model naming schemes (e.g. gemma-4-e2b).
   if fine_tuning_type == "full":
-    if any(size in model_lower for size in ["7b", "8b", "14b", "32b", "70b"]):
-      return "80gb"
-    return "24gb"
+    return "80gb"
 
   # LoRA fine-tuning memory scaling
   if any(size in model_lower for size in ["14b", "32b", "70b"]):

--- a/src/training/fft_trainer_worker.py
+++ b/src/training/fft_trainer_worker.py
@@ -347,6 +347,10 @@ class FFTTrainingWorker(BaseTrainerWorker):
     config = getattr(self.model, "config", None)
     if config is None:
       return layer_names_list, indices_list
+    # Multimodal wrappers (e.g. gemma-4 ForConditionalGeneration) nest the LM
+    # dims under text_config.
+    if getattr(config, "hidden_size", None) is None and getattr(config, "text_config", None) is not None:
+      config = config.text_config
 
     hidden_size = getattr(config, "hidden_size", None)
     num_heads = getattr(config, "num_attention_heads", None)
@@ -360,21 +364,29 @@ class FFTTrainingWorker(BaseTrainerWorker):
     q_numel = (num_heads * head_dim * hidden_size) if (hidden_size and num_heads and head_dim) else None
     k_numel = (num_kv_heads * head_dim * hidden_size) if (hidden_size and num_kv_heads and head_dim) else None
     gate_numel = (intermediate_size * hidden_size) if (hidden_size and intermediate_size) else None
+    # Bias rows fuse with bias-sized offsets (Qwen2.5 attention has QKV
+    # biases; using weight-sized offsets sent bias indices out of bounds).
+    q_bias_numel = (num_heads * head_dim) if (num_heads and head_dim) else None
+    k_bias_numel = (num_kv_heads * head_dim) if (num_kv_heads and head_dim) else None
 
     mapped_names: list[str] = []
     mapped_indices: list[torch.Tensor] = []
 
     for name, idx in zip(layer_names_list, indices_list):
+      is_bias = name.endswith(".bias")
       if (".q_proj." in name or ".k_proj." in name or ".v_proj." in name) and q_numel is not None and k_numel is not None:
         qkv_name = name.replace(".q_proj.", ".qkv_proj.").replace(".k_proj.", ".qkv_proj.").replace(".v_proj.", ".qkv_proj.")
-        offset = 0 if ".q_proj." in name else (q_numel if ".k_proj." in name else q_numel + k_numel)
+        qn, kn = (q_bias_numel, k_bias_numel) if is_bias else (q_numel, k_numel)
+        offset = 0 if ".q_proj." in name else (qn if ".k_proj." in name else qn + kn)
         mapped_names.append(qkv_name)
         mapped_indices.append(idx + offset)
         continue
 
       if (".gate_proj." in name or ".up_proj." in name) and gate_numel is not None:
         gate_up_name = name.replace(".gate_proj.", ".gate_up_proj.").replace(".up_proj.", ".gate_up_proj.")
-        offset = 0 if ".gate_proj." in name else gate_numel
+        # (No known FFT target has MLP biases; if one appears, intermediate_size
+        # is the bias-sized gate offset.)
+        offset = 0 if ".gate_proj." in name else (intermediate_size if is_bias else gate_numel)
         mapped_names.append(gate_up_name)
         mapped_indices.append(idx + offset)
         continue


### PR DESCRIPTION
Three fixes found while running FFT across different model families:

- **Fused-delta weight sync:** use bias-sized offsets for bias tensors — models with attention biases (e.g. Qwen2.5) crashed the sampler with `index_copy_` out of bounds; also fall back to `text_config` for wrapper-style model configs (e.g. Gemma 4).
- **Memory tier:** FFT trainers always map to the 80gb tier — name-based size sniffing misses names like `gemma-4-e2b`.
- **80gb tier limit 110Gi → 200Gi:** a 7B FFT trainer's pinned host shadow plus reload buffers exceeds 110Gi.

All three validated on GKE with Qwen2.5-7B and Gemma-4-E2B FFT runs.