### PR TITLE
feat(gateway): add the sampler metadata route

### DIFF
--- a/docs/tinker-client-compatibility.md
+++ b/docs/tinker-client-compatibility.md
@@ -1,6 +1,6 @@
 # Tinker Client Compatibility
 
-Generated from `tinker==0.18.1` by
+Generated from `tinker==0.22.7` by
 `tests/tinker_client_compat.py`.
 
 The test discovers public Tinker client methods with `dir()` and `inspect`,
@@ -10,19 +10,23 @@ discovered method
 with small fixture arguments, and records whether the call succeeds before
 the probe timeout.
 
-- Supported methods: 36
-- Unsupported methods: 43
+- Supported methods: 41
+- Unsupported methods: 41
 
 ## Supported Methods
 
 ### RestClient
 
+- `get_sampler`
+- `get_sampler_async`
 - `get_telemetry`
 
 ### SamplingClient
 
 - `compute_logprobs`
 - `compute_logprobs_async`
+- `get_base_model`
+- `get_base_model_async`
 - `get_telemetry`
 - `on_queue_state_change`
 - `sample`
@@ -43,6 +47,8 @@ the probe timeout.
 
 - `create_sampling_client`
 - `create_sampling_client_async`
+- `forward`
+- `forward_async`
 - `forward_backward`
 - `forward_backward_async`
 - `get_info`
@@ -59,7 +65,6 @@ the probe timeout.
 - `save_state_async`
 - `save_weights_and_get_sampling_client`
 - `save_weights_and_get_sampling_client_async`
-- `save_weights_and_get_sampling_client_submit`
 - `save_weights_for_sampler`
 - `save_weights_for_sampler_async`
 
@@ -67,16 +72,18 @@ the probe timeout.
 
 ### RestClient
 
+- `assign_session_project`
+- `assign_session_project_async`
 - `delete_checkpoint`
 - `delete_checkpoint_async`
 - `delete_checkpoint_from_tinker_path`
 - `delete_checkpoint_from_tinker_path_async`
+- `get_audit_log`
+- `get_audit_log_async`
 - `get_checkpoint_archive_url`
 - `get_checkpoint_archive_url_async`
 - `get_checkpoint_archive_url_from_tinker_path`
 - `get_checkpoint_archive_url_from_tinker_path_async`
-- `get_sampler`
-- `get_sampler_async`
 - `get_session`
 - `get_session_async`
 - `get_training_run`
@@ -102,8 +109,6 @@ the probe timeout.
 ### SamplingClient
 
 - `create`
-- `get_base_model`
-- `get_base_model_async`
 - `get_tokenizer`
 
 ### ServiceClient
@@ -115,7 +120,5 @@ the probe timeout.
 
 ### TrainingClient
 
-- `forward`
-- `forward_async`
 - `forward_backward_custom`
 - `forward_backward_custom_async`

--- a/src/server/gateway.py
+++ b/src/server/gateway.py
@@ -694,6 +694,28 @@ async def create_sampling_session(req: dict):
   return {"sampling_session_id": sess_id, "type": "create_sampling_session"}
 
 
+@app.get("/api/v1/samplers/{sampler_id:path}")
+async def get_sampler(sampler_id: str):
+  """SamplingClient.get_tokenizer() and .get_base_model().
+
+  The sampler id is whatever create_sampling_session handed back, so it is
+  either a base model name or a `tinker://<model_id>/sampler_weights/...` path;
+  `:path` on the route is what lets the slash in either form through. Both
+  resolve to the base model, which is all the client wants -- it loads the
+  tokenizer from the Hub itself.
+  """
+  base_model_id = base_model_id_from_sampling_ref(sampler_id)
+  model_meta = await store.get_model_metadata(base_model_id) if base_model_id else None
+  base_model = (model_meta or {}).get("base_model") or base_model_id or get_default_model_name()
+  if not base_model:
+    return JSONResponse(status_code=404, content={"error": f"Unknown sampler {sampler_id}"})
+  return {
+    "sampler_id": sampler_id,
+    "base_model": base_model,
+    "model_path": sampler_id if sampler_id.startswith("tinker://") else None,
+  }
+
+
 @app.post("/api/v1/asample")
 async def asample(req: dict):
   """SamplingClient.sample_async()"""

--- a/tests/tinker_client_compat.py
+++ b/tests/tinker_client_compat.py
@@ -247,7 +247,7 @@ def render_report(statuses: dict[str, str]) -> str:
     "`tests/tinker_client_compat.py`.",
     "",
     "The test discovers public Tinker client methods with `dir()` and `inspect`,",
-    "starts the real Open-RL FastAPI gateway in single-process mode with a tiny",
+    "starts the real OpenRL FastAPI gateway in single-process mode with a tiny",
     "local model fixture, lets the SDK fetch server bootstrap config, calls each",
     "discovered method",
     "with small fixture arguments, and records whether the call succeeds before",


### PR DESCRIPTION
`SamplingClient.get_base_model()` and `.get_tokenizer()` issue `GET /api/v1/samplers/<sampler_id>`, which the gateway did not serve, so both raised a 404. The sampler id is whatever `create_sampling_session` returned — either a base model name or a `tinker://` path — so the route uses a `:path` converter and resolves both to the base model.

Also regenerates `docs/tinker-client-compatibility.md`, which was still generated from tinker 0.18.1 while the repo pins 0.22.7. Beyond `get_sampler`/`get_base_model` moving to supported, the SDK bump alone accounts for `assign_session_project` and `get_audit_log` appearing, `save_weights_and_get_sampling_client_submit` disappearing, and `forward` moving to supported.