### PR TITLE
ci: publish a GitHub Release on v* tags

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - 'v*'
   workflow_dispatch:
 
 jobs:
@@ -43,12 +45,15 @@ jobs:
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           images: ghcr.io/gke-labs/open-rl/${{ matrix.image_name }}
-          # Tags every push `sha-<short>`, and the default branch `latest`.
+          # Tags every push `sha-<short>`, the default branch `latest`, and a
+          # `v*` tag push `v<x.y.z>`. The literal `v` keeps the image tag equal
+          # to the git tag, which the bundle pins to.
           flavor: |
             latest=false
           tags: |
             type=sha
             type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern=v{{version}}
 
       - name: Build and push
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
@@ -60,3 +65,27 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  # Attaches the rendered manifests to a GitHub Release, once the images they
+  # reference have been pushed.
+  release:
+    needs: build-and-publish
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          # Nothing in this job talks to git.
+          persist-credentials: false
+
+      # kustomize and gh both ship with the runner image.
+      - name: Render release bundle
+        run: make release-bundle VERSION="${GITHUB_REF_NAME}"
+
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "${GITHUB_REF_NAME}" dist/* --generate-notes

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: server vllm test lint fmt help push-vm pull-vm
+.PHONY: server vllm test lint fmt help render release-bundle push-vm pull-vm
 
 # ---------------------------------------------------------------------------
 # Knobs (override on the command line: make server BASE_MODEL=... SAMPLING_BACKEND=...)
@@ -39,6 +39,8 @@ help:
 	@echo "make test e2e fft-gsm8k TRAINING_TEST_ARGS='steps=10 eval_examples=8 extra=\"batch=2\"'"
 	@echo "make test piglatin                      # pig-latin example end-to-end tests"
 	@echo "make lint | fmt"
+	@echo "make render OVERLAY=k8s/deploy/distributed-shared VERSION=v0.1.0  # pinned manifests to stdout"
+	@echo "make release-bundle VERSION=v0.1.0     # release assets into $(DIST_DIR)/"
 
 # ---------------------------------------------------------------------------
 # Server
@@ -137,6 +139,42 @@ rollout:
 
 dashboard-apply:
 	@dev/monitoring/apply_dashboard.sh $(GCP_PROJECT)
+
+# ---------------------------------------------------------------------------
+# Release
+# ---------------------------------------------------------------------------
+# Images published by .github/workflows/build-and-push.yml. The names must match
+# the manifests exactly or the pin silently does nothing.
+IMAGE_REPO     ?= ghcr.io/gke-labs/open-rl
+RELEASE_IMAGES ?= server gateway client
+# Gitignored; the release job uploads everything in here.
+DIST_DIR       ?= dist
+
+# Print any overlay with the open-rl images pinned to VERSION:
+#   make render OVERLAY=examples/text-to-sql VERSION=v0.1.0 | kubectl apply -f -
+# Works on a temp copy of the repo: `kustomize edit` rewrites the kustomization
+# in place, and overlays reach into k8s/deploy/ by relative path.
+render:
+	@test -n "$(OVERLAY)" && test -d "$(OVERLAY)" || { echo "Set OVERLAY=<dir> to an overlay directory"; exit 2; }
+	@test -n "$(VERSION)" || { echo "Set VERSION=<tag>, e.g. VERSION=v0.1.0"; exit 2; }
+	@set -eu; \
+	tmp="$$(mktemp -d)"; \
+	trap 'rm -rf "$$tmp"' EXIT INT TERM; \
+	tar -cf - --exclude .git --exclude .venv --exclude __pycache__ --exclude $(DIST_DIR) . | tar -xf - -C "$$tmp"; \
+	cd "$$tmp/$(OVERLAY)"; \
+	for image in $(RELEASE_IMAGES); do \
+	  kustomize edit set image "$(IMAGE_REPO)/$$image:$(VERSION)"; \
+	done; \
+	kustomize build .
+
+# Build the assets attached to a GitHub Release. Asset names carry no version so
+# that /releases/latest/download/<name> keeps resolving.
+release-bundle:
+	@test -n "$(VERSION)" || { echo "Set VERSION=<tag>, e.g. VERSION=v0.1.0"; exit 2; }
+	@rm -rf $(DIST_DIR) && mkdir -p $(DIST_DIR)
+	@$(MAKE) --no-print-directory render OVERLAY=k8s/deploy/distributed-shared VERSION=$(VERSION) > $(DIST_DIR)/openrl-distributed-shared.yaml
+	@$(MAKE) --no-print-directory render OVERLAY=k8s/deploy/distributed-lustre VERSION=$(VERSION) > $(DIST_DIR)/openrl-distributed-lustre.yaml
+	@cd $(DIST_DIR) && { command -v sha256sum >/dev/null && sha256sum *.yaml || shasum -a 256 *.yaml; } > checksums.sha256
 
 # ---------------------------------------------------------------------------
 # Misc


### PR DESCRIPTION
Part of #182. Pushing a `v*` tag builds images tagged with the version, then attaches the rendered manifests to a GitHub Release, so users have an install target that does not move when `main` does. The release job runs only for `refs/tags/v*`, and only after every image the manifests reference has been pushed.

Two new Makefile targets, both runnable locally:

- `make render OVERLAY=<dir> VERSION=<tag>` prints any overlay with the open-rl images pinned to `VERSION`, recipes included: `make render OVERLAY=examples/text-to-sql VERSION=v0.1.0 | kubectl apply -f -`
- `make release-bundle VERSION=<tag>` writes the two core overlays to `dist/` under version-free names, so `/releases/latest/download/<asset>` keeps resolving, plus `checksums.sha256`.
