### PR TITLE
chore(fft): deploy the published llm-d Snapshot Agent image instead of building our own

### DIFF
--- a/docs/setup/gke-fft-timeslice.md
+++ b/docs/setup/gke-fft-timeslice.md
@@ -201,8 +201,9 @@ the relevant pod and process set.
   needs it) with the Filestore CSI driver enabled (see
   [gke-setup.md](gke-setup.md) for the base cluster, CPU pool, and PVC details).
 - llm-d's snapshot-agent running on each trainer GPU node and reachable from the
-  OpenRL time slicer at `127.0.0.1:9001`. OpenRL owns acquire/release ordering;
-  llm-d owns physical snapshot/restore.
+  OpenRL time slicer at `127.0.0.1:9001`. It ships in the kustomize bundle
+  (`00-llmd-snapshot-agent.yaml`). OpenRL owns acquire/release ordering; llm-d
+  owns physical snapshot/restore.
 - A working NVIDIA GPU driver on the DRA node. The llm-d snapshot path uses
   CUDA checkpointing under the hood, so use driver **r570 or newer**.
 - The **NVIDIA DRA GPU driver** (Helm chart `nvidia-dra-driver-gpu` >= 25.8.0)
@@ -274,38 +275,6 @@ Notes:
   plugin's [time-slicing config](https://github.com/NVIDIA/k8s-device-plugin#shared-access-to-gpus-with-cuda-time-slicing)
   (`replicas: 2`) plus the node label.
 
-## Setup 1.5: Install and deploy llm-d Snapshot Agent DaemonSet
-
-Because `open-rl-accel-timeslicer` runs with `--backend llmd` in cluster deployments, it delegates physical kernel-level CUDA process freezing and unfreezing (`cuda-checkpoint`) to `llmd-snapshot-agent` over gRPC on `127.0.0.1:9001`.
-
-To build and deploy the official `llmd-snapshot-agent` DaemonSet on GPU nodes:
-
-1. **Clone the official `llm-d-rl-time-slicing` repository:**
-   ```bash
-   git clone https://github.com/llm-d-incubation/llm-d-rl-time-slicing.git ~/.cache/checkouts/github.com/llm-d-incubation/llm-d-rl-time-slicing
-   cd ~/.cache/checkouts/github.com/llm-d-incubation/llm-d-rl-time-slicing
-   ```
-
-2. **Build and push the Go Daemon container image:**
-   *(Note: The Dockerfile requires a pre-built `bin/` directory. Ensure `bin/` exists before running Docker build).*
-   ```bash
-   mkdir -p bin/
-   DOCKER_BUILDKIT=1 docker build -t gcr.io/<YOUR_GCP_PROJECT>/llmd-snapshot-agent:latest -f deploy/snapshot-agent/Dockerfile .
-   docker push gcr.io/<YOUR_GCP_PROJECT>/llmd-snapshot-agent:latest
-   ```
-
-3. **Deploy the Helm Chart into `timeslice-system`:**
-   ```bash
-   helm template snapshot-agent deploy/snapshot-agent/ \
-     --namespace timeslice-system \
-     --set image.repository=gcr.io/<YOUR_GCP_PROJECT>/llmd-snapshot-agent \
-     --set image.tag=latest \
-     --set tolerations[0].key=nvidia.com/gpu \
-     --set tolerations[0].operator=Exists \
-     --set tolerations[0].effect=NoSchedule | kubectl apply -f -
-   ```
-   Verify both DaemonSet Pods (`llmd-snapshot-agent-*`) transition to `Running` and actively listen on TCP `9001` across all target GPU nodes.
-
 ## Setup 2: Build, push, and deploy OpenRL
 
 ```bash
@@ -314,9 +283,9 @@ make deploy-fft-timeslice
 ```
 
 `k8s/deploy/distributed-fft-timeslice/` deploys Redis, the shared PVC, the
-shared GPU `ResourceClaim`, the node-local OpenRL time-slicer DaemonSet, and the
-gateway with `OPEN_RL_ENABLE_FFT=true` and
-`OPEN_RL_WORKER_MANAGER=kubernetes`.
+shared GPU `ResourceClaim`, the llm-d Snapshot Agent DaemonSet, the node-local
+OpenRL time-slicer DaemonSet, and the gateway with `OPEN_RL_ENABLE_FFT=true`
+and `OPEN_RL_WORKER_MANAGER=kubernetes`.
 The deployment assumes one base model per rollout: set `BASE_MODEL` in
 `kustomization.yaml`, and the gateway uses that value for `get_info` and
 `create_model` requests that do not explicitly pass a base model.
@@ -341,6 +310,9 @@ When multiple training jobs share physical GPUs via the Accelerator Time-Slicer,
 - **Client Toggle:** Configured via `cpu_offload: bool = True` inside `FFTConfig`.
 - **Symmetric Primitives:** `sleep()` transfers model parameters and initialized AdamW optimizer states (`exp_avg`, `exp_avg_sq`) to pinned host memory (`.to("cpu", non_blocking=True).pin_memory()`) while replacing GPU tensors with empty shells (`torch.empty(0, ...)`). `wake_up()` reloads pinned shadow tensors back to CUDA instantly before processing training requests.
 
+### llm-d Snapshot Agent
+Because `open-rl-accel-timeslicer` runs with `--backend llmd` in the cluster, it delegates the physical kernel-level CUDA freeze/thaw (`cuda-checkpoint`) to the llm-d Snapshot Agent over gRPC on `127.0.0.1:9001`. The rollout includes `00-llmd-snapshot-agent.yaml`, which deploys that agent as a DaemonSet in `timeslice-system` on every node labeled `nvidia.com/gpu.present=true`, running the image upstream CI publishes to `ghcr.io/llm-d-incubation/llm-d-rl-time-slicing/snapshot-agent` and pinned by digest. There is nothing to build or install by hand; the manifest's header comment covers moving to a newer agent build.
+
 ### DCGM GPU Observability
 The Kustomize rollout includes `10-dcgm-monitoring.yaml`, deploying the NVIDIA DCGM Exporter DaemonSet and a Google Cloud Monitoring `PodMonitoring` custom resource to scrape GPU utilization, VRAM usage, clock speeds, and temperature metrics every 10 seconds.
 
@@ -361,6 +333,11 @@ make test e2e fft-gsm8k BASE_URL=http://127.0.0.1:8000
   `ResourceClaim`, so they should be schedulable onto the node that owns that
   claim. If only later pods are pending, check pod events for PVC attach limits,
   node selectors, taints, image pull errors, or an unallocated claim.
+- **No snapshot agent on a GPU node**: `kubectl get pods -n timeslice-system -l
+  app.kubernetes.io/name=snapshot-agent -o wide` should show a `Running` pod
+  listening on TCP `9001` for every GPU node. The DaemonSet selects
+  `nvidia.com/gpu.present=true` and mounts the host NVIDIA driver directory, so
+  it never starts on the CPU pool.
 - **Trainer worker fails on first CUDA batch with snapshot errors**: check the
   trainer worker pod logs, the `open-rl-accel-timeslicer` DaemonSet logs, and the
   llm-d snapshot-agent logs. The worker should connect to

--- a/k8s/deploy/distributed-fft-timeslice/00-llmd-snapshot-agent.yaml
+++ b/k8s/deploy/distributed-fft-timeslice/00-llmd-snapshot-agent.yaml
@@ -1,0 +1,162 @@
+# llm-d Snapshot Agent: the node-local daemon that performs the physical
+# CUDA checkpoint/restore (cuda-checkpoint) that open-rl-accel-timeslicer
+# drives over gRPC on 127.0.0.1:9001. It discovers the target pod's PIDs from
+# the timeslice.io/job-id label that the worker pod template stamps.
+#
+# Rendered from the upstream chart at llm-d-incubation/llm-d-rl-time-slicing
+# commit 7a3e86f4 (deploy/snapshot-agent, chart 0.1.0) — the same commit the
+# timeslice client is pinned to in pyproject.toml. The chart is not published
+# anywhere, so it has to be re-rendered from a checkout:
+#
+#   git clone https://github.com/llm-d-incubation/llm-d-rl-time-slicing.git
+#   helm template snapshot-agent deploy/snapshot-agent/ \
+#     --namespace timeslice-system \
+#     --set-string "nodeSelector.nvidia\.com/gpu\.present=true" \
+#     --set 'tolerations[0].key=nvidia.com/gpu' \
+#     --set 'tolerations[0].operator=Exists' \
+#     --set 'tolerations[0].effect=NoSchedule'
+#
+# Then re-apply these three edits by hand:
+#   1. Add back the Namespace below — it lives in the parent chart, so the
+#      subchart render omits it and the apply fails on a fresh cluster.
+#   2. Replace the :latest tag with a digest (crane digest <image>:latest).
+#   3. Bump the timeslice client pin in pyproject.toml to the same upstream
+#      commit, so the client and the agent stay paired.
+#
+# Temporary: pinned by digest because upstream publishes no release. Swap with
+# a version tag once they cut one (llm-d-incubation/llm-d-rl-time-slicing#179);
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: timeslice-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: snapshot-agent
+  namespace: timeslice-system
+  labels:
+    helm.sh/chart: snapshot-agent-0.1.0
+    app.kubernetes.io/name: snapshot-agent
+    app.kubernetes.io/instance: snapshot-agent
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: snapshot-agent
+  labels:
+    helm.sh/chart: snapshot-agent-0.1.0
+    app.kubernetes.io/name: snapshot-agent
+    app.kubernetes.io/instance: snapshot-agent
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  # Permission to query the kubelet via the API server proxy
+  - apiGroups: [""]
+    resources: ["nodes/proxy"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: snapshot-agent
+  labels:
+    helm.sh/chart: snapshot-agent-0.1.0
+    app.kubernetes.io/name: snapshot-agent
+    app.kubernetes.io/instance: snapshot-agent
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: snapshot-agent
+subjects:
+  - kind: ServiceAccount
+    name: snapshot-agent
+    namespace: timeslice-system
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: snapshot-agent
+  namespace: timeslice-system
+  labels:
+    helm.sh/chart: snapshot-agent-0.1.0
+    app.kubernetes.io/name: snapshot-agent
+    app.kubernetes.io/instance: snapshot-agent
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: snapshot-agent
+      app.kubernetes.io/instance: snapshot-agent
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: snapshot-agent
+        app.kubernetes.io/instance: snapshot-agent
+    spec:
+      serviceAccountName: snapshot-agent
+      hostNetwork: true
+      hostPID: true
+      containers:
+        - name: snapshot-agent
+          securityContext:
+            privileged: true
+          # Pinned by digest: the upstream :latest tag is rebuilt on every
+          # merge to their main. This digest is commit 7a3e86f4.
+          image: "ghcr.io/llm-d-incubation/llm-d-rl-time-slicing/snapshot-agent@sha256:a84a7bd39bc913371afcb9b550adfc3ce91240142b2a71b77745943413b6552b"
+          imagePullPolicy: Always
+          env:
+            - name: DEPLOYMENT_MODE
+              value: "k8s"
+            - name: PATH
+              value: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: AGENT_PORT
+              value: "9001"
+            - name: LD_LIBRARY_PATH
+              value: /usr/local/nvidia/lib64
+            - name: NVIDIA_VISIBLE_DEVICES
+              value: "all"
+            - name: NVIDIA_DRIVER_CAPABILITIES
+              value: "compute,utility"
+          ports:
+            - name: grpc
+              containerPort: 9001
+              protocol: TCP
+          resources:
+            {}
+          volumeMounts:
+            - name: nvidia-driver
+              mountPath: /usr/local/nvidia
+              readOnly: true
+            - name: nvidia-devices
+              mountPath: /dev
+      volumes:
+        - name: nvidia-driver
+          hostPath:
+            path: /home/kubernetes/bin/nvidia
+            type: Directory
+        - name: nvidia-devices
+          hostPath:
+            path: /dev
+            type: Directory
+      nodeSelector:
+        nvidia.com/gpu.present: "true"
+      tolerations:
+        - effect: NoSchedule
+          key: nvidia.com/gpu
+          operator: Exists

--- a/k8s/deploy/distributed-fft-timeslice/kustomization.yaml
+++ b/k8s/deploy/distributed-fft-timeslice/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 # GPU workloads reference the same DRA ResourceClaim, pinning them to one
 # physical GPU allocation. There is no static trainer worker in this variant.
 resources:
+  - 00-llmd-snapshot-agent.yaml
   - 01-shared-pvc.yaml
   - 02-redis.yaml
   - 03-rbac.yaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,9 @@ vllm = [
 # Kubernetes cluster mode: the k8s API client used to launch FFT worker pods.
 cluster = [
     "kubernetes>=29",
-    "timeslice @ git+https://github.com/llm-d-incubation/llm-d-rl-time-slicing.git@d03540a1c96af9d854bdaa3ef81fe435ad06a92f#subdirectory=pkg/client/python",
+    # Kept in step with the snapshot-agent image deployed in
+    # docs/setup/gke-fft-timeslice.md: both come from this upstream commit.
+    "timeslice @ git+https://github.com/llm-d-incubation/llm-d-rl-time-slicing.git@7a3e86f423fc6dd720ea20da04346ad667afc50a#subdirectory=pkg/client/python",
 ]
 dev = [
     "ruff>=0.5.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1906,7 +1906,7 @@ requires-dist = [
     { name = "redis", specifier = ">=5.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.5.0" },
     { name = "tilelang", marker = "sys_platform == 'linux' and extra == 'gpu'", specifier = ">=0.1.9" },
-    { name = "timeslice", marker = "extra == 'cluster'", git = "https://github.com/llm-d-incubation/llm-d-rl-time-slicing.git?subdirectory=pkg%2Fclient%2Fpython&rev=d03540a1c96af9d854bdaa3ef81fe435ad06a92f" },
+    { name = "timeslice", marker = "extra == 'cluster'", git = "https://github.com/llm-d-incubation/llm-d-rl-time-slicing.git?subdirectory=pkg%2Fclient%2Fpython&rev=7a3e86f423fc6dd720ea20da04346ad667afc50a" },
     { name = "torch", marker = "sys_platform == 'linux' and extra == 'gpu'", index = "https://download.pytorch.org/whl/cu129", conflict = { package = "open-rl", extra = "gpu" } },
     { name = "torch", marker = "sys_platform == 'linux' and extra == 'vllm'", index = "https://download.pytorch.org/whl/cu129", conflict = { package = "open-rl", extra = "vllm" } },
     { name = "torch", marker = "extra == 'cpu'", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "open-rl", extra = "cpu" } },
@@ -3085,7 +3085,7 @@ wheels = [
 [[package]]
 name = "timeslice"
 version = "0.2.1"
-source = { git = "https://github.com/llm-d-incubation/llm-d-rl-time-slicing.git?subdirectory=pkg%2Fclient%2Fpython&rev=d03540a1c96af9d854bdaa3ef81fe435ad06a92f#d03540a1c96af9d854bdaa3ef81fe435ad06a92f" }
+source = { git = "https://github.com/llm-d-incubation/llm-d-rl-time-slicing.git?subdirectory=pkg%2Fclient%2Fpython&rev=7a3e86f423fc6dd720ea20da04346ad667afc50a#7a3e86f423fc6dd720ea20da04346ad667afc50a" }
 dependencies = [
     { name = "grpcio" },
     { name = "protobuf" },


### PR DESCRIPTION
The setup guide had you clone llm-d-rl-time-slicing, `docker build` the snapshot agent, push it to your own registry, and `helm template | kubectl apply` it before deploying OpenRL. Upstream CI now publishes the image to `ghcr.io/llm-d-incubation/llm-d-rl-time-slicing/snapshot-agent`, so this vendors the rendered chart as `00-llmd-snapshot-agent.yaml` in the kustomize bundle, pointed at that image by digest, and `make deploy-fft-timeslice` brings the agent up with everything else.

The image and the `timeslice` client pin in `pyproject.toml` both move to upstream commit `7a3e86f4`, so the client and the agent stay paired. The digest pin is temporary: upstream publishes no release, so a digest is the only stable reference. We've asked them to cut one in llm-d-incubation/llm-d-rl-time-slicing#179, and once they do we can track a version tag instead.

Setup 1 now creates the `timeslice-system` namespace. Nothing in the guide ever did — the subchart namespaces every resource into it but the `Namespace` object lives in the parent chart — so a fresh cluster would have failed the apply.

Ref #183