### PR TITLE
chore: renumber the first release to v0.0.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,8 @@ help:
 	@echo "make test e2e fft-gsm8k TRAINING_TEST_ARGS='steps=10 eval_examples=8 extra=\"batch=2\"'"
 	@echo "make test piglatin                      # pig-latin example end-to-end tests"
 	@echo "make lint | fmt"
-	@echo "make render OVERLAY=k8s/deploy/distributed-shared VERSION=v0.1.0  # pinned manifests to stdout"
-	@echo "make release-bundle VERSION=v0.1.0     # release assets into $(DIST_DIR)/"
+	@echo "make render OVERLAY=k8s/deploy/distributed-shared VERSION=v0.0.1  # pinned manifests to stdout"
+	@echo "make release-bundle VERSION=v0.0.1     # release assets into $(DIST_DIR)/"
 
 # ---------------------------------------------------------------------------
 # Server
@@ -151,12 +151,12 @@ RELEASE_IMAGES ?= server gateway client
 DIST_DIR       ?= dist
 
 # Print any overlay with the open-rl images pinned to VERSION:
-#   make render OVERLAY=examples/text-to-sql VERSION=v0.1.0 | kubectl apply -f -
+#   make render OVERLAY=examples/text-to-sql VERSION=v0.0.1 | kubectl apply -f -
 # Works on a temp copy of the repo: `kustomize edit` rewrites the kustomization
 # in place, and overlays reach into k8s/deploy/ by relative path.
 render:
 	@test -n "$(OVERLAY)" && test -d "$(OVERLAY)" || { echo "Set OVERLAY=<dir> to an overlay directory"; exit 2; }
-	@test -n "$(VERSION)" || { echo "Set VERSION=<tag>, e.g. VERSION=v0.1.0"; exit 2; }
+	@test -n "$(VERSION)" || { echo "Set VERSION=<tag>, e.g. VERSION=v0.0.1"; exit 2; }
 	@set -eu; \
 	tmp="$$(mktemp -d)"; \
 	trap 'rm -rf "$$tmp"' EXIT INT TERM; \
@@ -170,7 +170,7 @@ render:
 # Build the assets attached to a GitHub Release. Asset names carry no version so
 # that /releases/latest/download/<name> keeps resolving.
 release-bundle:
-	@test -n "$(VERSION)" || { echo "Set VERSION=<tag>, e.g. VERSION=v0.1.0"; exit 2; }
+	@test -n "$(VERSION)" || { echo "Set VERSION=<tag>, e.g. VERSION=v0.0.1"; exit 2; }
 	@rm -rf $(DIST_DIR) && mkdir -p $(DIST_DIR)
 	@$(MAKE) --no-print-directory render OVERLAY=k8s/deploy/distributed-shared VERSION=$(VERSION) > $(DIST_DIR)/openrl-distributed-shared.yaml
 	@$(MAKE) --no-print-directory render OVERLAY=k8s/deploy/distributed-lustre VERSION=$(VERSION) > $(DIST_DIR)/openrl-distributed-lustre.yaml

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -5,7 +5,7 @@ manual upload step.
 
 ## Versioning
 
-Releases are semantic versions with a `v` prefix — `v0.1.0`, `v0.2.0`. Pushing a `v*` tag is what
+Releases are semantic versions with a `v` prefix — `v0.0.1`, `v0.0.2`. Pushing a `v*` tag is what
 produces a release; nothing else does.
 
 `main` keeps publishing `latest` on every push. `latest` is a moving target and is not a release.
@@ -34,7 +34,7 @@ Both bundles have their images pinned to the release tag.
 1. **Dry run locally.** Requires `kustomize`. Substitute the version you are about to cut.
 
    ```bash
-   make release-bundle VERSION=v0.2.0
+   make release-bundle VERSION=v0.0.2
    grep 'image:' dist/*.yaml
    ```
 
@@ -44,15 +44,15 @@ Both bundles have their images pinned to the release tag.
    To check a recipe overlay, which CI does not exercise:
 
    ```bash
-   make render OVERLAY=examples/text-to-sql VERSION=v0.2.0 | grep 'image:'
+   make render OVERLAY=examples/text-to-sql VERSION=v0.0.2 | grep 'image:'
    ```
 
 2. **Tag `main`** at the commit you want to release, and push the tag.
 
    ```bash
    git checkout main && git pull
-   git tag v0.2.0
-   git push origin v0.2.0
+   git tag v0.0.2
+   git push origin v0.0.2
    ```
 
 3. **Watch CI.** The tag push runs `build-and-push.yml`. Its `build-and-publish` job pushes the
@@ -63,10 +63,10 @@ Both bundles have their images pinned to the release tag.
 4. **Verify on a clean cluster.**
 
    ```bash
-   kubectl apply -f https://github.com/gke-labs/open-rl/releases/download/v0.2.0/openrl-distributed-shared.yaml
+   kubectl apply -f https://github.com/gke-labs/open-rl/releases/download/v0.0.2/openrl-distributed-shared.yaml
    kubectl get pods -o jsonpath='{..image}'
    ```
 
-   Every OpenRL image should read `:v0.2.0` and none should read `:latest`.
+   Every OpenRL image should read `:v0.0.2` and none should read `:latest`.
 
 5. **Edit the release notes** if the generated changelog needs a summary or upgrade instructions.

--- a/docs/setup/gke-setup.md
+++ b/docs/setup/gke-setup.md
@@ -101,14 +101,14 @@ Apply **only one** of the following. Options A and B install images pinned to a 
     ```bash
     kubectl apply -f https://github.com/gke-labs/open-rl/releases/latest/download/openrl-distributed-shared.yaml
     ```
-    Use `openrl-distributed-lustre.yaml` instead for a Lustre-backed filesystem, or replace `latest/download` with `download/v0.1.0` to pin a specific version.
+    Use `openrl-distributed-lustre.yaml` instead for a Lustre-backed filesystem, or replace `latest/download` with `download/v0.0.1` to pin a specific version.
 
 *   **Option B: Recipe-Specific Setup** (e.g., for Text-to-SQL). The recipe overlay includes the base setup and applies its own customizations, so do not apply Option A as well. Clone the repository at the release tag and render the overlay with its images pinned:
     ```bash
     git clone https://github.com/gke-labs/open-rl.git
     cd open-rl
-    git checkout v0.1.0
-    make render OVERLAY=examples/text-to-sql VERSION=v0.1.0 | kubectl apply -f -
+    git checkout v0.0.1
+    make render OVERLAY=examples/text-to-sql VERSION=v0.0.1 | kubectl apply -f -
     ```
 
 *   **Option C: Install from Source** (contributors, tracking unreleased code):

--- a/examples/pyproject.toml
+++ b/examples/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "open-rl-client"
-version = "0.1.0"
+version = "0.0.1"
 description = "Open-RL client: CLI and shared utilities for talking to an Open-RL server."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/examples/uv.lock
+++ b/examples/uv.lock
@@ -1756,7 +1756,7 @@ wheels = [
 
 [[package]]
 name = "open-rl-client"
-version = "0.1.0"
+version = "0.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "chz" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "open-rl"
-version = "0.1.0"
+version = "0.0.1"
 description = "Open-RL server and training runtime."
 readme = "README.md"
 requires-python = ">=3.12, <3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -1640,7 +1640,7 @@ wheels = [
 
 [[package]]
 name = "open-rl"
-version = "0.1.0"
+version = "0.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "chz" },


### PR DESCRIPTION
Replaces the v0.1.0 release with v0.0.1. Moves the `open-rl` and `open-rl-client` package versions, with their lockfiles, so they match the tag the images are published under, and updates the version examples in `docs/setup/gke-setup.md`, `RELEASING.md`, and the Makefile. `open-rl-tools` under `dev/tools` is left alone — it is never packaged or published.

Once this merges, cutting `v0.0.1` from main publishes the new release; the v0.1.0 release, tag, and GHCR image tags then get deleted.