### PR TITLE
Fix DRA claim scheduling, size FFT by model, cut worker startup cost

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
 .PHONY: server vllm test lint fmt help render release-bundle push-vm pull-vm cluster-eval \
+	cloud-build-gateway cloud-build-server cloud-build-client \
+	cloud-deploy-gateway cloud-deploy-server \
+	cloud-rollout-gateway cloud-rollout-server cloud-rollout \
 	kind-host-setup kind-create kind-gateway kind-deploy \
 	kind-client kind-e2e kind-status kind-logs kind-prune kind-delete
 
@@ -139,6 +142,52 @@ push-images:
 	kubectl set image deployment/open-rl-gateway gateway=gcr.io/$(GCP_PROJECT)/open-rl-gateway:$(IMAGE_TAG) 2>/dev/null || true
 	kubectl set image daemonset/open-rl-accel-timeslicer accel-timeslicer=gcr.io/$(GCP_PROJECT)/open-rl-server:$(IMAGE_TAG) 2>/dev/null || true
 	kubectl set env deployment/open-rl-gateway OPEN_RL_WORKER_IMAGE=gcr.io/$(GCP_PROJECT)/open-rl-server:$(IMAGE_TAG) 2>/dev/null || true
+
+# --- Cloud Build ------------------------------------------------------------
+# Builds in GCP instead of locally: `gcloud builds submit` uploads only the
+# tracked source (~7 MB after .dockerignore) and the CUDA base layers are pulled
+# inside Google's network. Useful when the workstation is far from the cluster
+# or has no Docker daemon.
+#
+#   make cloud-rollout-gateway   # slim gateway image, ~2 min -- covers gateway.py,
+#                                #   k8s_worker_manager.py, store.py
+#   make cloud-rollout-server    # CUDA worker image, ~20-40 min
+#   make cloud-rollout           # both, plus the client image
+#
+# Tag for cloud-built images. A dirty tree gets a unique -dev<stamp> suffix so
+# uncommitted work never reuses the committed sha's tag, and so the kubelet is
+# forced to pull rather than reuse a cached layer under the same name.
+CLOUD_IMAGE_TAG ?= $(shell test -z "$$(git status --porcelain 2>/dev/null)" && echo "$(IMAGE_TAG)" || echo "$(IMAGE_TAG)-dev$$(date +%m%d%H%M%S)")
+# Snapshot it. Left recursive, the shell above would re-run -- and re-stamp the
+# time -- on every reference within a single make invocation.
+CLOUD_IMAGE_TAG := $(CLOUD_IMAGE_TAG)
+
+CLOUD_BUILD = gcloud builds submit --project=$(GCP_PROJECT) --config=cloudbuild.yaml
+
+cloud-build-gateway:
+	$(CLOUD_BUILD) --substitutions=_IMAGE=gcr.io/$(GCP_PROJECT)/open-rl-gateway,_DOCKERFILE=src/server/Dockerfile.gateway,_TAG=$(CLOUD_IMAGE_TAG) .
+
+cloud-build-server:
+	$(CLOUD_BUILD) --substitutions=_IMAGE=gcr.io/$(GCP_PROJECT)/open-rl-server,_DOCKERFILE=src/server/Dockerfile,_TAG=$(CLOUD_IMAGE_TAG) .
+
+cloud-build-client:
+	$(CLOUD_BUILD) --substitutions=_IMAGE=gcr.io/$(GCP_PROJECT)/open-rl-client,_DOCKERFILE=src/server/Dockerfile.client,_TAG=$(CLOUD_IMAGE_TAG) .
+
+# Point the running workloads at the freshly built tag. Split from the build
+# steps so a tag built earlier can be re-deployed with
+# `make cloud-deploy-gateway CLOUD_IMAGE_TAG=<tag>`.
+cloud-deploy-gateway:
+	kubectl set image deployment/open-rl-gateway gateway=gcr.io/$(GCP_PROJECT)/open-rl-gateway:$(CLOUD_IMAGE_TAG)
+	@echo "gateway -> gcr.io/$(GCP_PROJECT)/open-rl-gateway:$(CLOUD_IMAGE_TAG)"
+
+cloud-deploy-server:
+	kubectl set image daemonset/open-rl-accel-timeslicer accel-timeslicer=gcr.io/$(GCP_PROJECT)/open-rl-server:$(CLOUD_IMAGE_TAG) 2>/dev/null || true
+	kubectl set env deployment/open-rl-gateway OPEN_RL_WORKER_IMAGE=gcr.io/$(GCP_PROJECT)/open-rl-server:$(CLOUD_IMAGE_TAG)
+	@echo "workers -> gcr.io/$(GCP_PROJECT)/open-rl-server:$(CLOUD_IMAGE_TAG)"
+
+cloud-rollout-gateway: cloud-build-gateway cloud-deploy-gateway
+cloud-rollout-server: cloud-build-server cloud-deploy-server
+cloud-rollout: cloud-build-gateway cloud-build-server cloud-build-client cloud-deploy-gateway cloud-deploy-server
 
 # --- kind on a GPU VM -------------------------------------------------------
 # These run against the local docker daemon and kube context, so run them on the

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,48 @@
+# Generic Cloud Build config: builds one image from one Dockerfile in this repo.
+#
+# The build runs in GCP, so the multi-GB CUDA base layers for the server image
+# never cross the developer's uplink -- only the ~7 MB of tracked source does.
+# Invoke it once per image (see the cloud-build-* targets in the Makefile):
+#
+#   gcloud builds submit --config=cloudbuild.yaml \
+#     --substitutions=_IMAGE=gcr.io/PROJECT/open-rl-gateway,_DOCKERFILE=src/server/Dockerfile.gateway,_TAG=abc1234 .
+#
+# Files sent as build context are filtered by .dockerignore, which already drops
+# .git, .venv, model caches, and runs/.
+
+substitutions:
+  _IMAGE: '' # Fully-qualified repository, e.g. gcr.io/my-project/open-rl-gateway
+  _DOCKERFILE: '' # Path to the Dockerfile, relative to the repo root
+  _TAG: '' # Immutable tag for this build
+
+options:
+  # The CUDA server image needs both the CPU and the disk; the slim gateway
+  # image finishes in a couple of minutes either way.
+  machineType: E2_HIGHCPU_8
+  diskSizeGb: 200
+  # Default logging (GCS + Cloud Logging) so `gcloud builds submit` can stream
+  # output live. That matters for the CUDA image, which runs for tens of
+  # minutes. Requires the legacy Cloud Build service account; a project using a
+  # user-specified build SA has to set CLOUD_LOGGING_ONLY here instead.
+
+# Long enough for the nvidia/cuda:12.9.0-devel base plus a full uv sync.
+timeout: 3600s
+
+steps:
+  - name: gcr.io/cloud-builders/docker
+    env: ['DOCKER_BUILDKIT=1']
+    args:
+      - build
+      - --file=${_DOCKERFILE}
+      - --tag=${_IMAGE}:${_TAG}
+      - --tag=${_IMAGE}:latest
+      # Warm-start from the previous build. BUILDKIT_INLINE_CACHE embeds the
+      # cache manifest in the pushed image so :latest is usable as --cache-from
+      # without a separate cache repository.
+      - --cache-from=${_IMAGE}:latest
+      - --build-arg=BUILDKIT_INLINE_CACHE=1
+      - .
+
+images:
+  - '${_IMAGE}:${_TAG}'
+  - '${_IMAGE}:latest'

--- a/dev/kind/kind-cluster.yaml
+++ b/dev/kind/kind-cluster.yaml
@@ -34,10 +34,10 @@ nodes:
     kubeadmConfigPatches:
       # node-labels covers two separate needs:
       #
-      # group.timeslice.io/{trainers,samplers} -- the pod templates in
-      #   k8s/deploy/distributed-fft-timeslice/ select on these and the
-      #   accel-timeslicer DaemonSet requires at least one, so setting both here
-      #   lets the GKE manifests apply unpatched.
+      # group.timeslice.io/{trainers,samplers} -- the accel-timeslicer DaemonSet
+      #   requires at least one of them to exist, so setting both here lets the
+      #   GKE manifests apply unpatched. Worker Pods no longer select on them:
+      #   their ResourceClaim decides placement.
       #
       # nvidia.com/gpu.present -- the DRA driver's kubelet-plugin DaemonSet has a
       #   required nodeAffinity matching one of several Node Feature Discovery

--- a/docs/designs/011-dynamic-managed-dra-claim-controller.md
+++ b/docs/designs/011-dynamic-managed-dra-claim-controller.md
@@ -218,11 +218,18 @@ Result: The 8x H100 node is partitioned into two equal 4-GPU sets with zero devi
 
 ### 4.8 Automated Garbage Collection & Reconciliation
 
-To prevent claim leaks, `reconcile_managed_claims()` runs periodically inside the control plane:
+To prevent claim leaks, `reconcile_managed_claims()` runs periodically inside the control plane, driven by a background task started in the Gateway lifespan (`OPEN_RL_CLAIM_RECONCILE_INTERVAL_SECONDS`, default `300`; set to `0` to disable):
 
-- Queries all claims labeled `open-rl.io/managed-by=open-rl-control-plane`.
+- Queries all claims labeled `open-rl.io/managed-by=open-rl-gateway`.
 - Cross-references active worker pods (`app in (open-rl-trainer-worker, open-rl-sampler-worker)`).
 - If a managed claim has **0 active worker pods referencing it**, the control plane deletes the `ResourceClaim` custom object, releasing physical GPU resources back to the cloud pool.
+
+A claim is created moments *before* its worker Pod, so an in-flight launch is indistinguishable from an abandoned claim. Two guards keep reconciliation from deleting a claim out from under a starting worker:
+
+- The reconcile pass holds the Workload Scheduler's launch lock, excluding launches from the same Gateway process.
+- Claims younger than `OPEN_RL_CLAIM_RECONCILE_MIN_AGE_SECONDS` (default `120`) are skipped, covering in-flight launches on *other* Gateway replicas, which this process cannot observe.
+
+Independently, a launch that fails after provisioning a claim releases that claim immediately rather than waiting for the next reconcile pass.
 
 ---
 

--- a/k8s/deploy/distributed-fft-timeslice/05-worker-pod-template.yaml
+++ b/k8s/deploy/distributed-fft-timeslice/05-worker-pod-template.yaml
@@ -62,8 +62,13 @@ data:
       - name: shared-storage
         persistentVolumeClaim:
           claimName: open-rl-shared-pvc
-      nodeSelector:
-        group.timeslice.io/trainers: "true"
+      # No nodeSelector: the ResourceClaim decides placement. Its CEL selector
+      # constrains the scheduler to nodes publishing a matching device, so a
+      # second constraint here can only disagree with it -- pinning samplers to
+      # a pool whose GPUs the claim rejects leaves the Pod unschedulable, which
+      # is what a 24gb claim did once small models stopped demanding an H100.
+      # The accel-timeslicer DaemonSet is unscoped and runs on every GPU node,
+      # so a worker finds one wherever its claim lands.
       tolerations:
       - key: "nvidia.com/gpu"
         operator: "Exists"

--- a/k8s/deploy/distributed-fft-timeslice/09-sampler-pod-template.yaml
+++ b/k8s/deploy/distributed-fft-timeslice/09-sampler-pod-template.yaml
@@ -66,8 +66,13 @@ data:
       - name: shared-storage
         persistentVolumeClaim:
           claimName: open-rl-shared-pvc
-      nodeSelector:
-        group.timeslice.io/samplers: "true"
+      # No nodeSelector: the ResourceClaim decides placement. Its CEL selector
+      # constrains the scheduler to nodes publishing a matching device, so a
+      # second constraint here can only disagree with it -- pinning samplers to
+      # a pool whose GPUs the claim rejects leaves the Pod unschedulable, which
+      # is what a 24gb claim did once small models stopped demanding an H100.
+      # The accel-timeslicer DaemonSet is unscoped and runs on every GPU node,
+      # so a worker finds one wherever its claim lands.
       tolerations:
       - key: "nvidia.com/gpu"
         operator: "Exists"

--- a/k8s/deploy/distributed-fft-timeslice/09-sampler-pod-template.yaml
+++ b/k8s/deploy/distributed-fft-timeslice/09-sampler-pod-template.yaml
@@ -39,6 +39,12 @@ data:
           value: "/mnt/shared/open-rl"
         - name: HF_HOME
           value: "/mnt/shared/open-rl/huggingface"
+        # torch.compile/inductor artifacts, on the shared volume for the same
+        # reason HF_HOME is: the default lands in the container filesystem and
+        # dies with the pod, so every sampler launch recompiles the graph from
+        # scratch -- measured at 15.2s for Qwen3-0.6B on an L4.
+        - name: VLLM_CACHE_ROOT
+          value: "/mnt/shared/open-rl/vllm-cache"
         - name: OPEN_RL_ACCEL_TIMESLICER_HOST
           valueFrom:
             fieldRef:

--- a/src/server/Dockerfile
+++ b/src/server/Dockerfile
@@ -36,8 +36,20 @@ WORKDIR /app
 COPY pyproject.toml .
 COPY uv.lock .
 
-# Configure uv for Docker and caching
-ENV UV_LINK_MODE=copy
+# Configure uv for Docker and caching.
+#
+# UV_COMPILE_BYTECODE: without it the venv ships 24k .py files and no .pyc, so
+# every worker start recompiles the whole import graph and throws it away --
+# `import vllm` measured 12.9s cold against 5.6s with bytecode present, on every
+# trainer and sampler launch, for ~0.4GB of image. The gateway and client images
+# already set this.
+#
+# UV_NO_SYNC: the source is exposed through PYTHONPATH below rather than
+# installed, so the implicit sync `uv run` performs at container start only
+# rebuilds and reinstalls the project to no effect.
+ENV UV_LINK_MODE=copy \
+    UV_COMPILE_BYTECODE=1 \
+    UV_NO_SYNC=1
 
 # Install dependencies using uv with BuildKit cache (fast dependency extraction)
 # --frozen ensures it uses the uv.lock exactly

--- a/src/server/Dockerfile.gateway
+++ b/src/server/Dockerfile.gateway
@@ -21,8 +21,12 @@ COPY pyproject.toml .
 COPY uv.lock .
 
 # Configure uv for Docker and caching
+# UV_NO_SYNC: the source is exposed through PYTHONPATH below rather than
+# installed, so the implicit sync `uv run` performs at container start only
+# rebuilds and reinstalls the project to no effect.
 ENV UV_LINK_MODE=copy \
-    UV_COMPILE_BYTECODE=1
+    UV_COMPILE_BYTECODE=1 \
+    UV_NO_SYNC=1
 
 # Install the CPU gateway dependencies plus the Kubernetes client used by the
 # cluster worker launcher. Keep the massive ML extras out of this image.

--- a/src/server/gateway.py
+++ b/src/server/gateway.py
@@ -294,12 +294,45 @@ def translate_future_result(result: dict) -> dict:
   return result
 
 
+async def run_claim_reconciler(manager: WorkerManager, interval: float) -> None:
+  """Periodically reclaim dynamic DRA claims left behind by finished workers.
+
+  Nothing else deletes them: the scheduler provisions a claim whenever no
+  eligible one is free, so without this loop every completed job strands a GPU
+  claim until an operator removes it by hand.
+  """
+  while True:
+    await asyncio.sleep(interval)
+    try:
+      deleted = await asyncio.to_thread(manager.reconcile_managed_claims)
+      if deleted:
+        print(f"[GATEWAY] Reclaimed {len(deleted)} unused DRA claim(s): {', '.join(deleted)}")
+    except asyncio.CancelledError:
+      raise
+    except Exception:
+      traceback.print_exc()
+
+
+def start_claim_reconciler(manager: WorkerManager | None) -> asyncio.Task | None:
+  """Start the reconcile loop when the worker manager provisions claims (Kubernetes mode only)."""
+  if manager is None or not hasattr(manager, "reconcile_managed_claims"):
+    return None
+  interval = float(os.getenv("OPEN_RL_CLAIM_RECONCILE_INTERVAL_SECONDS", "300"))
+  if interval <= 0:
+    print("[GATEWAY] DRA claim reconciliation disabled (OPEN_RL_CLAIM_RECONCILE_INTERVAL_SECONDS <= 0)")
+    return None
+  print(f"[GATEWAY] DRA claim reconciliation every {interval:.0f}s")
+  return asyncio.create_task(run_claim_reconciler(manager, interval))
+
+
 @asynccontextmanager
 async def lifespan(_: FastAPI):
   global worker_manager
   task = None
+  reconcile_task = None
   if is_fft_enabled() or os.getenv("REDIS_URL") or os.getenv("OPEN_RL_WORKER_MANAGER"):
     worker_manager = create_worker_manager()
+    reconcile_task = start_claim_reconciler(worker_manager)
   if is_single_process_mode():
     base_model = os.getenv("BASE_MODEL")
     print("\n" + "=" * 50)
@@ -322,6 +355,8 @@ async def lifespan(_: FastAPI):
   finally:
     if task is not None:
       task.cancel()
+    if reconcile_task is not None:
+      reconcile_task.cancel()
     if worker_manager is not None:
       worker_manager.shutdown_all()
       worker_manager = None

--- a/src/server/k8s_worker_manager.py
+++ b/src/server/k8s_worker_manager.py
@@ -13,9 +13,11 @@ dependencies are installed.
 """
 
 import copy
+import datetime
 import logging
 import os
 import re
+import threading
 import time
 import uuid
 from typing import Any
@@ -67,6 +69,14 @@ class KubernetesWorkerManager:
       core_api = client.CoreV1Api()
     self.core_api = core_api
 
+    # Claim resolution is a read-modify-write against the API server: discover
+    # eligible claims, inspect their usage, then create one if none fit. Two
+    # concurrent launches would both see "nothing eligible" and each provision a
+    # claim, so serialize the whole sequence. This guards a single gateway
+    # process; across replicas reconcile_managed_claims() is the backstop.
+    self._launch_lock = threading.RLock()
+    self._claims_created_this_launch: list[str] = []
+
     self._resource_slice_cache: dict[str, str] = {}
     self._resource_slice_cache_time: float = 0.0
     try:
@@ -91,18 +101,26 @@ class KubernetesWorkerManager:
     prefix = "open-rl-trainer-" if role == "trainer" else "open-rl-sampler-"
     pod_name = f"{prefix}{job_id}-1"
 
-    existing = self.read_pod(pod_name)
-    if existing is not None:
-      if existing.status.phase not in TERMINAL_POD_PHASES:
-        return
-      self.delete_pod_and_wait(pod_name)
+    with self._launch_lock:
+      existing = self.read_pod(pod_name)
+      if existing is not None:
+        if existing.status.phase not in TERMINAL_POD_PHASES:
+          return
+        self.delete_pod_and_wait(pod_name)
 
-    try:
-      pod_body = self.render_pod(pod_name, model_id, job_id, role=role)
-      self.core_api.create_namespaced_pod(namespace=self.namespace, body=pod_body)
-    except Exception as exc:
-      if getattr(exc, "status", None) != 409:
-        raise
+      self._claims_created_this_launch = []
+      try:
+        pod_body = self.render_pod(pod_name, model_id, job_id, role=role)
+        self.core_api.create_namespaced_pod(namespace=self.namespace, body=pod_body)
+      except Exception as exc:
+        # The pod never came up, so any claim provisioned while rendering it has
+        # no worker to reference it and reconciliation would be the only thing
+        # left to notice. Release it here instead of leaking a GPU claim.
+        self._release_claims_created_this_launch()
+        if getattr(exc, "status", None) != 409:
+          raise
+      finally:
+        self._claims_created_this_launch = []
 
   def shutdown(self, model_id: str) -> None:
     from server.worker_manager import get_model_target_info
@@ -158,14 +176,22 @@ class KubernetesWorkerManager:
       logger.debug("DRA label discovery failed for %s/%s (%s): %s", workload_type, role, memory_tier, exc)
       return []
 
-  def _get_claim_locks(self) -> dict[str, set[str]]:
-    locks: dict[str, set[str]] = {}
+  def _get_claim_usage(self) -> dict[str, dict[str, Any]]:
+    """Map each claim to its live usage: the set of base models bound to it and its worker count.
+
+    Both numbers come off Pod labels. They are not the same thing: two workers of
+    the same base model share one entry in ``models`` but count as two against
+    claim capacity, so packing decisions must use ``workers`` and LoRA mutual
+    exclusion must use ``models``.
+    """
+    usage: dict[str, dict[str, Any]] = {}
     try:
       pods = self.core_api.list_namespaced_pod(
         self.namespace,
         label_selector="app in (open-rl-trainer-worker, open-rl-sampler-worker)",
       )
-      items = pods.items if hasattr(pods, "items") else pods.get("items", [])
+      # dict.items is a method, so the isinstance check has to come first.
+      items = pods.get("items", []) if isinstance(pods, dict) else getattr(pods, "items", [])
       for pod in items:
         status_phase = ""
         metadata = {}
@@ -183,10 +209,12 @@ class KubernetesWorkerManager:
         claim_name = labels.get("open-rl.io/assigned-claim")
         bound_model = labels.get("open-rl.io/bound-base-model")
         if claim_name and bound_model:
-          locks.setdefault(claim_name, set()).add(bound_model)
+          entry = usage.setdefault(claim_name, {"models": set(), "workers": 0})
+          entry["models"].add(bound_model)
+          entry["workers"] += 1
     except Exception as exc:
-      logger.debug("Failed to inspect active Pod claim locks: %s", exc)
-    return locks
+      logger.debug("Failed to inspect active Pod claim usage: %s", exc)
+    return usage
 
   def _discover_cluster_gpu_products(self) -> dict[str, str]:
     """Scan cluster ResourceSlices and return a mapping of memory_tier -> productName (cached for 15 mins)."""
@@ -279,39 +307,92 @@ class KubernetesWorkerManager:
       body=claim_manifest,
     )
     logger.info("Created dynamic managed DRA claim %s for %s/%s (%s)", claim_name, workload_type, role, memory_tier)
+    self._claims_created_this_launch.append(claim_name)
     return claim_name
 
-  def reconcile_managed_claims(self) -> list[str]:
-    """Delete dynamic managed claims that have 0 active worker pods referencing them."""
-    deleted = []
+  def _delete_managed_claim(self, claim_name: str) -> None:
+    custom_api = client.CustomObjectsApi(self.core_api.api_client)
+    custom_api.delete_namespaced_custom_object(
+      group="resource.k8s.io",
+      version="v1",
+      namespace=self.namespace,
+      plural="resourceclaims",
+      name=claim_name,
+    )
+
+  def _release_claims_created_this_launch(self) -> None:
+    for claim_name in self._claims_created_this_launch:
+      try:
+        self._delete_managed_claim(claim_name)
+        logger.info("Released dynamic managed claim %s after failed worker launch", claim_name)
+      except Exception as exc:
+        logger.debug("Failed to release managed claim %s: %s", claim_name, exc)
+    self._claims_created_this_launch = []
+
+  @staticmethod
+  def _claim_age_seconds(metadata: dict[str, Any]) -> float:
+    """Age of a claim from its creationTimestamp; zero when the stamp is missing or unparseable.
+
+    Falling back to "brand new" keeps an unreadable timestamp from deleting
+    anything. The grace period exists to protect a claim another replica
+    provisioned moments ago, before its Pod exists to reference it; treating an
+    unknown age as old would invert that guard into deleting exactly those
+    claims. Skipping costs one more reconcile tick, so the claim is collected on
+    the next pass if it really is idle. The API server always sets the field, so
+    in practice this only affects fakes.
+    """
+    raw = metadata.get("creationTimestamp")
+    if not raw:
+      return 0.0
     try:
-      custom_api = client.CustomObjectsApi(self.core_api.api_client)
-      res = custom_api.list_namespaced_custom_object(
-        group="resource.k8s.io",
-        version="v1",
-        namespace=self.namespace,
-        plural="resourceclaims",
-        label_selector="open-rl.io/managed-by=open-rl-gateway",
-      )
-      items = res.get("items", []) if isinstance(res, dict) else getattr(res, "items", [])
-      active_locks = self._get_claim_locks()
-      for item in items:
-        claim_name = item.get("metadata", {}).get("name")
-        if claim_name and claim_name not in active_locks:
+      created = datetime.datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
+    except ValueError:
+      return 0.0
+    if created.tzinfo is None:
+      created = created.replace(tzinfo=datetime.UTC)
+    return (datetime.datetime.now(datetime.UTC) - created).total_seconds()
+
+  def reconcile_managed_claims(self, min_age_seconds: float | None = None) -> list[str]:
+    """Delete dynamic managed claims that have 0 active worker pods referencing them.
+
+    A claim is provisioned moments before its worker Pod, so "no Pod references
+    it" is also what an in-flight launch looks like. The launch lock closes that
+    window for this process; ``min_age_seconds`` closes it for the other gateway
+    replicas, whose in-flight launches this process cannot see.
+    """
+    if min_age_seconds is None:
+      min_age_seconds = float(os.getenv("OPEN_RL_CLAIM_RECONCILE_MIN_AGE_SECONDS", "120"))
+
+    deleted = []
+    with self._launch_lock:
+      try:
+        custom_api = client.CustomObjectsApi(self.core_api.api_client)
+        res = custom_api.list_namespaced_custom_object(
+          group="resource.k8s.io",
+          version="v1",
+          namespace=self.namespace,
+          plural="resourceclaims",
+          label_selector="open-rl.io/managed-by=open-rl-gateway",
+        )
+        items = res.get("items", []) if isinstance(res, dict) else getattr(res, "items", [])
+        active_usage = self._get_claim_usage()
+        for item in items:
+          metadata = item.get("metadata", {})
+          claim_name = metadata.get("name")
+          if not claim_name or claim_name in active_usage:
+            continue
+          age = self._claim_age_seconds(metadata)
+          if age < min_age_seconds:
+            logger.debug("Skipping managed claim %s: %.0fs old, below the %.0fs grace period", claim_name, age, min_age_seconds)
+            continue
           try:
-            custom_api.delete_namespaced_custom_object(
-              group="resource.k8s.io",
-              version="v1",
-              namespace=self.namespace,
-              plural="resourceclaims",
-              name=claim_name,
-            )
+            self._delete_managed_claim(claim_name)
             deleted.append(claim_name)
             logger.info("Reconciled and deleted unused dynamic managed claim %s", claim_name)
           except Exception as del_exc:
             logger.debug("Failed to delete managed claim %s: %s", claim_name, del_exc)
-    except Exception as exc:
-      logger.debug("Reconciliation of managed claims failed: %s", exc)
+      except Exception as exc:
+        logger.debug("Reconciliation of managed claims failed: %s", exc)
     return deleted
 
   def resolve_claim(
@@ -330,24 +411,28 @@ class KubernetesWorkerManager:
       memory_tier = estimate_memory_tier(base_model_name, fine_tuning_type=workload_type)
 
     claims = self._discover_eligible_claims(workload_type, role, memory_tier=memory_tier)
-    locks = self._get_claim_locks()
+    usage = self._get_claim_usage()
     clean_target = sanitize_job_id(target_id)
 
     max_workers_per_claim = int(os.getenv("OPEN_RL_MAX_WORKERS_PER_CLAIM", "2"))
 
+    def _models(c_name: str) -> set[str]:
+      return usage.get(c_name, {}).get("models", set())
+
+    def _workers(c_name: str) -> int:
+      return usage.get(c_name, {}).get("workers", 0)
+
     # Rule 1: Base-Model Affinity (reuse existing dynamic claim if under capacity and already running clean_target)
     for c_name in claims:
-      c_locks = locks.get(c_name, set())
-      if clean_target in c_locks and len(c_locks) < max_workers_per_claim:
+      if clean_target in _models(c_name) and _workers(c_name) < max_workers_per_claim:
         return c_name
 
     # Rule 2: Reuse eligible dynamic claim matching workload_type, role, and memory_tier if under capacity
     eligible = []
     for c_name in claims:
-      c_locks = locks.get(c_name, set())
-      if len(c_locks) >= max_workers_per_claim:
+      if _workers(c_name) >= max_workers_per_claim:
         continue
-      if workload_type == "lora" and c_locks and clean_target not in c_locks:
+      if workload_type == "lora" and _models(c_name) and clean_target not in _models(c_name):
         continue
       eligible.append(c_name)
 

--- a/src/server/store.py
+++ b/src/server/store.py
@@ -171,10 +171,14 @@ class InMemoryStore(RequestStore):
           model_id = tenants_list[0]
           queue = self.queues[model_id]
 
-          if not queue.empty():
-            batch = [queue.get_nowait()]
-            while not queue.empty():
-              batch.append(queue.get_nowait())
+          # Drain only what was pending on entry. Requests this tenant enqueues
+          # while we drain wait for its next turn, so a tenant whose producer
+          # outruns the consumer cannot hold the queue open indefinitely.
+          pending = queue.qsize()
+          if pending:
+            batch = [queue.get_nowait() for _ in range(pending)]
+            # Round-robin: rotate the tenant we just served to the tail.
+            tenants_list.append(tenants_list.pop(0))
             return batch
           else:
             tenants_list.pop(0)
@@ -289,6 +293,9 @@ class RedisStore(RequestStore):
         model_id = model_id_bytes.decode() if isinstance(model_id_bytes, bytes) else str(model_id_bytes)
 
       queue_key = f"open_rl:queue:{model_id}"
+      # Snapshot the depth before draining: requests this tenant enqueues while
+      # we drain belong to its next turn, otherwise a producer that outruns the
+      # consumer keeps the drain loop alive and never yields the head slot.
       q_len = await self.redis.llen(queue_key)
       if q_len == 0:
         await self.redis.lrem(active_list, 0, model_id)
@@ -296,13 +303,17 @@ class RedisStore(RequestStore):
         continue
 
       batch = []
-      while True:
+      for _ in range(q_len):
         item = await self.redis.lpop(queue_key)
         if not item:
           break
         batch.append(json.loads(item))
 
       if batch:
+        # Round-robin: move the tenant we just served from the head to the tail.
+        # Draining a tenant's whole batch keeps training batches intact; rotating
+        # afterwards keeps a continuously-enqueueing tenant from starving peers.
+        await self.redis.lmove(active_list, active_list, "LEFT", "RIGHT")
         return batch
 
   async def get_worker_launch_requests(self) -> list[dict[str, Any]]:

--- a/src/server/worker_manager.py
+++ b/src/server/worker_manager.py
@@ -6,7 +6,9 @@ separate launch queue: the subprocess table / the Kubernetes API already hold
 the launched-worker state, and both launchers are idempotent per model_id.
 """
 
+import logging
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -17,6 +19,8 @@ from typing import Protocol
 from accel_timeslicer.workload import SAMPLER_TIME_SLICE_GROUP, TRAINER_TIME_SLICE_GROUP, workload_job_id
 
 PROJECT_DIR = Path(__file__).resolve().parents[2]
+
+logger = logging.getLogger(__name__)
 
 
 def _py_cmd(extras: list[str], module: str, model_id: str, active_tenant_set_id: str | None = None) -> list[str]:
@@ -52,6 +56,91 @@ def _fetch_metadata_from_store(model_id: str) -> TrainingModelMetadata | None:
   return None
 
 
+# A bf16 full fine-tune holds 2 bytes of weights, 2 of gradients and 8 of fp32
+# AdamW moments per parameter. Activations, the sampler's KV cache and reload
+# buffers come on top, so only part of a tier's VRAM is budgeted here. The
+# pinned-DRAM weight shadow is host memory and does not count.
+FFT_VRAM_BYTES_PER_PARAM = 12
+# Of the 24gb tier's 23 GiB usable, leave headroom for everything above. 20 GiB
+# admits FFT up to ~1.7B params, which keeps the Qwen2.5-1.5B anchor on an L4.
+TIER_24GB_FFT_BUDGET_BYTES = 20 * 1024**3
+
+# Raw parameter counts for the models this project runs. Approximate on purpose:
+# they only have to land on the correct side of the 24gb budget below (~1.7B).
+#
+# A table rather than a Hub lookup. Sizing happens on the worker-launch path,
+# which should not depend on network reachability or on huggingface_hub being
+# installed, and the ids that actually matter cannot be sized by parsing them:
+# `gemma-4-e2b` states its *effective* size while holding roughly 5B raw
+# weights, so reading "2b" out of the name puts a 5B fine-tune on a 24 GB card
+# and OOMs it mid-run. Keys are normalized by _normalize_model_id.
+#
+# A model missing from this table is treated as large. Add an entry to let it
+# run on a smaller GPU; the count is the raw weight count, not an active or
+# effective parameter count.
+KNOWN_PARAMETER_COUNTS: dict[str, int] = {
+  # Qwen
+  "qwen2.5-0.5b": 494_000_000,
+  "qwen3-0.6b": 596_049_920,
+  "qwen2.5-1.5b": 1_540_000_000,
+  "qwen3-1.7b": 1_720_000_000,
+  "qwen3-4b": 4_020_000_000,
+  "qwen2.5-7b": 7_620_000_000,
+  "qwen3-8b": 8_190_000_000,
+  "qwen3.5-9b": 9_000_000_000,
+  "qwen3.5-27b": 27_000_000_000,
+  # Gemma. The e-prefixed ids are effective sizes; these are the raw weights.
+  "gemma-3-1b": 1_000_000_000,
+  "gemma-4-e2b": 5_440_000_000,
+  "gemma-4-e4b": 8_000_000_000,
+}
+
+# Fine-tune/variant tags that do not change the weight count.
+_VARIANT_SUFFIXES = ("-instruct", "-it", "-pt", "-base", "-chat")
+
+
+def _normalize_model_id(base_model: str) -> str:
+  """Reduce a model id to its KNOWN_PARAMETER_COUNTS key.
+
+  Drops the org prefix, lowercases, and strips variant and release-date tags,
+  so `Qwen/Qwen3-4B-Instruct-2507` and `google/gemma-4-E2B-it` both resolve.
+  """
+  name = (base_model or "").strip().lower().rsplit("/", 1)[-1]
+  while True:
+    stripped = re.sub(r"-\d{3,}$", "", name)
+    for suffix in _VARIANT_SUFFIXES:
+      if stripped.endswith(suffix):
+        stripped = stripped[: -len(suffix)]
+    if stripped == name:
+      return name
+    name = stripped
+
+
+def known_parameter_count(base_model: str) -> int | None:
+  """Raw parameter count for a known model, or None if it is not in the table."""
+  return KNOWN_PARAMETER_COUNTS.get(_normalize_model_id(base_model))
+
+
+def _fits_24gb_fft(params: int) -> bool:
+  return params * FFT_VRAM_BYTES_PER_PARAM <= TIER_24GB_FFT_BUDGET_BYTES
+
+
+def _fft_memory_tier(base_model: str) -> str:
+  """Tier for a full fine-tune, sized from the model's parameter count.
+
+  An unknown model resolves to '80gb'. That is the direction that cannot end a
+  run: too large a GPU wastes capacity, too small a one OOMs mid-training.
+  """
+  params = known_parameter_count(base_model)
+  if params is None:
+    logger.warning(
+      "No known parameter count for %r; using the 80gb tier. Add it to KNOWN_PARAMETER_COUNTS to run it on a smaller GPU.",
+      base_model,
+    )
+    return "80gb"
+  return "24gb" if _fits_24gb_fft(params) else "80gb"
+
+
 def estimate_memory_tier(base_model: str, fine_tuning_type: str = "lora") -> str:
   """Estimate VRAM memory tier ('24gb' or '80gb') based on base model scale and fine-tuning type.
 
@@ -60,15 +149,15 @@ def estimate_memory_tier(base_model: str, fine_tuning_type: str = "lora") -> str
     - Qwen3-8B / Qwen2.5-7B (LoRA): '24gb' (NVIDIA L4)
     - Qwen3-8B / Qwen2.5-7B (Full Fine-Tuning): '80gb' (NVIDIA H100)
     - 14B+ models (LoRA or FFT): '80gb' (NVIDIA H100)
+
+  Full fine-tuning is sized from the model's parameter count. When that cannot
+  be established the tier stays '80gb': an FFT sent to too small a GPU dies on
+  an OOM mid-run, while one sent to too large a GPU merely wastes it.
   """
   model_lower = (base_model or "").lower()
 
-  # Full fine-tuning always maps to the 80gb tier: FFT of any
-  # multi-billion-param model (bf16 params + grads + AdamW states +
-  # pinned-DRAM shadow) exceeds the 24gb tier, and name-based size
-  # sniffing misses many model naming schemes (e.g. gemma-4-e2b).
   if fine_tuning_type == "full":
-    return "80gb"
+    return _fft_memory_tier(base_model)
 
   # LoRA fine-tuning memory scaling
   if any(size in model_lower for size in ["14b", "32b", "70b"]):

--- a/tests/test_gateway_paths.py
+++ b/tests/test_gateway_paths.py
@@ -62,5 +62,53 @@ class GatewayPathTest(unittest.TestCase):
     self.assertEqual(gateway.checkpoint_state_path("job-a", "/mnt/checkpoints/final"), "/mnt/checkpoints/final")
 
 
+class ClaimReconcilerTest(unittest.IsolatedAsyncioTestCase):
+  class _K8sManager:
+    def __init__(self) -> None:
+      self.calls = 0
+
+    def reconcile_managed_claims(self) -> list[str]:
+      self.calls += 1
+      return ["claim-idle"]
+
+  class _LocalManager:
+    """Stands in for LocalWorkerManager, which provisions no DRA claims."""
+
+  async def test_reconciler_runs_on_its_interval(self) -> None:
+    manager = self._K8sManager()
+    task = asyncio.create_task(gateway.run_claim_reconciler(manager, interval=0.01))
+    await asyncio.sleep(0.1)
+    task.cancel()
+
+    self.assertGreater(manager.calls, 1, "reconcile loop should fire repeatedly, not once")
+
+  async def test_reconciler_survives_a_failing_pass(self) -> None:
+    manager = self._K8sManager()
+
+    def boom() -> list[str]:
+      manager.calls += 1
+      raise RuntimeError("API server unavailable")
+
+    manager.reconcile_managed_claims = boom
+    task = asyncio.create_task(gateway.run_claim_reconciler(manager, interval=0.01))
+    await asyncio.sleep(0.1)
+    task.cancel()
+
+    # A transient API error must not silently kill the only thing reclaiming GPUs.
+    self.assertGreater(manager.calls, 1)
+
+  async def test_reconciler_starts_only_for_claim_provisioning_managers(self) -> None:
+    self.assertIsNone(gateway.start_claim_reconciler(None))
+    self.assertIsNone(gateway.start_claim_reconciler(self._LocalManager()))
+
+    task = gateway.start_claim_reconciler(self._K8sManager())
+    self.assertIsNotNone(task)
+    task.cancel()
+
+  async def test_reconciler_can_be_disabled(self) -> None:
+    with patch.dict(os.environ, {"OPEN_RL_CLAIM_RECONCILE_INTERVAL_SECONDS": "0"}):
+      self.assertIsNone(gateway.start_claim_reconciler(self._K8sManager()))
+
+
 if __name__ == "__main__":
   unittest.main()

--- a/tests/test_k8s_worker_manager.py
+++ b/tests/test_k8s_worker_manager.py
@@ -1,5 +1,6 @@
 import os
 import tempfile
+import time
 import types
 import unittest
 from typing import Any
@@ -340,7 +341,8 @@ class KubernetesWorkerManagerTest(unittest.TestCase):
       self.assertEqual(manager.resolve_claim("lora", "trainer", "Qwen3-0.6B"), "lora-gpu-1")
 
       # Simulate lora-gpu-1 locked to qwen3-0-6b
-      with patch.object(manager, "_get_claim_locks", return_value={"lora-gpu-1": {"qwen3-0-6b"}}):
+      usage = {"lora-gpu-1": {"models": {"qwen3-0-6b"}, "workers": 1}}
+      with patch.object(manager, "_get_claim_usage", return_value=usage):
         # Same base model -> affinity reuses lora-gpu-1
         self.assertEqual(manager.resolve_claim("lora", "trainer", "Qwen3-0.6B"), "lora-gpu-1")
         # Different base model -> mutual exclusion skips lora-gpu-1 and selects lora-gpu-2
@@ -350,10 +352,238 @@ class KubernetesWorkerManagerTest(unittest.TestCase):
     fft_claims = ["fft-gpu-1", "fft-gpu-2"]
     with (
       patch.object(manager, "_discover_eligible_claims", return_value=fft_claims),
-      patch.object(manager, "_get_claim_locks", return_value={"fft-gpu-1": {"qwen3-0-6b"}}),
+      patch.object(manager, "_get_claim_usage", return_value={"fft-gpu-1": {"models": {"qwen3-0-6b"}, "workers": 1}}),
     ):
       # FFT trainer allows up to max_workers_per_claim (2) -> fft-gpu-1 has 1 worker (1/2), so reuses fft-gpu-1
       self.assertEqual(manager.resolve_claim("full", "trainer", "Qwen3-8B"), "fft-gpu-1")
+
+  def test_claim_capacity_counts_workers_not_distinct_models(self) -> None:
+    api = _FakeCoreApi()
+    manager = self._manager(api)
+    claims = ["fft-gpu-1", "fft-gpu-2"]
+
+    # Two workers of the SAME base model fill a claim with max_workers_per_claim=2.
+    # Counting distinct models here would see 1/2 and keep packing onto fft-gpu-1.
+    saturated = {"fft-gpu-1": {"models": {"qwen3-8b"}, "workers": 2}}
+    with (
+      patch.object(manager, "_discover_eligible_claims", return_value=claims),
+      patch.object(manager, "_get_claim_usage", return_value=saturated),
+    ):
+      self.assertEqual(manager.resolve_claim("full", "trainer", "Qwen3-8B"), "fft-gpu-2")
+
+    # Base-model affinity must respect the same worker ceiling.
+    with (
+      patch.object(manager, "_discover_eligible_claims", return_value=["fft-gpu-1"]),
+      patch.object(manager, "_get_claim_usage", return_value=saturated),
+      patch.object(manager, "_create_managed_claim", return_value="fft-gpu-new") as create,
+    ):
+      self.assertEqual(manager.resolve_claim("full", "trainer", "Qwen3-8B"), "fft-gpu-new")
+      create.assert_called_once()
+
+  def test_claim_usage_counts_each_pod_separately(self) -> None:
+    api = _FakeCoreApi()
+    manager = self._manager(api)
+
+    def _pod(name: str, claim: str, model: str, phase: str = "Running") -> dict[str, Any]:
+      return {
+        "metadata": {"name": name, "labels": {"open-rl.io/assigned-claim": claim, "open-rl.io/bound-base-model": model}},
+        "status": {"phase": phase},
+      }
+
+    pods = {
+      "items": [
+        _pod("w1", "claim-a", "qwen3-8b"),
+        _pod("w2", "claim-a", "qwen3-8b"),
+        _pod("w3", "claim-a", "qwen3-0-6b"),
+        _pod("w4", "claim-a", "qwen3-8b", phase="Succeeded"),
+      ]
+    }
+    with patch.object(api, "list_namespaced_pod", return_value=pods, create=True):
+      usage = manager._get_claim_usage()
+
+    # Terminal pods are excluded; the two live qwen3-8b pods count twice.
+    self.assertEqual(usage["claim-a"]["workers"], 3)
+    self.assertEqual(usage["claim-a"]["models"], {"qwen3-8b", "qwen3-0-6b"})
+
+  def test_dynamic_claim_is_released_when_pod_create_fails(self) -> None:
+    api = _FakeCoreApi()
+    api.create_error = _ApiError(500)
+    manager = self._manager(api)
+
+    with (
+      patch.dict(os.environ, {"OPEN_RL_ENABLE_FFT": "true"}),
+      patch.object(manager, "_discover_eligible_claims", return_value=[]),
+      patch.object(manager, "_delete_managed_claim") as delete_claim,
+      self.assertRaises(_ApiError),
+    ):
+      manager.launch("model-a")
+
+    # The claim provisioned while rendering the pod must not outlive the failure.
+    delete_claim.assert_called_once()
+    self.assertTrue(delete_claim.call_args[0][0].startswith("open-rl-managed-full-trainer-"))
+
+  def test_dynamic_claim_is_released_when_pod_create_conflicts(self) -> None:
+    api = _FakeCoreApi()
+    api.create_error = _ApiError(409)
+    manager = self._manager(api)
+
+    with (
+      patch.dict(os.environ, {"OPEN_RL_ENABLE_FFT": "true"}),
+      patch.object(manager, "_discover_eligible_claims", return_value=[]),
+      patch.object(manager, "_delete_managed_claim") as delete_claim,
+    ):
+      manager.launch("model-a")  # 409 is tolerated, but the claim still leaks without cleanup
+
+    delete_claim.assert_called_once()
+
+  def test_successful_launch_keeps_its_dynamic_claim(self) -> None:
+    api = _FakeCoreApi()
+    manager = self._manager(api)
+
+    with (
+      patch.dict(os.environ, {"OPEN_RL_ENABLE_FFT": "true"}),
+      patch.object(manager, "_discover_eligible_claims", return_value=[]),
+      patch.object(manager, "_delete_managed_claim") as delete_claim,
+    ):
+      manager.launch("model-a")
+
+    delete_claim.assert_not_called()
+    self.assertEqual(manager._claims_created_this_launch, [])
+    claim = api.created[0][1]["spec"]["resourceClaims"][0]["resourceClaimName"]
+    self.assertTrue(claim.startswith("open-rl-managed-full-trainer-"))
+
+  def test_concurrent_launches_provision_a_single_claim(self) -> None:
+    import threading
+
+    api = _FakeCoreApi()
+    manager = self._manager(api)
+    created_claims: list[str] = []
+    barrier = threading.Barrier(4)
+
+    real_create = manager._create_managed_claim
+
+    def slow_create(workload_type: str, role: str, memory_tier: str) -> str:
+      # Widen the resolve -> create window so an unsynchronized launch path would
+      # reliably interleave and double-provision.
+      time.sleep(0.05)
+      name = real_create(workload_type, role, memory_tier)
+      created_claims.append(name)
+      return name
+
+    def launch() -> None:
+      barrier.wait()
+      manager.launch("model-a")
+
+    with (
+      patch.dict(os.environ, {"OPEN_RL_ENABLE_FFT": "true"}),
+      patch.object(manager, "_discover_eligible_claims", side_effect=lambda *a, **k: list(created_claims)),
+      patch.object(manager, "_get_claim_usage", side_effect=lambda: {c: {"models": {"model-a"}, "workers": 1} for c in created_claims}),
+      patch.object(manager, "_create_managed_claim", side_effect=slow_create),
+    ):
+      threads = [threading.Thread(target=launch) for _ in range(4)]
+      for t in threads:
+        t.start()
+      for t in threads:
+        t.join()
+
+    self.assertEqual(len(created_claims), 1, f"expected one dynamic claim, got {created_claims}")
+
+  def _managed_claim(self, name: str, age_seconds: float) -> dict[str, Any]:
+    import datetime
+
+    created = datetime.datetime.now(datetime.UTC) - datetime.timedelta(seconds=age_seconds)
+    return {"metadata": {"name": name, "creationTimestamp": created.strftime("%Y-%m-%dT%H:%M:%SZ")}}
+
+  def _reconcile(self, manager: KubernetesWorkerManager, claims: list[dict], usage: dict, **kwargs) -> list[str]:
+    """Run a reconcile pass over `claims`, returning the names it deleted."""
+    with (
+      patch.object(_FakeCustomObjectsApi, "list_namespaced_custom_object", return_value={"items": claims}),
+      patch.object(manager, "_get_claim_usage", return_value=usage),
+      patch.object(manager, "_delete_managed_claim") as delete_claim,
+    ):
+      deleted = manager.reconcile_managed_claims(**kwargs)
+    # The returned names must be exactly the claims it actually issued deletes for.
+    self.assertEqual(deleted, [call.args[0] for call in delete_claim.call_args_list])
+    return deleted
+
+  def test_reconcile_deletes_unreferenced_claims(self) -> None:
+    manager = self._manager(_FakeCoreApi())
+    claims = [self._managed_claim("claim-idle", age_seconds=600), self._managed_claim("claim-busy", age_seconds=600)]
+    usage = {"claim-busy": {"models": {"qwen3-8b"}, "workers": 1}}
+
+    deleted = self._reconcile(manager, claims, usage)
+
+    self.assertEqual(deleted, ["claim-idle"])
+
+  def test_reconcile_skips_claims_inside_the_grace_period(self) -> None:
+    manager = self._manager(_FakeCoreApi())
+    # A claim provisioned seconds ago whose Pod has not registered yet is
+    # indistinguishable from an abandoned one; another replica may be mid-launch.
+    claims = [self._managed_claim("claim-just-created", age_seconds=5)]
+
+    self.assertEqual(self._reconcile(manager, claims, {}, min_age_seconds=120), [])
+    # Past the grace period the same claim is collected.
+    self.assertEqual(self._reconcile(manager, claims, {}, min_age_seconds=1), ["claim-just-created"])
+
+  def test_reconcile_grace_period_is_configurable_by_env(self) -> None:
+    manager = self._manager(_FakeCoreApi())
+    claims = [self._managed_claim("claim-idle", age_seconds=60)]
+
+    with patch.dict(os.environ, {**self.env, "OPEN_RL_CLAIM_RECONCILE_MIN_AGE_SECONDS": "600"}, clear=True):
+      self.assertEqual(self._reconcile(manager, claims, {}), [])
+    with patch.dict(os.environ, {**self.env, "OPEN_RL_CLAIM_RECONCILE_MIN_AGE_SECONDS": "10"}, clear=True):
+      self.assertEqual(self._reconcile(manager, claims, {}), ["claim-idle"])
+
+  def test_reconcile_excludes_launches_in_the_same_process(self) -> None:
+    import threading
+
+    manager = self._manager(_FakeCoreApi())
+    order: list[str] = []
+    launch_holds_lock = threading.Event()
+    reconcile_attempted = threading.Event()
+
+    def hold_lock() -> None:
+      with manager._launch_lock:
+        launch_holds_lock.set()
+        reconcile_attempted.wait(timeout=2)
+        time.sleep(0.05)
+        order.append("launch-done")
+
+    holder = threading.Thread(target=hold_lock)
+    holder.start()
+    self.assertTrue(launch_holds_lock.wait(timeout=2))
+
+    def reconcile() -> None:
+      reconcile_attempted.set()
+      self._reconcile(manager, [self._managed_claim("claim-idle", age_seconds=600)], {})
+      order.append("reconcile-done")
+
+    reconciler = threading.Thread(target=reconcile)
+    reconciler.start()
+    holder.join(timeout=5)
+    reconciler.join(timeout=5)
+
+    # Reconciliation cannot inspect claims while a launch is provisioning one.
+    self.assertEqual(order, ["launch-done", "reconcile-done"])
+
+  def test_claim_age_tolerates_missing_or_bad_timestamps(self) -> None:
+    # An unreadable stamp reads as brand new, not ancient: the grace period is
+    # there to protect a claim another replica just provisioned, and treating an
+    # unknown age as old would delete exactly those.
+    self.assertEqual(KubernetesWorkerManager._claim_age_seconds({}), 0.0)
+    self.assertEqual(KubernetesWorkerManager._claim_age_seconds({"creationTimestamp": "not-a-date"}), 0.0)
+    self.assertLess(KubernetesWorkerManager._claim_age_seconds(self._managed_claim("c", 30)["metadata"]) - 30, 5)
+
+  def test_reconcile_leaves_claims_with_unreadable_timestamps_alone(self) -> None:
+    manager = self._manager(_FakeCoreApi())
+    undated = {"metadata": {"name": "claim-undated", "labels": {"open-rl.io/managed-by": "open-rl-gateway"}}}
+    bad_stamp = {
+      "metadata": {"name": "claim-bad-stamp", "creationTimestamp": "not-a-date", "labels": {"open-rl.io/managed-by": "open-rl-gateway"}},
+    }
+
+    # Unreferenced, but their age cannot be established, so leave them for a
+    # later pass rather than risk yanking a claim out from under a starting Pod.
+    self.assertEqual(self._reconcile(manager, [undated, bad_stamp], {}, min_age_seconds=120), [])
 
   def test_requires_template_and_redis(self) -> None:
     with patch.dict(os.environ, {"REDIS_URL": "redis://r:6379"}, clear=True), self.assertRaisesRegex(RuntimeError, "POD_TEMPLATE"):

--- a/tests/test_redis_store.py
+++ b/tests/test_redis_store.py
@@ -100,6 +100,39 @@ class RedisFutureTest(unittest.IsolatedAsyncioTestCase):
     await self.store.set_future("req-1", {"status": "pending"})
     self.assertEqual((await self.store.get_future("req-1", timeout=0.3))["type"], "try_again")
 
+  async def test_get_requests_rotates_between_tenants(self) -> None:
+    for i in range(3):
+      await self.store.put_request({"model_id": "tenant-a", "request_id": f"a{i}"}, active_set_id="base-1")
+      await self.store.put_request({"model_id": "tenant-b", "request_id": f"b{i}"}, active_set_id="base-1")
+
+    served = []
+    for _ in range(2):
+      batch = await self.store.get_requests(active_set_id="base-1")
+      served.append(batch[0]["model_id"])
+
+    self.assertEqual(served, ["tenant-a", "tenant-b"])
+
+  async def test_busy_tenant_does_not_starve_its_peer(self) -> None:
+    await self.store.put_request({"model_id": "busy", "request_id": "b0"}, active_set_id="base-1")
+    await self.store.put_request({"model_id": "quiet", "request_id": "q0"}, active_set_id="base-1")
+
+    # The busy tenant keeps enqueueing after each turn. Without rotation it holds
+    # the head of the active list forever and 'quiet' is never served.
+    served = []
+    for i in range(4):
+      batch = await self.store.get_requests(active_set_id="base-1")
+      served.append(batch[0]["model_id"])
+      await self.store.put_request({"model_id": "busy", "request_id": f"b{i + 1}"}, active_set_id="base-1")
+
+    self.assertIn("quiet", served)
+
+  async def test_get_requests_drains_only_the_depth_present_on_entry(self) -> None:
+    for i in range(2):
+      await self.store.put_request({"model_id": "tenant-a", "request_id": f"a{i}"}, active_set_id="base-1")
+
+    batch = await self.store.get_requests(active_set_id="base-1")
+    self.assertEqual([r["request_id"] for r in batch], ["a0", "a1"])
+
 
 class InMemoryStoreTest(unittest.IsolatedAsyncioTestCase):
   def setUp(self) -> None:
@@ -120,6 +153,37 @@ class InMemoryStoreTest(unittest.IsolatedAsyncioTestCase):
 
     empty_batch = await self.store.get_sampling_requests_for_model("base-m1")
     self.assertEqual(empty_batch, [])
+
+  async def test_get_requests_rotates_between_tenants(self) -> None:
+    for i in range(3):
+      await self.store.put_request({"model_id": "tenant-a", "request_id": f"a{i}"}, active_set_id="base-1")
+      await self.store.put_request({"model_id": "tenant-b", "request_id": f"b{i}"}, active_set_id="base-1")
+
+    served = []
+    for _ in range(2):
+      batch = await self.store.get_requests(active_set_id="base-1")
+      served.append(batch[0]["model_id"])
+
+    self.assertEqual(served, ["tenant-a", "tenant-b"])
+
+  async def test_busy_tenant_does_not_starve_its_peer(self) -> None:
+    await self.store.put_request({"model_id": "busy", "request_id": "b0"}, active_set_id="base-1")
+    await self.store.put_request({"model_id": "quiet", "request_id": "q0"}, active_set_id="base-1")
+
+    served = []
+    for i in range(4):
+      batch = await self.store.get_requests(active_set_id="base-1")
+      served.append(batch[0]["model_id"])
+      await self.store.put_request({"model_id": "busy", "request_id": f"b{i + 1}"}, active_set_id="base-1")
+
+    self.assertIn("quiet", served)
+
+  async def test_get_requests_drains_only_the_depth_present_on_entry(self) -> None:
+    for i in range(2):
+      await self.store.put_request({"model_id": "tenant-a", "request_id": f"a{i}"}, active_set_id="base-1")
+
+    batch = await self.store.get_requests(active_set_id="base-1")
+    self.assertEqual([r["request_id"] for r in batch], ["a0", "a1"])
 
 
 if __name__ == "__main__":

--- a/tests/test_worker_manager.py
+++ b/tests/test_worker_manager.py
@@ -1,8 +1,9 @@
 import json
+import sys
 import unittest
 from unittest.mock import patch
 
-from server import gateway
+from server import gateway, worker_manager
 from server.worker_manager import LocalWorkerManager
 
 
@@ -417,6 +418,56 @@ class LocalWorkerManagerSamplerLaunchTest(unittest.TestCase):
     cmd_args = mock_popen.call_args[0][0]
     self.assertIn("server.vllm_sampler", cmd_args)
     self.assertIn("model-fft-1", cmd_args)
+
+
+class EstimateMemoryTierTest(unittest.TestCase):
+  """Tier selection for full fine-tuning is driven by the known-model table."""
+
+  def test_small_models_fit_the_24gb_tier(self) -> None:
+    for model in ("Qwen/Qwen3-0.6B", "Qwen/Qwen2.5-0.5B", "Qwen/Qwen2.5-1.5B", "google/gemma-3-1b-pt"):
+      self.assertEqual(worker_manager.estimate_memory_tier(model, "full"), "24gb", model)
+
+  def test_large_models_need_the_80gb_tier(self) -> None:
+    for model in ("Qwen/Qwen3-4B", "Qwen/Qwen3-8B", "Qwen/Qwen3.5-27B", "google/gemma-4-e4b"):
+      self.assertEqual(worker_manager.estimate_memory_tier(model, "full"), "80gb", model)
+
+  def test_effective_size_names_are_sized_by_their_raw_weights(self) -> None:
+    # `gemma-4-e2b` states its *effective* size; the raw weights an FFT has to
+    # hold are ~5B. Reading "2b" off the name is what puts it on a 24 GB card.
+    self.assertEqual(worker_manager.estimate_memory_tier("google/gemma-4-e2b", "full"), "80gb")
+
+  def test_unknown_models_stay_on_the_conservative_tier(self) -> None:
+    with self.assertLogs("server.worker_manager", level="WARNING"):
+      self.assertEqual(worker_manager.estimate_memory_tier("acme/mystery-model", "full"), "80gb")
+
+  def test_variant_and_release_tags_resolve_to_the_base_entry(self) -> None:
+    cases = {
+      "Qwen/Qwen2.5-0.5B-Instruct": "24gb",
+      "Qwen/Qwen3-4B-Instruct-2507": "80gb",
+      "google/gemma-4-E2B-it": "80gb",
+      "google/gemma-3-1b-it": "24gb",
+      "qwen3-0.6b": "24gb",  # bare id, no org prefix
+    }
+    for model, tier in cases.items():
+      self.assertEqual(worker_manager.estimate_memory_tier(model, "full"), tier, model)
+
+  def test_sizing_needs_no_network_or_hub_client(self) -> None:
+    # The launch path must not depend on the Hub being reachable, so a missing
+    # huggingface_hub must not change any verdict.
+    with patch.dict(sys.modules, {"huggingface_hub": None}):
+      self.assertEqual(worker_manager.estimate_memory_tier("Qwen/Qwen3-0.6B", "full"), "24gb")
+      self.assertEqual(worker_manager.estimate_memory_tier("Qwen/Qwen3-8B", "full"), "80gb")
+
+  def test_table_entries_agree_with_the_documented_budget(self) -> None:
+    # The 24gb tier admits ~1.7B params at 12 bytes each; guard the boundary so
+    # a future budget change has to be made deliberately.
+    threshold = worker_manager.TIER_24GB_FFT_BUDGET_BYTES / worker_manager.FFT_VRAM_BYTES_PER_PARAM
+    self.assertLess(worker_manager.KNOWN_PARAMETER_COUNTS["qwen3-1.7b"], threshold)
+    self.assertGreater(worker_manager.KNOWN_PARAMETER_COUNTS["qwen3-4b"], threshold)
+
+  def test_lora_tiers_are_unchanged(self) -> None:
+    self.assertEqual(worker_manager.estimate_memory_tier("Qwen/Qwen3-8B", "lora"), "24gb")
+    self.assertEqual(worker_manager.estimate_memory_tier("meta-llama/Llama-3-70B", "lora"), "80gb")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Four scheduling bugs that strand or overcommit GPU claims, one fairness bug in
the request store, and the sizing change that makes full fine-tuning runnable
on smaller GPUs.

## Scheduling

- **Capacity counted models, not workers**, so a full claim looked half empty
  and got overpacked.
- **Concurrent launches each provisioned a claim** — resolution is now
  serialized.
- **Nothing deleted claims.** The reconciler had no caller, so every finished
  job stranded a GPU. It now runs on an interval, with guards so an in-flight
  launch is never mistaken for an abandoned claim, and a failed launch releases
  its claim immediately.
- **Placement fought itself.** Workers carried a node selector alongside their
  ResourceClaim; the claim already decides placement, and the two contradicted
  once small models stopped needing the largest GPU, leaving samplers
  unschedulable.
- **One tenant could starve its peers** by enqueueing faster than the consumer
  drained. Queue depth is now snapshotted on entry and the served tenant
  rotates to the tail.

## Sizing

Full fine-tuning always demanded an 80 GB GPU, so a sub-billion-parameter run
reserved an H100 — and failed outright where none exists. Tiers now come from
the model's parameter count against an explicit VRAM budget, using a static
table rather than a registry lookup: launch shouldn't depend on network
reachability, and some model ids state an *effective* size while holding
several times the weights. Unknown models are treated as large.

## Startup

Worker images shipped no precompiled bytecode and re-synced the project on
every start; compiled inference graphs died with the pod. Roughly 10s off each
worker launch and 15s off each sampler. Cloud Build targets included since the
images are often too large to push from a workstation.

## Testing

Unit tests and lint pass. Verified on a two-L4 dev cluster (LoRA, FFT, and
automatic claim reclaim) and on an L4 + H100 cluster running two LoRA and two
FFT jobs concurrently: both tiers selected correctly at once, FFT jobs
time-shared the scarce H100s two workers per claim, LoRA jobs collapsed onto a
shared worker pair.

## Notes

Small full fine-tunes will now land on smaller GPUs that never received them
before. Adding a model to the sizing table is a deliberate step — skipping it
costs capacity, not correctness. Removing the node selector means role-based
node-pool reservation is no longer enforced by the manifests.