### PR TITLE
feat: integrate worker suspend/resume with the llm-d Snapshot Agent (app_channel)

### DIFF
--- a/src/accel_timeslicer/llmd_app.py
+++ b/src/accel_timeslicer/llmd_app.py
@@ -1,0 +1,76 @@
+# llm-d time-slicing platform integration ("llmd-app" mode).
+#
+# In this mode OpenRL delegates suspend/resume mechanics to the node-local
+# llm-d Snapshot Agent via the app_channel backend: workers register once at
+# startup with timeslice.snapshot_agent.register_workload and the agent PUSHES
+# snapshot/restore commands over the stream when jobs are swapped.
+#
+# Mode selection and addressing are environment driven:
+#   OPEN_RL_TIME_SLICE_MODE       "llmd-app" enables this mode (default: legacy)
+#   OPEN_RL_SNAPSHOT_AGENT_ADDR  node-local Snapshot Agent gRPC target
+#                                (falls back to LLMD_SNAPSHOT_AGENT_ENDPOINT, then NODE_IP:9001)
+#
+# Identity: the same job_id/group pair is used for the app_channel
+# registration and the timeslice.io/job-id / timeslice.io/group pod labels
+# (which the snapshot agent's k8s watcher uses to track job state).
+
+import os
+from collections.abc import Callable
+from typing import Any
+
+from .workload import WorkloadRef
+
+LLMD_APP_MODE = "llmd-app"
+DEFAULT_SNAPSHOT_AGENT_PORT = 9001
+
+
+def timeslice_mode() -> str:
+  return os.getenv("OPEN_RL_TIME_SLICE_MODE", "legacy").strip().lower()
+
+
+def is_llmd_app_mode() -> bool:
+  return timeslice_mode() == LLMD_APP_MODE
+
+
+def snapshot_agent_addr() -> str:
+  addr = os.getenv("OPEN_RL_SNAPSHOT_AGENT_ADDR") or os.getenv("LLMD_SNAPSHOT_AGENT_ENDPOINT")
+  if addr:
+    return addr
+  node_ip = os.getenv("NODE_IP")
+  if node_ip:
+    return f"{node_ip}:{DEFAULT_SNAPSHOT_AGENT_PORT}"
+  return f"127.0.0.1:{DEFAULT_SNAPSHOT_AGENT_PORT}"
+
+
+def register_app_channel_workload(
+  workload: WorkloadRef,
+  *,
+  engine: Any = None,
+  on_snapshot: Callable[..., Any] | None = None,
+  on_restore: Callable[..., Any] | None = None,
+  supported_modes: list[str] | None = None,
+  default_mode: str | None = None,
+  tags: list[str] | None = None,
+  agent_addr: str | None = None,
+) -> Any:
+  """Register this process with the node-local Snapshot Agent (app_channel).
+
+  Pass a recognized engine object (e.g. vLLM AsyncLLMEngine) via engine=, or
+  on_snapshot(mode, tags)/on_restore(tags) callbacks for custom workloads such
+  as the FFT trainer (supported_modes=["offload"]). Returns a WorkloadHandle;
+  call close() on clean shutdown. The library owns the stream lifecycle and
+  reconnects with backoff, re-registering after agent restarts.
+  """
+  from timeslice.snapshot_agent import register_workload
+
+  return register_workload(
+    agent_addr or snapshot_agent_addr(),
+    job_id=workload.job_id,
+    group=workload.group,
+    workload=engine,
+    on_snapshot=on_snapshot,
+    on_restore=on_restore,
+    supported_modes=supported_modes,
+    default_mode=default_mode,
+    tags=tags,
+  )

--- a/src/server/k8s_worker_manager.py
+++ b/src/server/k8s_worker_manager.py
@@ -447,6 +447,8 @@ class KubernetesWorkerManager:
     remove_env(container, "OPEN_RL_TIME_SLICE_GROUP")
     remove_env(container, "OPEN_RL_ACCEL_TIMESLICER_HOST")
     remove_env(container, "OPEN_RL_ACCEL_TIMESLICER_PORT")
+    remove_env(container, "OPEN_RL_TIME_SLICE_MODE")
+    remove_env(container, "OPEN_RL_SNAPSHOT_AGENT_ADDR")
 
     from server.model_metadata import WeightSyncConfig
 

--- a/src/server/training_requests_processor.py
+++ b/src/server/training_requests_processor.py
@@ -14,6 +14,7 @@ from fastapi import FastAPI, HTTPException
 from opentelemetry import context as otel_context
 from opentelemetry import propagate, trace
 
+from accel_timeslicer.llmd_app import is_llmd_app_mode, register_app_channel_workload
 from accel_timeslicer.time_slicer import TimeSlicerClient, time_slicer_client_from_env, workload_from_env
 from accel_timeslicer.workload import TRAINER_TIME_SLICE_GROUP, workload_job_id
 from server.store import RequestStore, get_store
@@ -309,9 +310,25 @@ class FFTTrainingRequestsProcessor(TrainingRequestsProcessor):
     self.workload = workload_from_env(os.getpid(), job_id=workload_job_id("trainer", model_id), group=TRAINER_TIME_SLICE_GROUP)
     self.time_slicer = time_slicer
     self.snapshot_registered = False
+    # llmd-app mode: the Snapshot Agent pushes offload/reload over the
+    # app_channel stream, so run_once must not call sleep()/wake_up() inline.
+    self.llmd_app_mode = is_llmd_app_mode()
+    self.app_channel_handle: Any = None
+    if self.llmd_app_mode and hasattr(worker, "external_offload_manager"):
+      worker.external_offload_manager = True
+
+  def close_app_channel(self) -> None:
+    if self.app_channel_handle is None:
+      return
+    try:
+      self.app_channel_handle.close()
+    except Exception as exc:
+      print(f"[WORKER] Failed to close app_channel workload handle: {exc}")
+    self.app_channel_handle = None
 
   async def exit_gracefully(self) -> None:
     print(f"[WORKER] Initiating immediate exit for model {self.model_id} trainer worker...")
+    self.close_app_channel()
     if self.snapshot_registered:
       try:
         await self.time_slicer.unregister(self.workload)
@@ -328,6 +345,18 @@ class FFTTrainingRequestsProcessor(TrainingRequestsProcessor):
     print("[WORKER] Full fine-tuning training requests processor started.")
 
     try:
+      if self.llmd_app_mode:
+        # The existing pinned-buffer offload/reload functions become the
+        # app_channel callbacks; the agent decides when they run. Trainers
+        # cannot reconstruct dropped state, so only "offload" is supported.
+        self.app_channel_handle = register_app_channel_workload(
+          self.workload,
+          on_snapshot=lambda mode, tags: self.worker.sleep(),
+          on_restore=lambda tags: self.worker.wake_up(),
+          supported_modes=["offload"],
+          default_mode="offload",
+        )
+        print(f"[WORKER] Registered app_channel workload {self.workload.key} with node-local snapshot agent.")
       await self.time_slicer.register(self.workload)
       self.snapshot_registered = True
       while True:
@@ -341,6 +370,7 @@ class FFTTrainingRequestsProcessor(TrainingRequestsProcessor):
           await asyncio.sleep(1)
     finally:
       try:
+        self.close_app_channel()
         if self.snapshot_registered:
           await self.time_slicer.unregister(self.workload)
       finally:
@@ -373,14 +403,20 @@ class FFTTrainingRequestsProcessor(TrainingRequestsProcessor):
 
         if gpu_reqs:
           async with self.time_slicer.acquire(self.workload):
-            if hasattr(self.worker, "wake_up"):
-              await asyncio.to_thread(self.worker.wake_up)
-            try:
+            # llmd-app mode: the Snapshot Agent owns offload/reload (pushed
+            # over the app_channel stream) — never sleep()/wake_up() inline.
+            if self.llmd_app_mode:
               for request in gpu_reqs:
                 results.append(await self.handle_request(request, self.model_id))
-            finally:
-              if hasattr(self.worker, "sleep"):
-                await asyncio.to_thread(self.worker.sleep)
+            else:
+              if hasattr(self.worker, "wake_up"):
+                await asyncio.to_thread(self.worker.wake_up)
+              try:
+                for request in gpu_reqs:
+                  results.append(await self.handle_request(request, self.model_id))
+              finally:
+                if hasattr(self.worker, "sleep"):
+                  await asyncio.to_thread(self.worker.sleep)
 
         if hasattr(self.worker, "cpu_offload") and not self.worker.cpu_offload and save_reqs:
           async with self.time_slicer.acquire(self.workload):

--- a/src/server/vllm_sampler.py
+++ b/src/server/vllm_sampler.py
@@ -62,10 +62,13 @@ def is_fft_enabled() -> bool:
 
 
 time_slicer: Any = None
+LLMD_APP_MODE = False
 if is_fft_enabled():
+  from accel_timeslicer.llmd_app import is_llmd_app_mode, register_app_channel_workload
   from accel_timeslicer.time_slicer import time_slicer_client_from_env, workload_from_env
   from accel_timeslicer.workload import SAMPLER_TIME_SLICE_GROUP, workload_job_id
 
+  LLMD_APP_MODE = is_llmd_app_mode()
   time_slicer = time_slicer_client_from_env()
 
 
@@ -294,9 +297,22 @@ async def run_sampling_worker(model_id: str) -> None:
 
   store = get_store()
   snapshot_registered = False
+  app_channel_handle: Any = None
   workload = None
   if time_slicer is not None:
     workload = workload_from_env(os.getpid(), job_id=workload_job_id("sampler", model_id), group=SAMPLER_TIME_SLICE_GROUP)
+
+  def register_app_channel() -> None:
+    # llmd-app mode: hand the engine object to the node-local snapshot agent.
+    # vLLM engines are recognized by type (requires enable_sleep_mode=True);
+    # the agent pushes sleep(level)/wake_up(tags) — the worker no longer calls
+    # them itself around lock boundaries.
+    nonlocal app_channel_handle
+    if not LLMD_APP_MODE or engine is None or app_channel_handle is not None:
+      return
+    assert workload is not None
+    app_channel_handle = register_app_channel_workload(workload, engine=engine)
+    print(f"[vLLM Worker] Registered app_channel workload {workload.key} with node-local snapshot agent.")
 
   if time_slicer is not None:
     assert workload is not None
@@ -309,20 +325,35 @@ async def run_sampling_worker(model_id: str) -> None:
         init_engine()
         print("[vLLM Worker] Engine initialized successfully.")
         if engine is not None:
-          print("[vLLM Worker] Sleeping engine after init to yield GPU memory (CPU offload)...")
-          await engine.sleep(level=1)
-          IS_ENGINE_SLEEPING = True
+          if LLMD_APP_MODE:
+            # Register before yielding the lock so the agent can snapshot this
+            # job as soon as another job needs the GPU. The engine stays
+            # resident; the agent decides when to sleep it.
+            register_app_channel()
+            IS_ENGINE_SLEEPING = False
+          else:
+            print("[vLLM Worker] Sleeping engine after init to yield GPU memory (CPU offload)...")
+            await engine.sleep(level=1)
+            IS_ENGINE_SLEEPING = True
     except Exception as exc:
       print(f"[vLLM Worker] Failed to perform coordinated initialization: {exc}")
       traceback.print_exc()
       if engine is None:
         init_engine()
+      register_app_channel()
   else:
     init_engine()
 
   async def exit_gracefully() -> None:
     print(f"[vLLM Worker] Initiating immediate exit for model {model_id} sampler worker...")
     nonlocal snapshot_registered
+    nonlocal app_channel_handle
+    if app_channel_handle is not None:
+      try:
+        app_channel_handle.close()
+      except Exception as exc:
+        print(f"[vLLM Worker] Failed to close app_channel workload handle: {exc}")
+      app_channel_handle = None
     if snapshot_registered and time_slicer is not None:
       assert workload is not None
       try:
@@ -376,7 +407,12 @@ async def run_sampling_worker(model_id: str) -> None:
           if time_slicer is not None:
             assert workload is not None
             async with time_slicer.acquire(workload):
-              if engine is not None and IS_ENGINE_SLEEPING:
+              if LLMD_APP_MODE:
+                # The snapshot agent pushes sleep(level)/wake_up(tags) over the
+                # app_channel stream; the worker no longer calls them itself
+                # around lock boundaries.
+                IS_ENGINE_SLEEPING = False
+              elif engine is not None and IS_ENGINE_SLEEPING:
                 print("[vLLM Worker] Engine is sleeping. Waking up weights and KV cache before batch processing...")
                 await engine.wake_up(tags=["weights", "kv_cache"])
                 IS_ENGINE_SLEEPING = False
@@ -384,7 +420,7 @@ async def run_sampling_worker(model_id: str) -> None:
               await asyncio.gather(*tasks)
               if has_shutdown:
                 await exit_gracefully()
-              if engine is not None:
+              if not LLMD_APP_MODE and engine is not None:
                 print("[vLLM Worker] Exiting batch: sleeping engine (CPU offload weights) to yield GPU memory...")
                 await engine.sleep(level=1)
                 IS_ENGINE_SLEEPING = True

--- a/src/training/fft_trainer_worker.py
+++ b/src/training/fft_trainer_worker.py
@@ -6,8 +6,10 @@ import json
 import logging
 import math
 import os
+import threading
 import time
 from datetime import datetime
+from functools import wraps
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -25,6 +27,24 @@ class FFTConfig(BaseModel):
   seed: int | None = None
   cpu_offload: bool = True
   weight_sync_strategy: str | None = None
+
+
+def with_offload_lock(fn):
+  """Serialize offload/reload with save paths.
+
+  In llmd-app mode the Snapshot Agent pushes sleep()/wake_up() over the
+  app_channel stream on a background thread, and (because the orchestrator
+  defers the snapshot until another job takes the lock) such a push can land
+  while the request loop is running a save operation after release. The RLock
+  keeps the pinned-CPU shadow state and tensor.data pointers consistent.
+  """
+
+  @wraps(fn)
+  def wrapper(self, *args, **kwargs):
+    with self._offload_lock:
+      return fn(self, *args, **kwargs)
+
+  return wrapper
 
 
 def trainable_model_parameters(model: PreTrainedModel) -> list[torch.nn.Parameter]:
@@ -47,6 +67,11 @@ class FFTTrainingWorker(BaseTrainerWorker):
     self.cpu_offload: bool = True
     self.weight_sync_cfg: WeightSyncConfig = WeightSyncConfig.from_env()
     self._is_offloaded: bool = False
+    # True when an external coordinator (llm-d Snapshot Agent app_channel)
+    # drives sleep()/wake_up(); saves may then legally run while resident
+    # because the orchestrator defers the snapshot on the zero-overhead path.
+    self.external_offload_manager: bool = False
+    self._offload_lock = threading.RLock()
     self._latest_delta_tensors: dict[str, torch.Tensor] = {}
     self._latest_total_changed: int = 0
     self._latest_total_elements: int = 0
@@ -137,9 +162,10 @@ class FFTTrainingWorker(BaseTrainerWorker):
         if tensor in self._param_shadow:
           tensor.data = torch.empty(0, dtype=tensor.dtype, device=self._param_shadow[tensor][0])
 
+  @with_offload_lock
   def save_model(self, alias: str | None = None) -> dict[str, Any]:
     assert self.model is not None, "Model must be loaded first."
-    if self.cpu_offload and not self._is_offloaded:
+    if self.cpu_offload and not self._is_offloaded and not self.external_offload_manager:
       raise RuntimeError(
         "Cannot save model while worker is not offloaded (self._is_offloaded is False) when cpu_offload=True. "
         "GPU time-slicer lock is not held during save operations."
@@ -171,9 +197,10 @@ class FFTTrainingWorker(BaseTrainerWorker):
     print(f"Saved full fine-tuning model to {save_path}")
     return {"path": save_path}
 
+  @with_offload_lock
   def save_state(self, model_id: str, state_path: str, include_optimizer: bool = False, kind: str = "state") -> dict[str, Any]:
     assert self.model is not None, "Model must be loaded first."
-    if self.cpu_offload and not self._is_offloaded:
+    if self.cpu_offload and not self._is_offloaded and not self.external_offload_manager:
       raise RuntimeError(
         "Cannot save state while worker is not offloaded (self._is_offloaded is False) when cpu_offload=True. "
         "GPU time-slicer lock is not held during save operations."
@@ -208,6 +235,7 @@ class FFTTrainingWorker(BaseTrainerWorker):
     print(f"Saved full fine-tuning state to {state_path}")
     return {"path": state_path}
 
+  @with_offload_lock
   def save_state_delta(
     self,
     model_id: str,
@@ -215,7 +243,7 @@ class FFTTrainingWorker(BaseTrainerWorker):
     kind: str = "sampler",
   ) -> dict[str, Any]:
     assert self.model is not None, "Model must be loaded first."
-    if self.cpu_offload and not self._is_offloaded:
+    if self.cpu_offload and not self._is_offloaded and not self.external_offload_manager:
       raise RuntimeError(
         "Cannot save state delta while worker is not offloaded (self._is_offloaded is False) when cpu_offload=True. "
         "GPU time-slicer lock is not held during save operations."
@@ -523,6 +551,7 @@ class FFTTrainingWorker(BaseTrainerWorker):
   ) -> dict[str, Any]:
     return super().generate(self.model, prompt_tokens, max_tokens, num_samples, temperature, include_prompt_logprobs)
 
+  @with_offload_lock
   def sleep(self) -> None:
     """Offload GPU tensors to pinned host CPU memory and empty CUDA allocator cache."""
     if not self.cpu_offload or self.model is None or self._is_offloaded or not torch.cuda.is_available():
@@ -593,6 +622,7 @@ class FFTTrainingWorker(BaseTrainerWorker):
     self._is_offloaded = True
     print(f"[FFT Worker] Offloaded weights & states to pinned CPU memory in {(time.perf_counter() - start_t) * 1000:.1f} ms.")
 
+  @with_offload_lock
   def wake_up(self) -> None:
     """Reload pinned CPU shadow tensors back to CUDA VRAM without destroying host shadow buffers."""
     if not self.cpu_offload or self.model is None or not self._is_offloaded or not torch.cuda.is_available():


### PR DESCRIPTION
**Depends on #195 (client v0.2.1) — merge that first.** This PR's diff is exactly its own change.

Adds an opt-in `llmd-app` mode (`OPEN_RL_TIME_SLICE_MODE=llmd-app`) where FFT workers register with the node-local llm-d Snapshot Agent over its app_channel and the agent drives suspend/resume:

- Trainer registers its existing `sleep()`/`wake_up()` as `on_snapshot`/`on_restore` callbacks (offload-only — trainers cannot reconstruct dropped state). An RLock serializes agent-pushed offloads against save paths.
- Sampler hands its vLLM engine to the agent, which drives the engine's sleep/wake directly.

**Low risk: the new path is opt-in only, and the original implementation remains both the default and the fallback.** With the flag unset (or `legacy`) nothing in the existing flow changes, and the flag can be switched off at any time to fall back to the current behavior. We're keeping this opt-in deliberately to avoid adding churn while fft merges to mainline. Once things stabilize, a separate follow-up PR will make the llm-d components the default and remove the internal checkpoint/restore and accel-timeslicer paths.