### PR TITLE
docs: refine README using the introductory blog post

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,61 @@
 # OpenRL: self-hosted API for your RL Infrastructure
 
+> **Research preview.** OpenRL is an early-stage project from GKE Labs. Expect the API surface
+> and architecture to keep evolving.
+
 OpenRL implements [Tinker](https://tinker-docs.thinkingmachines.ai/) compatible API for fine-tuning language models that you can run on your own infrastructure (machine or a kubernetes cluster). You can use the Tinker SDK to orchestrate RL training loops by writing imperative Python code directly from your local machine.
 
-# Why Tinker
+📖 For the full story behind why we built OpenRL, read our introductory blog post:
+[Introducing OpenRL: A self-hosted post-training API for fine-tuning LLMs](https://opensource.googleblog.com/2026/06/introducing-openrl-a-self-hosted-post-training-api-for-fine-tuning-llms.html)
+(Google Open Source Blog, June 2026).
 
-We love Tinker. Tinker simplifies LLM post-training for developers and researchers. The Tinker API provides a smarter abstraction that decouples the underlying infrastructure from the RL training loop. This gives AI researchers complete control over their training algorithms, data loops, and loss functions and platform engineers the ability to scale the infrastructure independently.
+## Why OpenRL
+
+Agentic RL on LLMs carries a lot of systems complexity. Running a single RL loop means
+coordinating dataset selection and cleaning, choosing RL environments, debugging the training
+loop, managing reward signals, handling inference mismatches, allocating hardware, and
+operating the infrastructure underneath all of it.
+
+Our view is that AI research and infrastructure concerns are too tightly coupled in today's
+tooling. Separating them lets infrastructure engineers and AI researchers move independently —
+much the way Kubernetes separated infrastructure concerns from application development.
+
+That is why we built on Tinker. Tinker simplifies LLM post-training for developers and
+researchers by hiding post-training infrastructure behind four API primitives. Researchers keep
+complete control over their training algorithms, data loops, and loss functions; platform
+engineers scale, orchestrate, and operate the infrastructure independently. OpenRL lets you run
+those same APIs on hardware you control.
 
 **Bonus**: you can use [tinker-cookbook](https://github.com/thinking-machines-lab/tinker-cookbook) that has awesome tutorials/recipes and utilities!
+
+### Share GPUs across jobs
+
+A traditional RL loop runs sequentially: trainers wait on samplers, and samplers wait on
+environments to score rewards — work that is often CPU- or network-bound. Expensive GPUs sit
+idle for much of the loop. Because the API decouples the loop from the hardware, OpenRL can run
+multiple RL jobs concurrently and pack their training and sampling steps together, which lifts
+overall GPU utilization.
+
+### Prototype locally, scale remotely
+
+Putting infrastructure behind an API also means researchers stop wrestling with heavy Python
+and CUDA dependency stacks. During R&D you can run your RL loop on a Mac while pointing it at
+training APIs hosted on a Kubernetes cluster or a pool of VMs, then scale up without rewriting
+the loop.
+
+### Autoresearch
+
+We expect frontier AI research to become increasingly automated, and abstracting away the
+infrastructure is groundwork for that. The [autoresearch recipes](examples/autoresearch/README.md),
+adapted from [Karpathy's autoresearch](https://github.com/karpathy/autoresearch), run parallel
+experiments for parameter sweeps and reward-signal improvement against a shared OpenRL gateway.
+
+## What OpenRL is not
+
+- **It is not a managed service.** OpenRL is self-hosted. The goal is that it is easy to deploy
+  and operate on your own Kubernetes cluster.
+- **It is not an RL framework.** You keep full control over your RL loop; OpenRL only provides
+  the training and sampling APIs underneath it.
 
 ## Quick Start
 
@@ -83,11 +132,21 @@ Detailed guides and runnable examples are structured under `docs/` and `examples
 
 ## Roadmap
 
-- [ ] Blog posts + Demo videos
-- [ ] Full parameter finetuning
-- [ ] Multi model support
+- [x] Blog posts — [Introducing OpenRL](https://opensource.googleblog.com/2026/06/introducing-openrl-a-self-hosted-post-training-api-for-fine-tuning-llms.html)
+- [x] Autoresearch integration — [recipes](examples/autoresearch/README.md)
+- [ ] Full parameter finetuning — 🚧 in progress on the [`fft`](https://github.com/gke-labs/open-rl/tree/fft) branch
+- [ ] Delta weight sync — 🚧 in progress on the [`fft`](https://github.com/gke-labs/open-rl/tree/fft) branch
+- [ ] Demo videos
+- [ ] Multi model support (multitenancy across different base model types)
 - [ ] Model checkpoints API
-- [ ] Autoresearch integration
+
+## Acknowledgements
+
+We are grateful to the open source AI communities whose work inspired OpenRL, in particular
+[Thinking Machines](https://thinkingmachines.ai/), [vLLM](https://github.com/vllm-project/vllm),
+[PyTorch](https://pytorch.org/), [prime-rl](https://github.com/PrimeIntellect-ai/prime-rl),
+[verl](https://github.com/volcengine/verl), [SkyRL](https://github.com/NovaSky-AI/SkyRL), and
+[llm-d](https://github.com/llm-d/llm-d).
 
 ## Contributing
 

--- a/docs/rl_concepts.md
+++ b/docs/rl_concepts.md
@@ -1,5 +1,0 @@
-# Reinforcement Learning Concepts in OpenRL
-
-This document provides an overview of the core Reinforcement Learning (RL) concepts used in the OpenRL project.
-
-<!-- TODO: Add RL concepts -->


### PR DESCRIPTION
Brings the motivation and positioning from "Introducing OpenRL: A self-hosted post-training API for fine-tuning LLMs" (Google Open Source Blog, June 2026) into the README, and links the post as background reading.

- Add a research preview callout
- Rewrite "Why Tinker" as "Why OpenRL": the systems complexity of agentic RL, the separation of research and infrastructure concerns, and why we built on Tinker. Also fixes the heading, which was an H1
- Add "Share GPUs across jobs": sequential RL loops leave GPUs idle, and decoupling the loop from the hardware allows packing concurrent jobs
- Add "Prototype locally, scale remotely"
- Add "Autoresearch", linking the existing recipes
- Add "What OpenRL is not": not a managed service, not an RL framework
- Add "Acknowledgements" for the projects that inspired OpenRL

Roadmap is brought up to date: blog posts and autoresearch are done, full parameter finetuning and delta weight sync are marked in progress on the fft branch, and demo videos are split out from blog posts.

Also removes docs/rl_concepts.md, which was an unreferenced stub containing only a heading and a TODO.