### PR TITLE
docs: document pinned install paths and the release process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@
 * [Pull Request Lifecycle](#pull-request-lifecycle)
 * [Sign Your Commits](#sign-your-commits)
 * [Pull Request Checklist](#pull-request-checklist)
+* [Releases](#releases)
 
 Welcome! We are glad that you want to contribute to OpenRL. 💖
 
@@ -163,3 +164,13 @@ following locally:
 * [ ] Documentation under `docs/` or `examples/` is updated if behavior changed.
 * [ ] The pull request description explains what changed and why, and links the related issue.
 * [ ] Commits are scoped and have clear messages.
+
+## Releases
+
+Maintainers cut releases by pushing a `v*` tag to `main`; CI publishes the images and attaches the
+rendered manifest bundles. See [RELEASING.md](RELEASING.md) for the full procedure, the local dry
+run, and the per-release compatibility matrix.
+
+Note for changes that touch `k8s/deploy/` or the build workflows: the release bundles are rendered
+from those overlays, so run `make release-bundle VERSION=v0.0.0-dev` and check the output before
+opening the pull request.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -163,4 +163,3 @@ following locally:
 * [ ] Documentation under `docs/` or `examples/` is updated if behavior changed.
 * [ ] The pull request description explains what changed and why, and links the related issue.
 * [ ] Commits are scoped and have clear messages.
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,6 @@
 * [Pull Request Lifecycle](#pull-request-lifecycle)
 * [Sign Your Commits](#sign-your-commits)
 * [Pull Request Checklist](#pull-request-checklist)
-* [Releases](#releases)
 
 Welcome! We are glad that you want to contribute to OpenRL. 💖
 
@@ -165,12 +164,3 @@ following locally:
 * [ ] The pull request description explains what changed and why, and links the related issue.
 * [ ] Commits are scoped and have clear messages.
 
-## Releases
-
-Maintainers cut releases by pushing a `v*` tag to `main`; CI publishes the images and attaches the
-rendered manifest bundles. See [RELEASING.md](RELEASING.md) for the full procedure, the local dry
-run, and the per-release compatibility matrix.
-
-Note for changes that touch `k8s/deploy/` or the build workflows: the release bundles are rendered
-from those overlays, so run `make release-bundle VERSION=v0.0.0-dev` and check the output before
-opening the pull request.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # OpenRL: self-hosted API for your RL Infrastructure
 
+[![Release](https://img.shields.io/github/v/release/gke-labs/open-rl?label=release)](https://github.com/gke-labs/open-rl/releases/latest)
+
 > **Research preview.** OpenRL is an early-stage project from GKE Labs. Expect the API surface
 > and architecture to keep evolving.
 
@@ -58,6 +60,17 @@ experiments for parameter sweeps and reward-signal improvement against a shared 
   the training and sampling APIs underneath it.
 
 ## Quick Start
+
+Deploy the latest release to a Kubernetes cluster:
+
+```bash
+kubectl apply -f https://github.com/gke-labs/open-rl/releases/latest/download/openrl-distributed-shared.yaml
+```
+
+Cluster prerequisites, the Lustre variant, and the recipe-specific install are covered in the
+[GKE Setup Guide](docs/setup/gke-setup.md).
+
+To see training in action:
 
  - Follow the [Pig Latin notebook](examples/sft/pig-latin/piglatin_sft_notebook.ipynb) or [Text-to-SQL notebook](examples/sft/text-to-sql/texttosql_sft_notebook.ipynb) to see supervised fine-tuning in action.
  - Follow the [Text-to-SQL RL recipe](examples/text-to-sql/README.md) to see reinforcement learning in action.

--- a/README.md
+++ b/README.md
@@ -61,17 +61,6 @@ experiments for parameter sweeps and reward-signal improvement against a shared 
 
 ## Quick Start
 
-Deploy the latest release to a Kubernetes cluster:
-
-```bash
-kubectl apply -f https://github.com/gke-labs/open-rl/releases/latest/download/openrl-distributed-shared.yaml
-```
-
-Cluster prerequisites, the Lustre variant, and the recipe-specific install are covered in the
-[GKE Setup Guide](docs/setup/gke-setup.md).
-
-To see training in action:
-
  - Follow the [Pig Latin notebook](examples/sft/pig-latin/piglatin_sft_notebook.ipynb) or [Text-to-SQL notebook](examples/sft/text-to-sql/texttosql_sft_notebook.ipynb) to see supervised fine-tuning in action.
  - Follow the [Text-to-SQL RL recipe](examples/text-to-sql/README.md) to see reinforcement learning in action.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -29,15 +29,6 @@ Assets, attached to the GitHub Release:
 
 Both bundles have their images pinned to the release tag.
 
-**Asset names carry no version, deliberately.** That is what makes
-`https://github.com/gke-labs/open-rl/releases/latest/download/openrl-distributed-shared.yaml`
-resolve — GitHub only serves `latest/download/<name>` when `<name>` is stable across releases.
-Renaming an asset to include the version breaks every install command in the docs. If a bundle is
-ever added or renamed, update `Makefile`'s `release-bundle` target and the docs in the same change.
-
-Recipe overlays (`examples/text-to-sql`, the autoresearch recipes) are not shipped as assets. Users
-render them from a tagged checkout with `make render`.
-
 ## Cut a release
 
 1. **Dry run locally.** Requires `kustomize`. Substitute the version you are about to cut.
@@ -78,46 +69,4 @@ render them from a tagged checkout with `make render`.
 
    Every OpenRL image should read `:v0.2.0` and none should read `:latest`.
 
-5. **Edit the release notes** if the generated changelog needs a summary or upgrade instructions,
-   and record the dependency versions below.
-
-## Prereleases
-
-Not currently used, and the tooling does not support them as-is. `docker/metadata-action` is
-configured with `type=semver,pattern=v{{version}}`, which it honours for release tags but ignores
-for prerelease tags — `v0.1.0-rc.1` publishes the image tag `0.1.0-rc.1`, without the `v`. The
-release bundle pins `${GITHUB_REF_NAME}` (`v0.1.0-rc.1`), so the manifests would point at an image
-tag that was never published and the deploy would fail with `ImagePullBackOff`.
-
-To enable prereleases, switch the pattern to `type=semver,pattern={{raw}}`, which emits the git tag
-verbatim in both cases, and confirm the resulting tag set before tagging.
-
-## Backports
-
-`/releases/latest/` is decided by release creation date, not by version order. Tagging `v0.1.1`
-after `v0.2.0` has shipped makes `v0.1.1` the "latest" release and silently downgrades every
-`latest/download/` link in the docs and the README badge.
-
-CI has no way to know a tag is a backport, so it always publishes a normal release. Fix it by hand
-straight after the run finishes:
-
-```bash
-gh release edit v0.1.1 --prerelease          # excludes it from /releases/latest
-gh release view --json tagName               # confirm latest is back on v0.2.0
-```
-
-The image tags are unaffected — `metadata-action` reads the git tag, not the release's prerelease
-flag, so `v0.1.1` still publishes `v0.1.1` images and the bundle's pin resolves.
-
-## Compatibility
-
-The versions each release was built and tested against. Clients must run from the same tag as the
-deployed gateway: the Tinker SDK pin lives in `examples/pyproject.toml` and moves independently on
-`main`, so a client from `main` can disagree with a released gateway about the API.
-
-| Release | Tinker SDK | tinker-cookbook | vLLM | torch | Python |
-| --- | --- | --- | --- | --- | --- |
-| `v0.1.0` | 0.22.7 | 0.4.2 | 0.20.0 | 2.11.0+cu129 | 3.12 |
-
-Add a row for every release. The sources of truth are `examples/pyproject.toml` (Tinker SDK,
-cookbook), `pyproject.toml` (vLLM, Python) and `uv.lock` (resolved torch build).
+5. **Edit the release notes** if the generated changelog needs a summary or upgrade instructions.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,123 @@
+# Releasing
+
+How maintainers cut an OpenRL release. Everything here is driven by a git tag; there is no
+manual upload step.
+
+## Versioning
+
+Releases are semantic versions with a `v` prefix — `v0.1.0`, `v0.2.0`. Pushing a `v*` tag is what
+produces a release; nothing else does.
+
+`main` keeps publishing `latest` on every push. `latest` is a moving target and is not a release.
+
+## What a release contains
+
+Images, published to GHCR by `.github/workflows/build-and-push.yml` and tagged with the git tag
+verbatim:
+
+- `ghcr.io/gke-labs/open-rl/server:<tag>`
+- `ghcr.io/gke-labs/open-rl/gateway:<tag>`
+- `ghcr.io/gke-labs/open-rl/client:<tag>`
+
+Assets, attached to the GitHub Release:
+
+| Asset | Rendered from |
+| --- | --- |
+| `openrl-distributed-shared.yaml` | `k8s/deploy/distributed-shared` |
+| `openrl-distributed-lustre.yaml` | `k8s/deploy/distributed-lustre` |
+| `checksums.sha256` | the two YAML files above |
+
+Both bundles have their images pinned to the release tag.
+
+**Asset names carry no version, deliberately.** That is what makes
+`https://github.com/gke-labs/open-rl/releases/latest/download/openrl-distributed-shared.yaml`
+resolve — GitHub only serves `latest/download/<name>` when `<name>` is stable across releases.
+Renaming an asset to include the version breaks every install command in the docs. If a bundle is
+ever added or renamed, update `Makefile`'s `release-bundle` target and the docs in the same change.
+
+Recipe overlays (`examples/text-to-sql`, the autoresearch recipes) are not shipped as assets. Users
+render them from a tagged checkout with `make render`.
+
+## Cut a release
+
+1. **Dry run locally.** Requires `kustomize`. Substitute the version you are about to cut.
+
+   ```bash
+   make release-bundle VERSION=v0.2.0
+   grep 'image:' dist/*.yaml
+   ```
+
+   `dist/` is gitignored, and this is the same target CI runs. The images it pins do not exist yet;
+   the point is to confirm the bundles render and every OpenRL image reads the new tag.
+
+   To check a recipe overlay, which CI does not exercise:
+
+   ```bash
+   make render OVERLAY=examples/text-to-sql VERSION=v0.2.0 | grep 'image:'
+   ```
+
+2. **Tag `main`** at the commit you want to release, and push the tag.
+
+   ```bash
+   git checkout main && git pull
+   git tag v0.2.0
+   git push origin v0.2.0
+   ```
+
+3. **Watch CI.** The tag push runs `build-and-push.yml`. Its `build-and-publish` job pushes the
+   images; the `release` job then renders the bundles and calls `gh release create` with
+   `--generate-notes`. The release job only runs once the images are published, so a build failure
+   means no release is created.
+
+4. **Verify on a clean cluster.**
+
+   ```bash
+   kubectl apply -f https://github.com/gke-labs/open-rl/releases/download/v0.2.0/openrl-distributed-shared.yaml
+   kubectl get pods -o jsonpath='{..image}'
+   ```
+
+   Every OpenRL image should read `:v0.2.0` and none should read `:latest`.
+
+5. **Edit the release notes** if the generated changelog needs a summary or upgrade instructions,
+   and record the dependency versions below.
+
+## Prereleases
+
+Not currently used, and the tooling does not support them as-is. `docker/metadata-action` is
+configured with `type=semver,pattern=v{{version}}`, which it honours for release tags but ignores
+for prerelease tags — `v0.1.0-rc.1` publishes the image tag `0.1.0-rc.1`, without the `v`. The
+release bundle pins `${GITHUB_REF_NAME}` (`v0.1.0-rc.1`), so the manifests would point at an image
+tag that was never published and the deploy would fail with `ImagePullBackOff`.
+
+To enable prereleases, switch the pattern to `type=semver,pattern={{raw}}`, which emits the git tag
+verbatim in both cases, and confirm the resulting tag set before tagging.
+
+## Backports
+
+`/releases/latest/` is decided by release creation date, not by version order. Tagging `v0.1.1`
+after `v0.2.0` has shipped makes `v0.1.1` the "latest" release and silently downgrades every
+`latest/download/` link in the docs and the README badge.
+
+CI has no way to know a tag is a backport, so it always publishes a normal release. Fix it by hand
+straight after the run finishes:
+
+```bash
+gh release edit v0.1.1 --prerelease          # excludes it from /releases/latest
+gh release view --json tagName               # confirm latest is back on v0.2.0
+```
+
+The image tags are unaffected — `metadata-action` reads the git tag, not the release's prerelease
+flag, so `v0.1.1` still publishes `v0.1.1` images and the bundle's pin resolves.
+
+## Compatibility
+
+The versions each release was built and tested against. Clients must run from the same tag as the
+deployed gateway: the Tinker SDK pin lives in `examples/pyproject.toml` and moves independently on
+`main`, so a client from `main` can disagree with a released gateway about the API.
+
+| Release | Tinker SDK | tinker-cookbook | vLLM | torch | Python |
+| --- | --- | --- | --- | --- | --- |
+| `v0.1.0` | 0.22.7 | 0.4.2 | 0.20.0 | 2.11.0+cu129 | 3.12 |
+
+Add a row for every release. The sources of truth are `examples/pyproject.toml` (Tinker SDK,
+cookbook), `pyproject.toml` (vLLM, Python) and `uv.lock` (resolved torch build).

--- a/docs/setup/gke-setup.md
+++ b/docs/setup/gke-setup.md
@@ -95,18 +95,38 @@ gcloud container clusters get-credentials "${CLUSTER}" --location="${REGION}"
 
 ## 3. Deploy OpenRL
 
-Deploy the manifests using the Kustomize overlay. You should apply **only one** of the following, depending on your needs:
+Apply **only one** of the following. Options A and B install images pinned to a released version, so the cluster stays on that version until you deploy another one. Option C tracks `main`.
 
-*   **Option A: Generic Base Setup** (without recipe-specific configurations):
+*   **Option A: Generic Base Setup** (without recipe-specific configurations). Apply the release bundle directly:
     ```bash
-    kubectl apply -k k8s/deploy/distributed-shared
+    kubectl apply -f https://github.com/gke-labs/open-rl/releases/latest/download/openrl-distributed-shared.yaml
+    ```
+    Use `openrl-distributed-lustre.yaml` instead for a Lustre-backed filesystem, or replace `latest/download` with `download/v0.1.0` to pin a specific version.
+
+*   **Option B: Recipe-Specific Setup** (e.g., for Text-to-SQL). The recipe overlay includes the base setup and applies its own customizations, so do not apply Option A as well. Clone the repository at the release tag and render the overlay with its images pinned:
+    ```bash
+    git clone https://github.com/gke-labs/open-rl.git
+    cd open-rl
+    git checkout v0.1.0
+    make render OVERLAY=examples/text-to-sql VERSION=v0.1.0 | kubectl apply -f -
     ```
 
-*   **Option B: Recipe-Specific Setup** (e.g., for Text-to-SQL):
-    The recipe overlay automatically includes the base setup and applies specific customizations. You do not need to apply the base setup separately.
+    > [!WARNING]
+    > Do not apply the Option A bundle and then `kubectl apply -k examples/text-to-sql`. The
+    > second apply re-renders the base from your clone and resets every image back to `latest`,
+    > silently undoing the pin.
+
+*   **Option C: Install from Source** (contributors, tracking unreleased code):
     ```bash
-    kubectl apply -k examples/text-to-sql
+    kubectl apply -k k8s/deploy/distributed-shared    # or: kubectl apply -k examples/text-to-sql
     ```
+    This deploys `:latest`, which is retagged on every push to `main`, so pods move to a newer build whenever they restart. Checking out a tag does **not** change that — the overlays carry the `latest` tag on every branch. `make render` is the only pinned from-source path.
+
+> [!IMPORTANT]
+> Run recipe clients from the same tag you deployed. The client pins a `tinker` SDK version in
+> `examples/pyproject.toml`, and that pin moves on `main`, so a client from `main` can disagree
+> with a released gateway about the API. If the cluster runs `v0.1.0`, run the recipe from a
+> `v0.1.0` checkout.
 
 Wait for the shared storage (PVC) to be bound:
 

--- a/docs/setup/gke-setup.md
+++ b/docs/setup/gke-setup.md
@@ -111,22 +111,11 @@ Apply **only one** of the following. Options A and B install images pinned to a 
     make render OVERLAY=examples/text-to-sql VERSION=v0.1.0 | kubectl apply -f -
     ```
 
-    > [!WARNING]
-    > Do not apply the Option A bundle and then `kubectl apply -k examples/text-to-sql`. The
-    > second apply re-renders the base from your clone and resets every image back to `latest`,
-    > silently undoing the pin.
-
 *   **Option C: Install from Source** (contributors, tracking unreleased code):
     ```bash
     kubectl apply -k k8s/deploy/distributed-shared    # or: kubectl apply -k examples/text-to-sql
     ```
-    This deploys `:latest`, which is retagged on every push to `main`, so pods move to a newer build whenever they restart. Checking out a tag does **not** change that — the overlays carry the `latest` tag on every branch. `make render` is the only pinned from-source path.
-
-> [!IMPORTANT]
-> Run recipe clients from the same tag you deployed. The client pins a `tinker` SDK version in
-> `examples/pyproject.toml`, and that pin moves on `main`, so a client from `main` can disagree
-> with a released gateway about the API. If the cluster runs `v0.1.0`, run the recipe from a
-> `v0.1.0` checkout.
+    This deploys `:latest`, which is retagged on every push to `main`.
 
 Wait for the shared storage (PVC) to be bound:
 


### PR DESCRIPTION
Update docs to use latest tagged release and document the release process. 

Part of #182.