### PR TITLE
fix(sampler): skip vLLM's multimodal profiling for text models

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -89,6 +89,7 @@ backend by default for physical checkpoint/restore.
 | --- | --- | --- |
 | `MOCK_VLLM` | `0` | `1` starts the vLLM worker without a real vLLM engine, useful for local API debugging. |
 | `VLLM_ARCHITECTURE_OVERRIDE` | unset | Optional architecture override passed to the in-repo vLLM worker. Gemma 4 examples use `Gemma4ForCausalLM`. |
+| `VLLM_ENABLE_MULTIMODAL` | `0` | By default the samplers pass `limit_mm_per_prompt={"image": 0, "video": 0}`. Text checkpoints published as `*ForConditionalGeneration` otherwise make vLLM reserve a multi-GiB encoder cache during startup that no OpenRL code path can use, which can OOM engine init. Set to `1` to restore stock vLLM behaviour. |
 
 ## Client variables
 

--- a/src/server/lora_sampler.py
+++ b/src/server/lora_sampler.py
@@ -11,6 +11,7 @@ from vllm.lora.request import LoRARequest
 from vllm.sampling_params import RequestOutputKind, SamplingParams
 
 from server.store import get_store
+from server.vllm_options import text_only_engine_kwargs
 
 TMP_DIR = os.getenv("OPEN_RL_TMP_DIR", "/tmp/open-rl")
 engine: AsyncLLMEngine | None = None
@@ -165,6 +166,8 @@ async def main():
   if arch_override:
     hf_overrides = engine_kwargs.setdefault("hf_overrides", {})
     hf_overrides["architectures"] = [arch_override]
+
+  engine_kwargs.update(text_only_engine_kwargs())
 
   engine_args = AsyncEngineArgs(**engine_kwargs)
   engine = AsyncLLMEngine.from_engine_args(engine_args)

--- a/src/server/vllm_options.py
+++ b/src/server/vllm_options.py
@@ -1,0 +1,17 @@
+"""Engine and sampling options shared by the two vLLM sampler workers."""
+
+import os
+
+
+def text_only_engine_kwargs() -> dict:
+  """Stop vLLM reserving an encoder cache OpenRL can never use.
+
+  Text checkpoints published under a `*ForConditionalGeneration` architecture
+  make vLLM profile a max-resolution image and video at startup and reserve a
+  multi-GiB encoder cache before the KV cache is sized, which can OOM engine
+  init. OpenRL only ever passes token ids, so that capacity is unreachable.
+  `VLLM_ENABLE_MULTIMODAL=1` restores stock vLLM behaviour.
+  """
+  if os.getenv("VLLM_ENABLE_MULTIMODAL", "0") == "1":
+    return {}
+  return {"limit_mm_per_prompt": {"image": 0, "video": 0}}

--- a/src/server/vllm_sampler.py
+++ b/src/server/vllm_sampler.py
@@ -10,6 +10,7 @@ from typing import Any
 os.environ["VLLM_ALLOW_INSECURE_SERIALIZATION"] = "1"
 
 from server.model_metadata import WeightSyncConfig
+from server.vllm_options import text_only_engine_kwargs
 
 try:
   from vllm import SamplingParams
@@ -104,6 +105,8 @@ def init_engine():
     }
     if hf_overrides:
       engine_kwargs["hf_overrides"] = hf_overrides
+
+    engine_kwargs.update(text_only_engine_kwargs())
 
     from server.model_metadata import WeightSyncConfig
 


### PR DESCRIPTION
Text checkpoints published under a `*ForConditionalGeneration` architecture make vLLM profile a max-resolution image and video at startup and reserve an encoder cache before the KV cache is sized, which can OOM engine init on a 24GB card. OpenRL only ever passes token ids, so both samplers now set `limit_mm_per_prompt` to zero; `VLLM_ENABLE_MULTIMODAL=1` opts back out.

Conflicts with #214 — both add `src/server/vllm_options.py` and an import to the same two samplers. Whichever merges second needs the union of the two functions and a combined import line.