### PR TITLE
chore: pin the timeslice client and adopt its 0.2.x API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ vllm = [
 # Kubernetes cluster mode: the k8s API client used to launch FFT worker pods.
 cluster = [
     "kubernetes>=29",
-    "timeslice @ git+https://github.com/llm-d-incubation/llm-d-rl-time-slicing.git#subdirectory=pkg/client/python",
+    "timeslice @ git+https://github.com/llm-d-incubation/llm-d-rl-time-slicing.git@d03540a1c96af9d854bdaa3ef81fe435ad06a92f#subdirectory=pkg/client/python",
 ]
 dev = [
     "ruff>=0.5.0",

--- a/src/accel_timeslicer/llmd.py
+++ b/src/accel_timeslicer/llmd.py
@@ -1,4 +1,4 @@
-from typing import Protocol
+from typing import Any, Protocol
 
 from .checkpoint import CheckpointRestorer
 from .workload import WorkloadRef
@@ -10,9 +10,9 @@ class LlmDOperationResult(Protocol):
 
 
 class LlmDClient(Protocol):
-  def snapshot_and_wait(self, job_id: str, group: str, backend: str, poll_interval_sec: float = 1.0) -> LlmDOperationResult: ...
+  def snapshot_and_wait(self, job_id: str, group: str = "", poll_interval_sec: float = 1.0, backend_config: Any = None) -> LlmDOperationResult: ...
 
-  def restore_and_wait(self, job_id: str, group: str, backend: str, poll_interval_sec: float = 1.0) -> LlmDOperationResult: ...
+  def restore_and_wait(self, job_id: str, group: str = "", poll_interval_sec: float = 1.0, backend_config: Any = None) -> LlmDOperationResult: ...
 
   def close(self) -> None: ...
 
@@ -23,20 +23,24 @@ class LlmDCheckpointRestorer(CheckpointRestorer):
   def __init__(
     self,
     client: LlmDClient,
-    backend: str = "CUDA",
+    backend_config: Any = None,
     poll_interval_sec: float = 1.0,
   ):
-    self.backend = backend
+    self.backend_config = backend_config
     self.poll_interval_sec = poll_interval_sec
     self.client = client
 
   def checkpoint(self, workload: WorkloadRef) -> bool:
-    result = self.client.snapshot_and_wait(workload.job_id, workload.group, self.backend, self.poll_interval_sec)
+    result = self.client.snapshot_and_wait(
+      workload.job_id, group=workload.group, poll_interval_sec=self.poll_interval_sec, backend_config=self.backend_config
+    )
     ensure_complete("snapshot", workload.job_id, result)
     return True
 
   def restore(self, workload: WorkloadRef) -> None:
-    result = self.client.restore_and_wait(workload.job_id, workload.group, self.backend, self.poll_interval_sec)
+    result = self.client.restore_and_wait(
+      workload.job_id, group=workload.group, poll_interval_sec=self.poll_interval_sec, backend_config=self.backend_config
+    )
     ensure_complete("restore", workload.job_id, result)
 
 

--- a/src/accel_timeslicer/serve.py
+++ b/src/accel_timeslicer/serve.py
@@ -99,7 +99,12 @@ async def main_async() -> None:
   if args.backend == "llmd":
     if LlmDClient is None:
       raise RuntimeError("--backend llmd requires the llm-d timeslice snapshot client package")
-    restorer = LlmDCheckpointRestorer(LlmDClient(endpoint=args.llmd_snapshot_endpoint), args.llmd_backend, args.llmd_poll_interval_sec)
+    if args.llmd_backend != "CUDA":
+      raise RuntimeError(f"--llmd-backend {args.llmd_backend} is not supported; only CUDA is")
+    from timeslice.snapshot_agent import snapshot_agent_pb2
+
+    backend_config = snapshot_agent_pb2.BackendConfig(cuda=snapshot_agent_pb2.CudaBackendConfig())
+    restorer = LlmDCheckpointRestorer(LlmDClient(endpoint=args.llmd_snapshot_endpoint), backend_config, args.llmd_poll_interval_sec)
     time_slicer = SingleNodeTimeSlicer(restorer=restorer, scheduling_policy=args.scheduling_policy)
   else:
     restorer = CudaCheckpointRestorer(args.cuda_checkpoint_bin, args.cuda_checkpoint_timeout_ms)

--- a/tests/test_accel_timeslicer.py
+++ b/tests/test_accel_timeslicer.py
@@ -443,7 +443,7 @@ class LlmDCheckpointRestorerTest(unittest.TestCase):
       parameters = inspect.signature(getattr(SnapshotAgentClient, name)).parameters
       self.assertEqual(
         list(parameters)[:5],
-        ["self", "job_id", "group", "backend", "poll_interval_sec"],
+        ["self", "job_id", "group", "poll_interval_sec", "backend_config"],
       )
       self.assertEqual(parameters["poll_interval_sec"].default, 1.0)
 
@@ -456,19 +456,20 @@ class LlmDCheckpointRestorerTest(unittest.TestCase):
       def __init__(self):
         self.calls = []
 
-      def snapshot_and_wait(self, job_id, group, backend, poll_interval_sec=1.0):
-        self.calls.append(("snapshot", job_id, group, backend, poll_interval_sec))
+      def snapshot_and_wait(self, job_id, group="", poll_interval_sec=1.0, backend_config=None):
+        self.calls.append(("snapshot", job_id, group, poll_interval_sec, backend_config))
         return SimpleNamespace(status="OPERATION_STATUS_COMPLETE")
 
-      def restore_and_wait(self, job_id, group, backend, poll_interval_sec=1.0):
-        self.calls.append(("restore", job_id, group, backend, poll_interval_sec))
+      def restore_and_wait(self, job_id, group="", poll_interval_sec=1.0, backend_config=None):
+        self.calls.append(("restore", job_id, group, poll_interval_sec, backend_config))
         return SimpleNamespace(status="OPERATION_STATUS_COMPLETE")
 
       def close(self):
         pass
 
     client = Client()
-    restorer = LlmDCheckpointRestorer(client, "CUDA", 0.25)
+    cuda_config = object()
+    restorer = LlmDCheckpointRestorer(client, cuda_config, 0.25)
 
     target = WorkloadRef(job_id="job-a")
     restorer.checkpoint(target)
@@ -477,8 +478,8 @@ class LlmDCheckpointRestorerTest(unittest.TestCase):
     self.assertEqual(
       client.calls,
       [
-        ("snapshot", "job-a", "shared-accelerator", "CUDA", 0.25),
-        ("restore", "job-a", "shared-accelerator", "CUDA", 0.25),
+        ("snapshot", "job-a", "shared-accelerator", 0.25, cuda_config),
+        ("restore", "job-a", "shared-accelerator", 0.25, cuda_config),
       ],
     )
 

--- a/uv.lock
+++ b/uv.lock
@@ -1906,7 +1906,7 @@ requires-dist = [
     { name = "redis", specifier = ">=5.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.5.0" },
     { name = "tilelang", marker = "sys_platform == 'linux' and extra == 'gpu'", specifier = ">=0.1.9" },
-    { name = "timeslice", marker = "extra == 'cluster'", git = "https://github.com/llm-d-incubation/llm-d-rl-time-slicing.git?subdirectory=pkg%2Fclient%2Fpython" },
+    { name = "timeslice", marker = "extra == 'cluster'", git = "https://github.com/llm-d-incubation/llm-d-rl-time-slicing.git?subdirectory=pkg%2Fclient%2Fpython&rev=d03540a1c96af9d854bdaa3ef81fe435ad06a92f" },
     { name = "torch", marker = "sys_platform == 'linux' and extra == 'gpu'", index = "https://download.pytorch.org/whl/cu129", conflict = { package = "open-rl", extra = "gpu" } },
     { name = "torch", marker = "sys_platform == 'linux' and extra == 'vllm'", index = "https://download.pytorch.org/whl/cu129", conflict = { package = "open-rl", extra = "vllm" } },
     { name = "torch", marker = "extra == 'cpu'", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "open-rl", extra = "cpu" } },
@@ -3084,8 +3084,8 @@ wheels = [
 
 [[package]]
 name = "timeslice"
-version = "0.1.0"
-source = { git = "https://github.com/llm-d-incubation/llm-d-rl-time-slicing.git?subdirectory=pkg%2Fclient%2Fpython#d420d796afc6705335d1b99dd17eef1bd3f2885b" }
+version = "0.2.1"
+source = { git = "https://github.com/llm-d-incubation/llm-d-rl-time-slicing.git?subdirectory=pkg%2Fclient%2Fpython&rev=d03540a1c96af9d854bdaa3ef81fe435ad06a92f#d03540a1c96af9d854bdaa3ef81fe435ad06a92f" }
 dependencies = [
     { name = "grpcio" },
     { name = "protobuf" },


### PR DESCRIPTION
The `timeslice` git dependency is unpinned in pyproject, but `uv.lock` has been frozen at v0.1.0 (`d420d796`) since it was last resolved. The current client's `snapshot_and_wait`/`restore_and_wait` signatures changed (`backend: str` → trailing `backend_config`), so the next `uv lock` refresh would break `LlmDCheckpointRestorer` at runtime.

This PR defuses that:
- Pins the dependency to the current v0.2.1 client and regenerates `uv.lock` (only the timeslice entry moves).
- Adopts the 0.2.x API: `serve.py` constructs the `BackendConfig` directly at the input edge (CUDA, the only value used today) and `LlmDCheckpointRestorer` forwards it as-is.
- Updates the client-contract test accordingly.

No behavior change for current builds (the lockfile was already the de-facto pin); this makes the pairing explicit and current.