### PR TITLE
k8s: make distributed overlays image-pinnable

### DIFF
--- a/k8s/deploy/distributed-lustre/kustomization.yaml
+++ b/k8s/deploy/distributed-lustre/kustomization.yaml
@@ -7,3 +7,10 @@ resources:
   - 03-vllm.yaml
   - 04-gateway.yaml
   - 05-trainer-worker.yaml
+
+# Release builds repoint these with `kustomize edit set image`.
+images:
+  - name: ghcr.io/gke-labs/open-rl/server
+    newTag: latest
+  - name: ghcr.io/gke-labs/open-rl/gateway
+    newTag: latest

--- a/k8s/deploy/distributed-shared/kustomization.yaml
+++ b/k8s/deploy/distributed-shared/kustomization.yaml
@@ -8,6 +8,13 @@ resources:
   - 04-gateway.yaml
   - 05-trainer-worker.yaml
 
+# Release builds repoint these with `kustomize edit set image`.
+images:
+  - name: ghcr.io/gke-labs/open-rl/server
+    newTag: latest
+  - name: ghcr.io/gke-labs/open-rl/gateway
+    newTag: latest
+
 configMapGenerator:
   - name: open-rl-config
     literals:


### PR DESCRIPTION
Part of #182. Follows #188.

Adds an `images:` block to the `distributed-shared` and `distributed-lustre`
kustomizations, listing `ghcr.io/gke-labs/open-rl/server` and
`ghcr.io/gke-labs/open-rl/gateway` at their existing `latest` tag. 

`kustomize edit set image` writes into this block, so it has to exist for the release job
to pin the bundle to a version tag.
