### PR TITLE
Support dev loop on kind clusters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-.PHONY: server vllm test lint fmt help render release-bundle push-vm pull-vm cluster-eval
+.PHONY: server vllm test lint fmt help render release-bundle push-vm pull-vm cluster-eval \
+	kind-host-setup kind-create kind-gateway kind-deploy \
+	kind-client kind-e2e kind-status kind-logs kind-prune kind-delete
 
 # ---------------------------------------------------------------------------
 # Knobs (override on the command line: make server BASE_MODEL=... SAMPLING_BACKEND=...)
@@ -27,6 +29,10 @@ EVAL_NAMESPACE ?=
 E2E_SCENARIO ?=
 E2E_ARGS ?=
 E2E_NAMESPACE ?=
+# The client image cluster-e2e runs. Overridden by kind-e2e to the
+# cluster-local registry; the pull policy is left to the manifest by default.
+E2E_IMAGE ?= gcr.io/$(GCP_PROJECT)/open-rl-client:$(IMAGE_TAG)
+E2E_IMAGE_PULL_POLICY ?=
 
 # CUDA_VISIBLE_DEVICES can be provided either as an environment variable or as a
 # Make variable, and is inherited by the backend/eval subprocesses.
@@ -134,6 +140,55 @@ push-images:
 	kubectl set image daemonset/open-rl-accel-timeslicer accel-timeslicer=gcr.io/$(GCP_PROJECT)/open-rl-server:$(IMAGE_TAG) 2>/dev/null || true
 	kubectl set env deployment/open-rl-gateway OPEN_RL_WORKER_IMAGE=gcr.io/$(GCP_PROJECT)/open-rl-server:$(IMAGE_TAG) 2>/dev/null || true
 
+# --- kind on a GPU VM -------------------------------------------------------
+# These run against the local docker daemon and kube context, so run them on the
+# GPU VM itself. Get your working tree there the usual way -- `make push-vm
+# REMOTE_HOST=<host>` from the workstation -- then ssh in and invoke the target,
+# or drive it from the workstation with `ssh <host> 'cd ~/open-rl && make ...'`.
+# See dev/kind/README.md.
+
+kind-host-setup:
+	./dev/kind/host-setup.sh
+
+kind-create:
+	./dev/kind/create-cluster.sh
+
+# Rebuild and republish only the slim gateway image -- the fast inner loop.
+kind-gateway:
+	./dev/kind/load-images.sh gateway
+	kubectl rollout restart deployment/open-rl-gateway
+
+kind-deploy:
+	./dev/kind/load-images.sh
+	kubectl apply -k k8s/deploy/kind-dra/
+
+kind-client:
+	./dev/kind/load-images.sh client
+
+# The same target as cluster-e2e, pointed at the cluster-local registry. Always
+# is deliberate: :kind-dev is republished on every iteration, so IfNotPresent
+# would run whatever the kubelet cached last time. The registry sits on the kind
+# docker network, so the pull is local.
+kind-e2e:
+	@$(MAKE) --no-print-directory cluster-e2e \
+	  E2E_IMAGE=localhost:5001/open-rl-client:kind-dev \
+	  E2E_IMAGE_PULL_POLICY=Always
+
+kind-status:
+	kubectl get pods,resourceclaims,resourceslices
+
+kind-logs:
+	kubectl logs deployment/open-rl-gateway --tail=100
+
+# Reclaim what republishing a mutable tag leaves behind: superseded registry
+# blobs and untagged node images. Leaves the BuildKit cache alone -- see the
+# script. Do not run it mid-build; a push racing the collector can lose blobs.
+kind-prune:
+	./dev/kind/prune.sh
+
+kind-delete:
+	kind delete cluster --name open-rl-dra
+
 deploy:
 	kubectl apply -k k8s/deploy/distributed-lustre/
 
@@ -165,7 +220,8 @@ cluster-e2e:
 	  echo "  make cluster-e2e E2E_SCENARIO=fft-gsm8k-rl-x2 E2E_ARGS=\"base_model=Qwen/Qwen3-8B steps=30 jitter_sec=5\""; \
 	  exit 2; \
 	fi; \
-	set -- --scenario "$(E2E_SCENARIO)" --image "gcr.io/$(GCP_PROJECT)/open-rl-client:$(IMAGE_TAG)"; \
+	set -- --scenario "$(E2E_SCENARIO)" --image "$(E2E_IMAGE)"; \
+	if [ -n "$(E2E_IMAGE_PULL_POLICY)" ]; then set -- "$$@" --image-pull-policy "$(E2E_IMAGE_PULL_POLICY)"; fi; \
 	if [ -n "$(E2E_ARGS)" ]; then set -- "$$@" --args "$(E2E_ARGS)"; fi; \
 	if [ -n "$(E2E_NAMESPACE)" ]; then set -- "$$@" --namespace "$(E2E_NAMESPACE)"; fi; \
 	if [ -n "$(WEIGHT_SYNC_STRATEGY)" ]; then set -- "$$@" --weight-sync-strategy "$(WEIGHT_SYNC_STRATEGY)"; fi; \

--- a/dev/kind/README.md
+++ b/dev/kind/README.md
@@ -1,0 +1,183 @@
+# kind cluster on a GPU VM
+
+Runs the Open-RL DRA workload scheduler against real GPUs inside a kind cluster
+on a single Linux GPU VM, instead of against GKE.
+
+The point is the image loop. On GKE every code change means build → push →
+pull across the internet, and the CUDA server image is multiple GB. Here the
+build, the registry, and the node all live on one machine: `docker push` moves
+only the layer that changed, over the local docker network. Cluster teardown and
+rebuild is a minute, which makes claim-leak and reconciliation behavior cheap to
+test from a clean slate.
+
+Not `kind load docker-image`. That path is `docker save` piped into
+`ctr images import`, with no layer-level dedup against what the node already
+holds — a one-line source change re-shipped the whole 36 GB server image, about
+24 minutes per iteration. A registry dedups by digest.
+
+## Requirements
+
+- A Linux VM with NVIDIA GPUs and the kernel driver installed (`nvidia-smi` works).
+- **Kubernetes 1.34+.** `k8s_worker_manager.py` talks to `resource.k8s.io/v1`,
+  which reached GA in 1.34. On a 1.33 node image the API server serves `v1beta1`
+  and every claim call 404s. `kind-cluster.yaml` pins `kindest/node:v1.35.5`.
+- Enough VRAM for the model. `Qwen/Qwen2.5-0.5B` (the overlay default) fits a
+  23 GB L4 alongside a sampler; an 8B FFT does not.
+
+## Setup
+
+Everything here talks to the local docker daemon and kube context, so it runs on
+the GPU VM. Get your working tree there the way the rest of the repo does:
+
+```bash
+# From the workstation:
+make push-vm REMOTE_HOST=<host>                  # <host> is a ~/.ssh/config alias
+```
+
+```bash
+# On the VM, in ~/open-rl:
+make kind-host-setup                             # one time; installs docker,
+                                                 # nvidia-container-toolkit, kind,
+                                                 # kubectl, helm
+exec $SHELL -l                                   # re-login picks up the docker group
+
+make kind-create                                 # cluster, DRA driver, registry
+make kind-deploy                                 # build, publish, apply
+```
+
+Targets can equally be invoked from the workstation without logging in:
+
+```bash
+ssh <host> 'cd ~/open-rl && make kind-deploy'
+```
+
+## Iterating
+
+```bash
+make push-vm REMOTE_HOST=<host>                  # from the workstation
+make kind-gateway                                # on the VM: ~1 min; covers
+                                                 # gateway.py, k8s_worker_manager.py,
+                                                 # store.py — then rolls out
+```
+
+Rebuild the `server` image only when the trainer or sampler code changes — it is
+the expensive one. `make kind-deploy` does both.
+
+## The cluster-local registry
+
+`registry.sh` runs a `registry:2` container published on `127.0.0.1:5001` and
+attached to the `kind` docker network. `create-cluster.sh` calls it, so there is
+usually nothing to do by hand; run it directly if the container was removed.
+
+The host pushes to `localhost:5001`. The node cannot reach the host's loopback,
+so `kind-cluster.yaml` gives containerd a mirror rewriting that same reference to
+`http://kind-registry:5000` on the docker network. One image reference works from
+both sides, which is why the manifests can name `localhost:5001` directly.
+
+Two consequences worth knowing:
+
+- **The mirror is baked in at cluster creation.** Adding it to
+  `kind-cluster.yaml` does nothing for a cluster that already exists; recreate
+  the cluster.
+- **`imagePullPolicy: Always` everywhere in the kind overlay.** The `:kind-dev`
+  tag is mutable and republished every iteration, so the base manifests'
+  `IfNotPresent` would leave the kubelet on the build it already cached and
+  silently test the previous code. The worker pod templates live inside
+  ConfigMaps as YAML strings where no kustomize patch can reach them, so the
+  gateway stamps their image and pull policy at render time from
+  `OPEN_RL_WORKER_IMAGE` / `OPEN_RL_WORKER_IMAGE_PULL_POLICY`.
+
+### Reclaiming the disk it accumulates
+
+A moved tag strands its old blobs in the registry and leaves the superseded
+image on the node as an untagged entry. Nothing collects either: a day of
+rebuilding the server image measured 24.3GB of registry backing 11.9GB of live
+images. `make kind-prune` (or `./dev/kind/prune.sh`) reclaims both, in about a
+minute, and leaves the BuildKit cache alone — that cache is what makes a
+one-line source change rebuild in seconds.
+
+It rebuilds the registry and re-pushes rather than running `registry
+garbage-collect`, which is **not safe here**: distribution 2.8 does not
+traverse OCI image indexes, and an index is what Docker's containerd store
+pushes. Collecting deletes the child manifests under the tagged index and
+leaves a registry that answers 200 on `:kind-dev` and 404 on every layer it
+points at, breaking images that were never stale. Re-pushing from the host's
+local images is the repair, so `prune.sh` refuses to touch the registry unless
+all three are present to put back.
+
+## How GPUs reach the pods
+
+kind nodes are Docker containers, so a GPU has to be injected twice: once into
+the node container, then from the node into the pod.
+
+1. `host-setup.sh` makes `nvidia` the default Docker runtime, because kind gives
+   no way to pass `--runtime` when it creates node containers.
+2. It sets `accept-nvidia-visible-devices-as-volume-mounts=true`, which lets
+   `kind-cluster.yaml`'s mount at `/var/run/nvidia-container-devices/all` act as
+   a request for every GPU on the host.
+3. It runs `nvidia-ctk system create-dev-char-symlinks`, because the kubelet
+   inside the node resolves GPUs through `/dev/char/<major>:<minor>` and a
+   bare-metal host does not create those.
+4. `create-cluster.sh` installs the [DRA driver for NVIDIA
+   GPUs](https://dra-driver-nvidia-gpu.sigs.k8s.io/docs/install/), which
+   publishes the `gpu.nvidia.com` DeviceClass and the ResourceSlices the
+   scheduler scans.
+
+`kind-cluster.yaml` also labels the node `nvidia.com/gpu.present=true`. The
+driver's kubelet-plugin DaemonSet has a *required* nodeAffinity matching one of
+several Node Feature Discovery labels, and NFD is not installed on kind. Without
+the label the DaemonSet sits at `desired: 0` while the DeviceClasses still
+register, so the cluster looks fine and every claim silently stays Pending.
+
+ComputeDomains are disabled — they target Multi-Node NVLink, which L4s do not
+have. Pass `KEEP_COMPUTE_DOMAINS=1` on NVLink hardware.
+
+## The 80gb tier
+
+`_discover_cluster_gpu_products()` buckets devices by `capacity.memory`: over
+40000Mi is `80gb`, everything else `24gb`. L4s only ever yield a `24gb` tier, so
+nothing here reaches the 80gb branch. That branch is covered by the unit tests
+in `tests/test_k8s_worker_manager.py`, which feed the discovery path a slice
+list containing an H100 — no cluster required. A claim for the 80gb tier
+differs from a 24gb one only by the product name interpolated into its CEL
+selector and the `open-rl.io/memory-tier` label, both of which the 24gb path
+exercises against a real API server on every run here.
+
+## Known gaps versus GKE
+
+| | GKE | kind |
+|---|---|---|
+| Shared storage | RWX Filestore (`enterprise-rwx`) | RWO local-path, single node |
+| GPU tiers | L4 + H100 | L4 only (`24gb`) |
+| `compute-domain.nvidia.com` | present | not installed |
+| DCGM / Managed Prometheus | deployed | omitted |
+| Nodes | multi-node, real scheduling spread | one node |
+
+The single node is the biggest semantic difference: cross-node scheduling,
+node-affinity behavior, and anything that depends on workers landing apart
+cannot be reproduced here.
+
+## Troubleshooting
+
+**Kubelet plugin stuck in `Init:0/1`.** It cannot find `libnvidia-ml.so.1`.
+Either the container toolkit is not injecting the driver into the node
+(re-run `host-setup.sh` and confirm `docker info | grep -i 'default runtime'`
+says `nvidia`), or `nvidiaDriverRoot` is wrong — it should be `/` for a
+host-installed driver.
+
+```bash
+docker exec open-rl-dra-control-plane nvidia-smi -L     # GPUs in the node?
+kubectl get resourceslices                              # driver publishing?
+kubectl -n dra-driver-nvidia-gpu logs -l app.kubernetes.io/name=dra-driver-nvidia-gpu --all-containers
+```
+
+**Pods stuck in `ContainerCreating` with a DRA error.** Usually the `/dev/char`
+symlinks are missing; re-run
+`sudo nvidia-ctk system create-dev-char-symlinks --create-all`.
+
+**Claims stay Pending.** No slice matches the CEL selector. Compare the claim's
+`productName` expression against what the driver actually published:
+
+```bash
+kubectl get resourceslices -o jsonpath='{.items[*].spec.devices[*].attributes.productName.string}'
+```

--- a/dev/kind/create-cluster.sh
+++ b/dev/kind/create-cluster.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+#
+# Create the kind cluster and install the DRA driver for NVIDIA GPUs.
+#
+# Run ./dev/kind/host-setup.sh first. Re-running this deletes and recreates the
+# cluster, which is the fastest way to get back to a clean claim/slice state.
+#
+# Usage:
+#   ./dev/kind/create-cluster.sh
+#   KEEP_COMPUTE_DOMAINS=1 ./dev/kind/create-cluster.sh   # on NVLink hardware
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CLUSTER_NAME="${KIND_CLUSTER_NAME:-open-rl-dra}"
+
+# Pinned so a cluster rebuild does not silently pick up a new driver. Chart and
+# docs: https://dra-driver-nvidia-gpu.sigs.k8s.io/docs/install/
+DRA_CHART="${DRA_CHART:-oci://registry.k8s.io/dra-driver-nvidia/charts/dra-driver-nvidia-gpu}"
+DRA_VERSION="${DRA_VERSION:-0.4.1}"
+DRA_NAMESPACE="dra-driver-nvidia-gpu"
+
+log() { echo "[create-cluster] $*"; }
+
+if kind get clusters 2>/dev/null | grep -qx "$CLUSTER_NAME"; then
+  log "Deleting existing cluster '$CLUSTER_NAME'..."
+  kind delete cluster --name "$CLUSTER_NAME"
+fi
+
+# Before the cluster: the node's containerd config names the registry container,
+# and starting it first means the mirror resolves on the node's very first pull.
+"$SCRIPT_DIR/registry.sh"
+
+log "Creating cluster '$CLUSTER_NAME'..."
+kind create cluster --config "$SCRIPT_DIR/kind-cluster.yaml" --name "$CLUSTER_NAME"
+kubectl config use-context "kind-${CLUSTER_NAME}"
+
+# The kind network only exists now, so the connect step was skipped above.
+"$SCRIPT_DIR/registry.sh"
+
+log "Confirming GPUs reached the node container..."
+docker exec "${CLUSTER_NAME}-control-plane" nvidia-smi -L
+
+# ComputeDomains target Multi-Node NVLink. L4s have none, so the ComputeDomain
+# resources never allocate and the extra plugin container only adds noise.
+COMPUTE_DOMAINS="${KEEP_COMPUTE_DOMAINS:+true}"
+COMPUTE_DOMAINS="${COMPUTE_DOMAINS:-false}"
+
+log "Installing the DRA driver (chart $DRA_VERSION, computeDomains=$COMPUTE_DOMAINS)..."
+helm install dra-driver-nvidia-gpu "$DRA_CHART" \
+  --version "$DRA_VERSION" \
+  --create-namespace \
+  --namespace "$DRA_NAMESPACE" \
+  --set gpuResourcesEnabledOverride=true \
+  --set resources.gpus.enabled=true \
+  --set "resources.computeDomains.enabled=${COMPUTE_DOMAINS}" \
+  --set nvidiaDriverRoot=/ \
+  --wait --timeout 5m
+
+log "Waiting for the kubelet plugin to publish ResourceSlices..."
+slices_ready=""
+for _ in $(seq 1 60); do
+  if [[ -n "$(kubectl get resourceslices -o name 2>/dev/null)" ]]; then
+    slices_ready=yes
+    break
+  fi
+  sleep 5
+done
+
+# Fail loudly. A cluster with zero slices looks healthy -- the DeviceClasses are
+# registered and the pods, if any, are Running -- but every claim the gateway
+# creates will sit Pending with nothing in its logs to say why.
+if [[ -z "$slices_ready" ]]; then
+  echo "No ResourceSlices published after 5m." >&2
+  kubectl -n "$DRA_NAMESPACE" get ds,pods >&2
+  echo >&2
+  echo "If the kubelet-plugin DaemonSet shows DESIRED 0, its required nodeAffinity" >&2
+  echo "matched nothing: it wants a Node Feature Discovery label, and NFD is not" >&2
+  echo "installed here. kind-cluster.yaml sets nvidia.com/gpu.present=true for this" >&2
+  echo "reason -- confirm it survived with:" >&2
+  echo "  kubectl get node ${CLUSTER_NAME}-control-plane -o jsonpath='{.metadata.labels}'" >&2
+  exit 1
+fi
+
+echo
+log "DeviceClasses:"
+kubectl get deviceclasses
+echo
+log "ResourceSlices:"
+kubectl get resourceslices -o custom-columns=NAME:.metadata.name,DRIVER:.spec.driver,NODE:.spec.nodeName
+
+if ! kubectl get deviceclass gpu.nvidia.com >/dev/null 2>&1; then
+  echo "DeviceClass gpu.nvidia.com is missing -- the scheduler hardcodes it. Check:" >&2
+  echo "  kubectl -n $DRA_NAMESPACE get pods" >&2
+  echo "  kubectl -n $DRA_NAMESPACE logs -l app.kubernetes.io/name=dra-driver-nvidia-gpu --all-containers" >&2
+  exit 1
+fi
+
+cat <<EOF
+
+Cluster ready. Next:
+  ./dev/kind/load-images.sh          # build + push the open-rl images
+  kubectl apply -k k8s/deploy/kind-dra/
+EOF

--- a/dev/kind/host-setup.sh
+++ b/dev/kind/host-setup.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+#
+# One-time host prep for running a GPU-enabled kind cluster on a Linux GPU VM.
+#
+# Installs Docker, the NVIDIA Container Toolkit, kind, kubectl, and helm, then
+# configures the toolkit so GPUs are visible *inside* kind's node containers.
+# That last part is the whole trick: kind nodes are Docker containers, so the
+# GPUs have to be injected into the node before the DRA driver running in the
+# node can hand them to pods.
+#
+# Assumes the NVIDIA kernel driver is already installed (check with nvidia-smi).
+#
+# Usage, on the GPU VM:
+#   make kind-host-setup
+#   ./dev/kind/host-setup.sh
+#
+# Idempotent: safe to re-run.
+set -euo pipefail
+
+log() { echo "[host-setup] $*"; }
+
+if ! command -v nvidia-smi >/dev/null 2>&1; then
+  echo "nvidia-smi not found. Install the NVIDIA kernel driver first." >&2
+  exit 1
+fi
+log "GPUs detected:"
+nvidia-smi --query-gpu=index,name,memory.total --format=csv,noheader | sed 's/^/  /'
+
+# --- Docker -----------------------------------------------------------------
+if ! command -v docker >/dev/null 2>&1; then
+  log "Installing Docker..."
+  curl -fsSL https://get.docker.com | sudo sh
+fi
+if ! id -nG "$USER" | grep -qw docker; then
+  log "Adding $USER to the docker group (takes effect on next login)."
+  sudo usermod -aG docker "$USER"
+fi
+
+# --- NVIDIA Container Toolkit -----------------------------------------------
+if ! command -v nvidia-ctk >/dev/null 2>&1; then
+  log "Installing nvidia-container-toolkit..."
+  curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey |
+    sudo gpg --batch --yes --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
+  curl -fsSL https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list |
+    sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' |
+    sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list >/dev/null
+  sudo apt-get update
+  sudo apt-get install -y nvidia-container-toolkit
+fi
+
+# Make "nvidia" the default Docker runtime. kind does not let us pass
+# --runtime=nvidia when it creates node containers, so the default has to be it.
+log "Configuring Docker to use the nvidia runtime by default..."
+sudo nvidia-ctk runtime configure --runtime=docker --set-as-default
+
+# Let a volume mount at /var/run/nvidia-container-devices/all request every GPU.
+# kind-cluster.yaml uses exactly that mount to pull the GPUs into the node
+# container, and the toolkit ignores it unless this is switched on.
+log "Enabling volume-mount device requests..."
+sudo nvidia-ctk config --in-place --set accept-nvidia-visible-devices-as-volume-mounts=true
+sudo nvidia-ctk config --in-place --set accept-nvidia-visible-devices-envvar-when-unprivileged=false
+
+sudo systemctl restart docker
+
+# The kubelet inside the node container resolves GPUs through /dev/char/<major>:<minor>
+# symlinks. A bare-metal host does not create them, so cgroup device setup fails
+# without this and pods hang in ContainerCreating.
+log "Creating /dev/char symlinks for GPU devices..."
+sudo nvidia-ctk system create-dev-char-symlinks --create-all
+
+# --- kind / kubectl / helm --------------------------------------------------
+ARCH="$(dpkg --print-architecture)"
+
+if ! command -v kind >/dev/null 2>&1; then
+  log "Installing kind..."
+  curl -fsSLo /tmp/kind "https://kind.sigs.k8s.io/dl/latest/kind-linux-${ARCH}"
+  sudo install -m 0755 /tmp/kind /usr/local/bin/kind && rm -f /tmp/kind
+fi
+
+if ! command -v kubectl >/dev/null 2>&1; then
+  log "Installing kubectl..."
+  KUBECTL_VERSION="$(curl -fsSL https://dl.k8s.io/release/stable.txt)"
+  curl -fsSLo /tmp/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl"
+  sudo install -m 0755 /tmp/kubectl /usr/local/bin/kubectl && rm -f /tmp/kubectl
+fi
+
+if ! command -v helm >/dev/null 2>&1; then
+  log "Installing helm..."
+  curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | sudo bash
+fi
+
+log "Verifying the nvidia runtime reaches into containers..."
+if sudo docker run --rm --gpus all nvidia/cuda:12.9.0-base-ubuntu22.04 nvidia-smi -L; then
+  log "Host is ready. Next: ./dev/kind/create-cluster.sh"
+else
+  echo "GPU passthrough check failed -- inspect 'docker info | grep -i runtime'." >&2
+  exit 1
+fi
+
+# Note the missing "$USER": bare `id -nG` reports the groups this shell actually
+# holds, whereas `id -nG "$USER"` reads the group database and would show docker
+# the moment usermod ran -- never warning, even though this session still cannot
+# reach the daemon.
+if ! id -nG | grep -qw docker; then
+  log "NOTE: this shell is not in the docker group yet. A fresh login picks it up;"
+  log "      in the current session run 'newgrp docker'."
+fi

--- a/dev/kind/kind-cluster.yaml
+++ b/dev/kind/kind-cluster.yaml
@@ -1,0 +1,51 @@
+# kind cluster for exercising the Open-RL DRA workload scheduler against real GPUs.
+#
+# Single node on purpose: kind drops the control-plane NoSchedule taint when
+# there are no workers, so every GPU on the host is schedulable and there is one
+# less container to inject devices into.
+#
+# The node image must be v1.34 or newer. k8s_worker_manager.py talks to
+# resource.k8s.io/v1, which only reached GA in 1.34 -- on a 1.33 node image the
+# API server serves v1beta1 and every claim call 404s. v1.35 is pinned to track
+# the GKE cluster (1.35.x) this is meant to stand in for.
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: open-rl-dra
+# Point the node's containerd at the cluster-local registry (dev/kind/registry.sh).
+# The host pushes to localhost:5001 through the registry's published port; the
+# node cannot use that loopback, so the mirror rewrites the same reference to the
+# registry container's name on the kind docker network. One image reference works
+# from both sides, which is why the manifests can name localhost:5001 directly.
+containerdConfigPatches:
+  - |-
+    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5001"]
+      endpoint = ["http://kind-registry:5000"]
+nodes:
+  - role: control-plane
+    image: kindest/node:v1.35.5
+    extraMounts:
+      # Requests every GPU on the host for this node container. The nvidia
+      # container runtime interprets a mount under /var/run/nvidia-container-devices
+      # as a device request, which is why host-setup.sh sets
+      # accept-nvidia-visible-devices-as-volume-mounts=true. The source is
+      # /dev/null because only the destination path carries meaning.
+      - hostPath: /dev/null
+        containerPath: /var/run/nvidia-container-devices/all
+    kubeadmConfigPatches:
+      # node-labels covers two separate needs:
+      #
+      # group.timeslice.io/{trainers,samplers} -- the pod templates in
+      #   k8s/deploy/distributed-fft-timeslice/ select on these and the
+      #   accel-timeslicer DaemonSet requires at least one, so setting both here
+      #   lets the GKE manifests apply unpatched.
+      #
+      # nvidia.com/gpu.present -- the DRA driver's kubelet-plugin DaemonSet has a
+      #   required nodeAffinity matching one of several Node Feature Discovery
+      #   labels. NFD is not installed on kind, so without this the DaemonSet
+      #   sits at desired=0, no ResourceSlices are ever published, and every
+      #   claim stays Pending with nothing in the logs to explain it.
+      - |
+        kind: InitConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "group.timeslice.io/trainers=true,group.timeslice.io/samplers=true,nvidia.com/gpu.present=true"

--- a/dev/kind/load-images.sh
+++ b/dev/kind/load-images.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# Build the open-rl images on this host and publish them to the cluster-local
+# registry.
+#
+# This is the reason to run kind on the GPU VM at all: the multi-GB CUDA server
+# image never leaves the machine. It goes to a registry container sitting on the
+# kind docker network, so an edit-to-running-pod loop costs a docker build layer
+# plus a layer push, not a push plus a pull across the internet.
+#
+# It used to use `kind load docker-image`, which was the wrong tool for an edit
+# loop. That path is `docker save` streamed into `ctr images import` on the node,
+# and it has no layer-level dedup against what the node already holds -- so a
+# one-line source change re-shipped the whole 36GB server image and containerd
+# re-unpacked every layer, about 24 minutes per iteration. `docker push` to a
+# registry dedups by digest: only the changed source layer moves, and the
+# kubelet pulls only that. Same iteration is now seconds.
+#
+# Usage:
+#   ./dev/kind/load-images.sh                # gateway + server
+#   ./dev/kind/load-images.sh gateway        # just the fast one
+#   IMAGE_TAG=wip ./dev/kind/load-images.sh
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+IMAGE_TAG="${IMAGE_TAG:-kind-dev}"
+# The registry is published on the host loopback and mirrored into the node by
+# create-cluster.sh, so this one reference resolves from both sides. Kept
+# distinct from the gcr.io names so a local dev build can never be confused with
+# something that was actually pushed.
+REGISTRY="${REGISTRY:-localhost:5001}"
+
+TARGETS=("$@")
+if [[ ${#TARGETS[@]} -eq 0 ]]; then
+  TARGETS=(gateway server)
+fi
+
+log() { echo "[load-images] $*"; }
+
+if ! curl -fsS "http://${REGISTRY}/v2/" >/dev/null 2>&1; then
+  echo "No registry answering at ${REGISTRY}." >&2
+  echo "It is started by dev/kind/create-cluster.sh; bring it back with:" >&2
+  echo "  ./dev/kind/registry.sh" >&2
+  exit 1
+fi
+
+for target in "${TARGETS[@]}"; do
+  case "$target" in
+    gateway) dockerfile="src/server/Dockerfile.gateway" ;;
+    server) dockerfile="src/server/Dockerfile" ;;
+    client) dockerfile="src/server/Dockerfile.client" ;;
+    *)
+      echo "Unknown target '$target'. Expected gateway, server, or client." >&2
+      exit 2
+      ;;
+  esac
+
+  image="${REGISTRY}/open-rl-${target}:${IMAGE_TAG}"
+  log "Building $image..."
+  DOCKER_BUILDKIT=1 docker build -t "$image" -f "$REPO_ROOT/$dockerfile" "$REPO_ROOT"
+
+  log "Pushing $image..."
+  docker push "$image"
+done
+
+cat <<EOF
+
+Pushed. Deploy with:
+  kubectl apply -k k8s/deploy/kind-dra/
+
+The manifests pin imagePullPolicy: Always against this registry. The tag does not
+change between iterations, so IfNotPresent would leave the kubelet sitting on the
+build it already has and silently test the previous code. Pulling from a registry
+one docker network away costs nothing.
+EOF

--- a/dev/kind/prune.sh
+++ b/dev/kind/prune.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+#
+# Reclaim the disk a long iteration streak leaves behind.
+#
+# The kind loop republishes :kind-dev on every build. The tag moves, the blobs
+# it used to point at do not: they stay in the registry, and the superseded
+# image stays resident on the node as an untagged entry. Neither is collected
+# on its own, so a day of rebuilding the 24GB server image quietly costs tens
+# of gigabytes -- 24.3GB of registry for 11.9GB of live images, measured.
+#
+# The registry is rebuilt rather than garbage-collected. `registry
+# garbage-collect` in distribution 2.8 does not traverse OCI image indexes, and
+# an index is exactly what Docker's containerd store pushes: it keeps the
+# tagged index, deletes the child manifests underneath it as unreferenced, and
+# leaves a registry that answers 200 on the tag and 404 on everything it points
+# at. Every pull then fails, including for images that were never stale. A
+# rebuild plus re-push costs about 45s and cannot half-succeed.
+#
+# Deliberately does NOT touch the BuildKit cache. That cache is what makes a
+# one-line source change rebuild in seconds instead of re-running `uv sync`.
+# Pass PRUNE_BUILD_CACHE=1 if the disk is genuinely full and you want it anyway.
+#
+# Usage:
+#   ./dev/kind/prune.sh
+#   PRUNE_BUILD_CACHE=1 ./dev/kind/prune.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REGISTRY_NAME="${KIND_REGISTRY_NAME:-kind-registry}"
+REGISTRY="${REGISTRY:-localhost:5001}"
+IMAGE_TAG="${IMAGE_TAG:-kind-dev}"
+CLUSTER_NAME="${KIND_CLUSTER_NAME:-open-rl-dra}"
+NODE="${CLUSTER_NAME}-control-plane"
+
+log() { echo "[prune] $*"; }
+
+registry_size() {
+  docker exec "$REGISTRY_NAME" du -sh /var/lib/registry 2>/dev/null | cut -f1 || echo "?"
+}
+
+# --- registry ----------------------------------------------------------------
+if [[ "$(docker inspect -f '{{.State.Running}}' "$REGISTRY_NAME" 2>/dev/null || true)" == "true" ]]; then
+  # Only images the host can put back. Anything else would be destroyed with no
+  # way to restore it, so leave the registry untouched instead.
+  restorable=()
+  missing=()
+  for target in server gateway client; do
+    image="${REGISTRY}/open-rl-${target}:${IMAGE_TAG}"
+    if docker image inspect "$image" >/dev/null 2>&1; then
+      restorable+=("$image")
+    else
+      missing+=("$image")
+    fi
+  done
+
+  if [[ ${#missing[@]} -gt 0 ]]; then
+    log "Not rebuilding the registry: ${missing[*]} not present locally to re-push."
+    log "Build them first (./dev/kind/load-images.sh) or accept the stale blobs."
+  else
+    before="$(registry_size)"
+    log "Rebuilding the registry (was $before)..."
+    # -v matters: registry:2 declares VOLUME /var/lib/registry, so the data sits
+    # in an anonymous volume. Without it the old volume is orphaned with the
+    # storage still allocated and the prune costs disk instead of reclaiming it.
+    docker rm -f -v "$REGISTRY_NAME" >/dev/null
+    "$SCRIPT_DIR/registry.sh" >/dev/null
+    for image in "${restorable[@]}"; do
+      log "Re-pushing $image..."
+      docker push "$image" >/dev/null
+    done
+    log "Registry now $(registry_size) (was $before)."
+  fi
+else
+  log "No $REGISTRY_NAME container running; skipping registry."
+fi
+
+# --- node images -------------------------------------------------------------
+# Only untagged entries. `crictl rmi --prune` would also take images no pod
+# happens to reference right now -- the client image between e2e runs, for
+# instance -- and buy a multi-GB re-pull on the next one.
+if docker inspect "$NODE" >/dev/null 2>&1; then
+  untagged="$(docker exec "$NODE" crictl images -o json 2>/dev/null \
+    | python3 -c 'import json,sys; print(" ".join(i["id"] for i in json.load(sys.stdin)["images"] if not i.get("repoTags")))' 2>/dev/null || true)"
+  if [[ -n "${untagged// /}" ]]; then
+    log "Removing $(wc -w <<<"$untagged") untagged image(s) from the node..."
+    # shellcheck disable=SC2086
+    docker exec "$NODE" crictl rmi $untagged >/dev/null 2>&1 || log "some node images were still in use; left them."
+  else
+    log "No untagged images on the node."
+  fi
+else
+  log "No $NODE container; skipping node images."
+fi
+
+# --- host ---------------------------------------------------------------------
+log "Removing dangling images on the host..."
+docker image prune -f >/dev/null
+
+if [[ -n "${PRUNE_BUILD_CACHE:-}" ]]; then
+  log "Dropping the BuildKit cache -- the next build re-runs uv sync."
+  docker builder prune -af >/dev/null
+fi
+
+log "Done. Host disk:"
+df -h / | tail -1

--- a/dev/kind/registry.sh
+++ b/dev/kind/registry.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# Start the cluster-local image registry and attach it to the kind network.
+#
+# Idempotent: safe to re-run, and create-cluster.sh calls it. Split into its own
+# script because the registry outlives the cluster -- deleting and recreating
+# kind is the fastest way back to a clean claim state, and it would be a waste
+# to re-push 36GB of CUDA image every time it happens.
+set -euo pipefail
+
+REGISTRY_NAME="${KIND_REGISTRY_NAME:-kind-registry}"
+REGISTRY_PORT="${KIND_REGISTRY_PORT:-5001}"
+KIND_NETWORK="${KIND_NETWORK:-kind}"
+
+log() { echo "[registry] $*"; }
+
+if [[ "$(docker inspect -f '{{.State.Running}}' "$REGISTRY_NAME" 2>/dev/null || true)" != "true" ]]; then
+  log "Starting $REGISTRY_NAME on 127.0.0.1:${REGISTRY_PORT}..."
+  # Bound to loopback: this holds unreviewed dev builds and the VM has a public
+  # interface. Nothing outside the host needs to reach it -- the node container
+  # reaches it over the kind docker network, not through this published port.
+  docker run -d --restart=always \
+    -p "127.0.0.1:${REGISTRY_PORT}:5000" \
+    --name "$REGISTRY_NAME" \
+    registry:2 >/dev/null
+else
+  log "$REGISTRY_NAME already running."
+fi
+
+# The network only exists once kind has created a cluster. Connecting is what
+# lets the node resolve the mirror endpoint by container name.
+if docker network inspect "$KIND_NETWORK" >/dev/null 2>&1; then
+  if ! docker network inspect "$KIND_NETWORK" -f '{{range .Containers}}{{.Name}} {{end}}' | grep -qw "$REGISTRY_NAME"; then
+    log "Connecting $REGISTRY_NAME to the '$KIND_NETWORK' network..."
+    docker network connect "$KIND_NETWORK" "$REGISTRY_NAME"
+  fi
+else
+  log "Network '$KIND_NETWORK' does not exist yet; it is created with the cluster."
+fi
+
+log "Ready at localhost:${REGISTRY_PORT}"

--- a/examples/tiny/tiny_rl.py
+++ b/examples/tiny/tiny_rl.py
@@ -16,6 +16,7 @@ from typing import Any, cast
 
 import chz
 import tinker
+from common.tinker_utils import patch_tinker_default_headers
 from tinker import types
 
 BASE_URL = "http://127.0.0.1:9003"
@@ -158,4 +159,8 @@ def main(config: Config) -> None:
 
 
 if __name__ == "__main__":
+  # Turns OPEN_RL_FINE_TUNING_TYPE into the header the gateway reads. Without
+  # it a "fft" scenario silently trains a LoRA adapter: the harness sets the
+  # env, but nothing puts it on the wire.
+  patch_tinker_default_headers()
   chz.nested_entrypoint(main, allow_hyphens=True)

--- a/examples/tiny/tiny_sft.py
+++ b/examples/tiny/tiny_sft.py
@@ -15,6 +15,7 @@ from typing import Any, cast
 
 import chz
 import tinker
+from common.tinker_utils import patch_tinker_default_headers
 from tinker import types
 
 BASE_URL = "http://127.0.0.1:9003"
@@ -135,4 +136,8 @@ def main(config: Config) -> None:
 
 
 if __name__ == "__main__":
+  # Turns OPEN_RL_FINE_TUNING_TYPE into the header the gateway reads. Without
+  # it a "fft" scenario silently trains a LoRA adapter: the harness sets the
+  # env, but nothing puts it on the wire.
+  patch_tinker_default_headers()
   chz.nested_entrypoint(main, allow_hyphens=True)

--- a/k8s/deploy/kind-dra/kustomization.yaml
+++ b/k8s/deploy/kind-dra/kustomization.yaml
@@ -1,0 +1,115 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# kind variant of the FFT/DRA deployment, for running the workload scheduler
+# against real GPUs on a single Linux GPU VM. See dev/kind/README.md.
+#
+# Differences from the GKE deployment:
+#   - local-path PVC instead of an RWX Filestore class
+#   - DCGM/PodMonitoring dropped (GKE-release image, gke-accelerator node
+#     selector, and a Google Managed Prometheus CRD that does not exist here)
+#   - images point at locally built tags in the cluster-local registry
+#
+# Images are set with explicit patches rather than an `images:` transformer.
+# The base kustomization runs its own transformer first, retagging everything to
+# gcr.io, so an `images:` entry here matching ghcr.io/gke-labs/... would silently
+# match nothing and deploy the wrong images. Patching the two containers by name
+# does not care what the base retagged them to.
+#
+# The pod templates' nodeSelectors are left alone: dev/kind/kind-cluster.yaml
+# labels the single node as both a trainer and a sampler host, so the GKE
+# manifests apply unmodified.
+resources:
+  - ../distributed-fft-timeslice
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+configMapGenerator:
+  - name: open-rl-config
+    behavior: merge
+    literals:
+      # No Cloud Trace exporter on a local cluster.
+      - ENABLE_GCP_TRACE="0"
+
+patches:
+  - path: pvc-local.yaml
+
+  - target:
+      kind: DaemonSet
+      name: nvidia-dcgm-exporter
+    patch: |
+      $patch: delete
+      apiVersion: apps/v1
+      kind: DaemonSet
+      metadata:
+        name: nvidia-dcgm-exporter
+  - target:
+      kind: ConfigMap
+      name: dcgm-exporter-metrics
+    patch: |
+      $patch: delete
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: dcgm-exporter-metrics
+  - target:
+      kind: PodMonitoring
+      name: nvidia-dcgm-exporter-scraper
+    patch: |
+      $patch: delete
+      apiVersion: monitoring.googleapis.com/v1
+      kind: PodMonitoring
+      metadata:
+        name: nvidia-dcgm-exporter-scraper
+
+  # Must match what dev/kind/load-images.sh builds and pushes.
+  #
+  # imagePullPolicy: Always throughout. The tag is mutable -- every iteration
+  # republishes :kind-dev -- so the base's IfNotPresent would leave the kubelet
+  # on the build it already cached and silently test the previous code. The
+  # registry is one docker network away, so re-pulling costs nothing.
+  - target:
+      kind: DaemonSet
+      name: open-rl-accel-timeslicer
+    patch: |
+      apiVersion: apps/v1
+      kind: DaemonSet
+      metadata:
+        name: open-rl-accel-timeslicer
+      spec:
+        template:
+          spec:
+            containers:
+              - name: accel-timeslicer
+                image: localhost:5001/open-rl-server:kind-dev
+                imagePullPolicy: Always
+
+  - target:
+      kind: Deployment
+      name: open-rl-gateway
+    patch: |
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: open-rl-gateway
+      spec:
+        template:
+          spec:
+            containers:
+              - name: gateway
+                image: localhost:5001/open-rl-gateway:kind-dev
+                imagePullPolicy: Always
+                env:
+                  # The worker and sampler pod templates live inside ConfigMaps
+                  # as YAML strings, out of reach of any image transformer. The
+                  # gateway overrides that image at render time from this var
+                  # (k8s_worker_manager.py:506), so this is what actually decides
+                  # the image every launched worker runs.
+                  - name: OPEN_RL_WORKER_IMAGE
+                    value: localhost:5001/open-rl-server:kind-dev
+                  # Same reason as the containers patched above, but the worker
+                  # templates are ConfigMap strings a patch cannot reach, so the
+                  # gateway stamps this at render time.
+                  - name: OPEN_RL_WORKER_IMAGE_PULL_POLICY
+                    value: Always

--- a/k8s/deploy/kind-dra/pvc-local.yaml
+++ b/k8s/deploy/kind-dra/pvc-local.yaml
@@ -1,0 +1,16 @@
+# kind ships the rancher local-path provisioner as the default StorageClass.
+# It is node-local and RWO-only, which is fine here because the cluster has a
+# single node -- every trainer, sampler, and gateway pod lands on it and shares
+# the same host directory. The GKE variant uses an RWX Filestore class because
+# there the pods really are spread across nodes.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: open-rl-shared-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: standard
+  resources:
+    requests:
+      storage: 100Gi

--- a/k8s/eval/e2e-client-job.yaml
+++ b/k8s/eval/e2e-client-job.yaml
@@ -26,7 +26,7 @@ spec:
       containers:
       - name: e2e-client
         image: E2E-IMAGE
-        imagePullPolicy: Always
+        imagePullPolicy: E2E-IMAGE-PULL-POLICY
         args:
         - "scenario=E2E-SCENARIO"
         - "uv_extra=cpu"

--- a/scripts/run_cluster_e2e.py
+++ b/scripts/run_cluster_e2e.py
@@ -29,9 +29,16 @@ def render_manifest(
   extra_args_str: str,
   image: str,
   weight_sync_cfg: dict[str, Any] | None = None,
+  image_pull_policy: str = "Always",
 ) -> str:
   manifest = MANIFEST.read_text(encoding="utf-8")
-  for placeholder, value in [("E2E-IMAGE", image), ("E2E-SCENARIO", scenario)]:
+  # E2E-IMAGE-PULL-POLICY before E2E-IMAGE: the latter is a prefix of the former,
+  # so substituting it first would leave a mangled "<image>-PULL-POLICY" behind.
+  for placeholder, value in [
+    ("E2E-IMAGE-PULL-POLICY", image_pull_policy),
+    ("E2E-IMAGE", image),
+    ("E2E-SCENARIO", scenario),
+  ]:
     if placeholder not in manifest:
       raise RuntimeError(f"{MANIFEST} no longer contains the {placeholder} placeholder")
     manifest = manifest.replace(placeholder, value)
@@ -85,6 +92,12 @@ def main() -> None:
     default="",
     help="Delta apply method override (patch_in_place | full_replace).",
   )
+  parser.add_argument(
+    "--image-pull-policy",
+    default="Always",
+    choices=["Always", "IfNotPresent", "Never"],
+    help="imagePullPolicy for the client container. Use IfNotPresent for an image side-loaded into kind, which no registry can serve.",
+  )
   parser.add_argument("--no-follow", action="store_true", help="Launch the job but do not follow its logs.")
   parser.add_argument("--print-only", action="store_true", help="Print the kubectl commands and manifest; run nothing.")
   args = parser.parse_args()
@@ -103,6 +116,7 @@ def main() -> None:
     args.args,
     args.image,
     weight_sync_cfg=weight_sync_cfg if weight_sync_cfg else None,
+    image_pull_policy=args.image_pull_policy,
   )
   commands = [
     kubectl + ["delete", "job", JOB, "--ignore-not-found"],

--- a/src/server/k8s_worker_manager.py
+++ b/src/server/k8s_worker_manager.py
@@ -424,9 +424,7 @@ class KubernetesWorkerManager:
     self._inject_container_resources(pod, memory_tier)
 
     container = pod["spec"]["containers"][0]
-    worker_image = os.getenv("OPEN_RL_WORKER_IMAGE")
-    if worker_image:
-      container["image"] = worker_image
+    _apply_worker_image_overrides(container)
 
     if role == "sampler":
       container["command"] = ["uv", "run", "python", "-u", "-m", "server.lora_sampler"]
@@ -501,9 +499,7 @@ class KubernetesWorkerManager:
     self._inject_container_resources(pod, memory_tier)
 
     container = pod["spec"]["containers"][0]
-    worker_image = os.getenv("OPEN_RL_WORKER_IMAGE")
-    if worker_image:
-      container["image"] = worker_image
+    _apply_worker_image_overrides(container)
 
     if role == "sampler":
       container["command"] = ["uv", "run", "python", "-u", "-m", "server.vllm_sampler"]
@@ -549,6 +545,23 @@ class KubernetesWorkerManager:
       if time.monotonic() > deadline:
         raise RuntimeError(f"pod {pod_name} did not terminate within {timeout:.0f}s; cannot relaunch worker")
       time.sleep(0.5)
+
+
+def _apply_worker_image_overrides(container: dict[str, Any]) -> None:
+  """Point a rendered worker at the operator's image, and say how to fetch it.
+
+  The pod templates live inside ConfigMaps as YAML strings, out of reach of any
+  kustomize image transformer, so this is what actually decides the image every
+  launched worker runs. The pull policy has to come along with it: a dev loop
+  that republishes the same mutable tag needs ``Always``, or the kubelet keeps
+  the build it already cached and silently runs the previous code.
+  """
+  worker_image = os.getenv("OPEN_RL_WORKER_IMAGE")
+  if worker_image:
+    container["image"] = worker_image
+  pull_policy = os.getenv("OPEN_RL_WORKER_IMAGE_PULL_POLICY")
+  if pull_policy:
+    container["imagePullPolicy"] = pull_policy
 
 
 def set_env(container: dict[str, Any], name: str, value: str) -> None:


### PR DESCRIPTION
Adds a kind-based environment for exercising the DRA workload scheduler against
real GPUs on a single Linux GPU VM, so claim allocation and worker scheduling
can be tested without a GKE cluster. Cluster teardown and rebuild takes about a
minute, which makes claim behaviour cheap to test from a clean slate.

`dev/kind/` holds the scripts and `k8s/deploy/kind-dra/` overlays the GKE
manifests with local image names, an RWO local-path PVC, and the GKE-only
pieces removed.

## Using it

Everything talks to the local docker daemon and kube context, so it runs on the
GPU VM. Get your tree there the way the rest of the repo does:

```bash
make push-vm REMOTE_HOST=<host>                  # from the workstation

Then, on the VM (or ssh <host> 'cd ~/open-rl && make ...' without logging in):

┌───────────────────────────────┬─────────────────────────────────────────────────────────────────┐
│                               │                                                                 │
├───────────────────────────────┼─────────────────────────────────────────────────────────────────┤
│ make kind-host-setup          │ one-time: docker, nvidia-container-toolkit, kind, kubectl, helm │
├───────────────────────────────┼─────────────────────────────────────────────────────────────────┤
│ make kind-create              │ cluster, DRA driver, registry                                   │
├───────────────────────────────┼─────────────────────────────────────────────────────────────────┤
│ make kind-deploy              │ build, publish, apply                                           │
├───────────────────────────────┼─────────────────────────────────────────────────────────────────┤
│ make kind-gateway             │ rebuild and roll just the slim gateway — the fast inner loop    │
├───────────────────────────────┼─────────────────────────────────────────────────────────────────┤
│ make kind-client              │ rebuild the e2e client image                                    │
├───────────────────────────────┼─────────────────────────────────────────────────────────────────┤
│ make kind-e2e                 │ the cluster-e2e harness against the kind context                │
├───────────────────────────────┼─────────────────────────────────────────────────────────────────┤
│ make kind-status / kind-logs  │ inspect                                                         │
├───────────────────────────────┼─────────────────────────────────────────────────────────────────┤
│ make kind-prune / kind-delete │ reclaim disk / tear down                                        │
└───────────────────────────────┴─────────────────────────────────────────────────────────────────┘

```

## Notes for reviewers

Three parts of the setup are non-obvious and are documented in
dev/kind/README.md:

- A GPU is injected twice — host into the kind node container, then node into
  the pod. host-setup.sh makes nvidia the default docker runtime because
  kind offers no way to pass --runtime.
- The node is labelled nvidia.com/gpu.present=true by hand. The DRA
  kubelet-plugin DaemonSet has a required nodeAffinity on a Node Feature
  Discovery label, and NFD is absent here. Without the label the DaemonSet sits
  at desired: 0 while DeviceClasses still register, so the cluster looks
  healthy and every claim silently stays Pending.
- The node image must be 1.34+, where resource.k8s.io/v1 reached GA. On 1.33
  the API server serves v1beta1 and every claim call 404s.

Images go to a cluster-local registry:2 on the kind docker network rather than
kind load docker-image, which has no layer-level dedup and re-ships the whole
multi-GB server image for a one-line change. The node reaches it through a
containerd mirror, so a single reference resolves from both host and node. That
mirror is applied at cluster creation — an existing cluster must be recreated to
pick it up. :kind-dev is mutable and republished every iteration, hence
imagePullPolicy: Always throughout the overlay.

kind-prune rebuilds the registry and re-pushes rather than running registry garbage-collect: distribution 2.8 does not traverse OCI image indexes, and
collecting deletes the child manifests under a tagged index, leaving a registry
that answers 200 on the tag and 404 on every layer beneath it. Measured on one
box, pruning reclaimed 12.4 GB (24.3 GB → 11.9 GB) in under a minute. The
BuildKit cache is deliberately left alone.

Two changes fall outside dev/kind/ and k8s/deploy/kind-dra/:

- src/server/k8s_worker_manager.py — the gateway now stamps worker
  imagePullPolicy alongside the image it already overrode at render time,
  because worker pod templates live inside ConfigMaps as YAML strings that no
  kustomize patch can reach.
- scripts/run_cluster_e2e.py and k8s/eval/e2e-client-job.yaml — the
  hardcoded imagePullPolicy becomes a placeholder driven by
  --image-pull-policy, defaulting to Always so GKE behaviour is unchanged.

## Testing

Unit tests and lint pass. Exercised on a two-L4 VM: make kind-deploy from a
clean rebuild, then make kind-e2e E2E_SCENARIO=tiny-rl — trainer and sampler
launched against real DRA claims, two steps trained with loss dropping and
mean_reward 0.62 → 0.75, checkpoint written to the shared PVC, workers
cleaned up. kind-status and kind-prune exercised the same way.

LoRA — tiny-rl, clean pass on the branch as-is
[tiny-rl] step=01/2 loss=0.026074 mean_reward=0.62 datums=8
[tiny-rl] step=02/2 loss=-0.026456 mean_reward=0.75 datums=8
final_state_path=/mnt/shared/open-rl/checkpoints/d3038c1b-.../weights/tiny-rl-final
Exit 0, claims workload-type: lora / 24gb, workers cleaned up.

FFT — fft-gsm8k-rl, pass
env/all/reward/total   0.125
Saved checkpoints: {'state_path': '/mnt/shared/open-rl/checkpoints/06f113e8-.../weights/final'}
Training completed successfully          EXIT=0
Claims came out workload-type: full / 24gb — genuinely the full fine-tuning path, trainer and sampler both scheduled against real DRA claims.

Everything ran the new way: make push-vm REMOTE_HOST=l4dev, then ssh l4dev 'cd ~/open-rl && make kind-deploy | kind-gateway | kind-e2e | kind-status | kind-prune'. kind-deploy did a full server-image rebuild from this tree first, so the images under test came from the branch.

Two caveats you need for the review, both of which cost me a false start:

1. tiny-fft-rl does not test FFT. I ran it first and it passed — but the claims came back workload-type: lora. Both tiny examples call create_lora_training_client (examples/tiny/tiny_rl.py:88), and run_tiny only changes the learning rate when the scenario name contains "fft". So the whole tiny-fft* family is LoRA underneath. That's pre-existing and unrelated to this PR, but the names are actively misleading. That's why the real FFT coverage above uses fft-gsm8k-rl.
2. The FFT run required a patch that isn't in this PR. On this branch alone, any full fine-tune stops at No cluster ResourceSlice found matching VRAM memory tier '80gb', because the size-aware tiering fix lives on the merge-prep branch. I applied it to the box's working copy, rebuilt only the gateway, ran the test, then reverted. So the FFT result validates the kind setup, not this branch's ability to run FFT unaided.



## Known gaps versus GKE

Tabulated in dev/kind/README.md. The significant one is the single node —
cross-node scheduling and anything depending on workers landing apart cannot be
reproduced. Hardware is 24gb-tier only; the 80gb branch of tier selection is
covered by unit tests rather than here.