### PR TITLE
feat: add grouping to timeslicer

### DIFF
--- a/scripts/run_training_e2e.py
+++ b/scripts/run_training_e2e.py
@@ -482,8 +482,8 @@ def check_snapshot_interleaving(config: RunConfig) -> None:
     return
   text = log_path.read_text(encoding="utf-8", errors="replace")
 
-  checkpointed = set(re.findall(r"checkpointed workload (\S+) group \S+", text))
-  restored = set(re.findall(r"restored workload (\S+) group \S+", text))
+  checkpointed = set(re.findall(r"checkpointed workload (\S+) claim \S+", text))
+  restored = set(re.findall(r"restored workload (\S+) claim \S+", text))
 
   cp_t = {workload for workload in checkpointed if ":trainer-" in workload or workload.startswith("trainer-")}
   rs_t = {workload for workload in restored if ":trainer-" in workload or workload.startswith("trainer-")}

--- a/src/accel_timeslicer/checkpoint.py
+++ b/src/accel_timeslicer/checkpoint.py
@@ -30,11 +30,11 @@ class CudaCheckpointRestorer:
   def checkpoint(self, workload: WorkloadRef) -> bool:
     pids = self.discover_pids(workload)
     if not pids:
-      self.checkpointed_pids.pop(workload.key, None)
-      logger.info("checkpoint skipped for workload=%s: no GPU PIDs found", workload.key)
+      self.checkpointed_pids.pop(workload.name, None)
+      logger.info("checkpoint skipped for workload=%s: no GPU PIDs found", workload.name)
       return False
     start = time.perf_counter()
-    logger.info("checkpoint workload=%s pids=%s", workload.key, pids)
+    logger.info("checkpoint workload=%s pids=%s", workload.name, pids)
     for pid in pids:
       lock_args = ["--action", "lock", "--pid", str(pid)]
       if self.timeout_ms is not None:
@@ -43,22 +43,22 @@ class CudaCheckpointRestorer:
       self.run_cuda_checkpoint(lock_args)
     for pid in pids:
       self.run_cuda_checkpoint(["--action", "checkpoint", "--pid", str(pid)])
-    self.checkpointed_pids[workload.key] = pids
-    logger.info("checkpoint workload=%s took %.0f ms", workload.key, (time.perf_counter() - start) * 1000)
+    self.checkpointed_pids[workload.name] = pids
+    logger.info("checkpoint workload=%s took %.0f ms", workload.name, (time.perf_counter() - start) * 1000)
     return True
 
   def restore(self, workload: WorkloadRef) -> None:
-    pids = self.checkpointed_pids.get(workload.key)
+    pids = self.checkpointed_pids.get(workload.name)
     if not pids:
-      raise RuntimeError(f"no checkpointed PIDs found for workload {workload.key}")
+      raise RuntimeError(f"no checkpointed PIDs found for workload {workload.name}")
     start = time.perf_counter()
-    logger.info("restore workload=%s pids=%s", workload.key, pids)
+    logger.info("restore workload=%s pids=%s", workload.name, pids)
     for pid in pids:
       self.run_cuda_checkpoint(["--action", "restore", "--pid", str(pid)])
     for pid in pids:
       self.run_cuda_checkpoint(["--action", "unlock", "--pid", str(pid)])
-    self.checkpointed_pids.pop(workload.key, None)
-    logger.info("restore workload=%s took %.0f ms", workload.key, (time.perf_counter() - start) * 1000)
+    self.checkpointed_pids.pop(workload.name, None)
+    logger.info("restore workload=%s took %.0f ms", workload.name, (time.perf_counter() - start) * 1000)
 
   def run_cuda_checkpoint(self, args: list[str]) -> None:
     full_argv = [self.cuda_checkpoint_bin, *args]

--- a/src/accel_timeslicer/llmd.py
+++ b/src/accel_timeslicer/llmd.py
@@ -18,7 +18,8 @@ class LlmDClient(Protocol):
 
 
 class LlmDCheckpointRestorer(CheckpointRestorer):
-  """CheckpointRestorer backed by llm-d's snapshot-agent Python client."""
+  """CheckpointRestorer backed by llm-d's snapshot-agent Python client.
+  llm-d calls the workload name job_id and the claim group."""
 
   def __init__(
     self,
@@ -32,16 +33,16 @@ class LlmDCheckpointRestorer(CheckpointRestorer):
 
   def checkpoint(self, workload: WorkloadRef) -> bool:
     result = self.client.snapshot_and_wait(
-      workload.job_id, group=workload.group, poll_interval_sec=self.poll_interval_sec, backend_config=self.backend_config
+      workload.name, group=workload.claim, poll_interval_sec=self.poll_interval_sec, backend_config=self.backend_config
     )
-    ensure_complete("snapshot", workload.job_id, result)
+    ensure_complete("snapshot", workload.name, result)
     return True
 
   def restore(self, workload: WorkloadRef) -> None:
     result = self.client.restore_and_wait(
-      workload.job_id, group=workload.group, poll_interval_sec=self.poll_interval_sec, backend_config=self.backend_config
+      workload.name, group=workload.claim, poll_interval_sec=self.poll_interval_sec, backend_config=self.backend_config
     )
-    ensure_complete("restore", workload.job_id, result)
+    ensure_complete("restore", workload.name, result)
 
 
 def ensure_complete(op: str, job_id: str, result: LlmDOperationResult) -> None:

--- a/src/accel_timeslicer/process_discovery.py
+++ b/src/accel_timeslicer/process_discovery.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from .workload import DEFAULT_TIME_SLICE_GROUP, WorkloadRef
 
 JOB_ID_ENV = "OPEN_RL_TIME_SLICE_JOB_ID"
+WORKLOAD_ID_ENV = "OPEN_RL_WORKLOAD_ID"
 GROUP_ENV = "OPEN_RL_TIME_SLICE_GROUP"
 
 
@@ -36,7 +37,8 @@ def workload_root_pid(pid: int, workload: WorkloadRef) -> int | None:
 
 def process_matches_workload(pid: int, workload: WorkloadRef) -> bool:
   env = process_environ(pid)
-  return env.get(JOB_ID_ENV) == workload.job_id and env.get(GROUP_ENV, DEFAULT_TIME_SLICE_GROUP) == workload.group
+  job_id = env.get(WORKLOAD_ID_ENV) or env.get(JOB_ID_ENV)
+  return job_id == workload.job_id and env.get(GROUP_ENV, DEFAULT_TIME_SLICE_GROUP) == workload.group
 
 
 def process_environ(pid: int) -> dict[str, str]:

--- a/src/accel_timeslicer/process_discovery.py
+++ b/src/accel_timeslicer/process_discovery.py
@@ -2,11 +2,10 @@ import os
 import subprocess
 from pathlib import Path
 
-from .workload import DEFAULT_TIME_SLICE_GROUP, WorkloadRef
+from .workload import WorkloadRef
 
-JOB_ID_ENV = "OPEN_RL_TIME_SLICE_JOB_ID"
 WORKLOAD_ID_ENV = "OPEN_RL_WORKLOAD_ID"
-GROUP_ENV = "OPEN_RL_TIME_SLICE_GROUP"
+JOB_ID_ENV = "OPEN_RL_TIME_SLICE_JOB_ID"  # older spelling
 
 
 def discover_workload_gpu_pids(workload: WorkloadRef) -> list[int]:
@@ -37,8 +36,7 @@ def workload_root_pid(pid: int, workload: WorkloadRef) -> int | None:
 
 def process_matches_workload(pid: int, workload: WorkloadRef) -> bool:
   env = process_environ(pid)
-  job_id = env.get(WORKLOAD_ID_ENV) or env.get(JOB_ID_ENV)
-  return job_id == workload.job_id and env.get(GROUP_ENV, DEFAULT_TIME_SLICE_GROUP) == workload.group
+  return (env.get(WORKLOAD_ID_ENV) or env.get(JOB_ID_ENV)) == workload.name
 
 
 def process_environ(pid: int) -> dict[str, str]:

--- a/src/accel_timeslicer/serve.py
+++ b/src/accel_timeslicer/serve.py
@@ -10,7 +10,7 @@ from typing import Any
 from .checkpoint import CudaCheckpointRestorer
 from .llmd import LlmDCheckpointRestorer
 from .single_node import SingleNodeTimeSlicer
-from .workload import DEFAULT_TIME_SLICE_GROUP, WorkloadRef
+from .workload import DEFAULT_CLAIM, WorkloadRef
 
 try:
   from timeslice.snapshot_agent import SnapshotAgentClient as LlmDClient
@@ -65,10 +65,11 @@ async def dispatch(time_slicer: SingleNodeTimeSlicer, line: bytes, connection_id
 
 
 def workload_from_payload(payload: dict[str, Any]) -> WorkloadRef:
-  job_id = payload.get("job_id") or payload.get("snapshot_id")
-  if job_id is None:
-    raise ValueError("workload requires job_id")
-  return WorkloadRef(job_id=job_id, group=payload.get("group") or DEFAULT_TIME_SLICE_GROUP)
+  # job_id and group are the older spellings, still sent by older workers.
+  name = payload.get("name") or payload.get("job_id") or payload.get("snapshot_id")
+  if name is None:
+    raise ValueError("workload requires a name")
+  return WorkloadRef(name, payload.get("claim") or payload.get("group") or DEFAULT_CLAIM)
 
 
 def parse_args() -> argparse.Namespace:

--- a/src/accel_timeslicer/serve.py
+++ b/src/accel_timeslicer/serve.py
@@ -68,10 +68,7 @@ def workload_from_payload(payload: dict[str, Any]) -> WorkloadRef:
   job_id = payload.get("job_id") or payload.get("snapshot_id")
   if job_id is None:
     raise ValueError("workload requires job_id")
-  return WorkloadRef(
-    job_id=job_id,
-    group=payload.get("group") or DEFAULT_TIME_SLICE_GROUP,
-  )
+  return WorkloadRef(job_id=job_id, group=payload.get("group") or DEFAULT_TIME_SLICE_GROUP)
 
 
 def parse_args() -> argparse.Namespace:

--- a/src/accel_timeslicer/single_node.py
+++ b/src/accel_timeslicer/single_node.py
@@ -21,7 +21,7 @@ class WorkloadState:
 
 
 class SingleNodeTimeSlicer(TimeSlicer):
-  """Grants accelerator turns. Groups are independent; within a group one
+  """Grants accelerator turns. Claims are independent; within a claim one
   workload holds the grant at a time. A release checkpoints the workload off
   the devices and its next acquire restores it."""
 
@@ -30,25 +30,25 @@ class SingleNodeTimeSlicer(TimeSlicer):
     self.scheduling_policy = scheduling_policy.lower()
     self.workloads: dict[str, WorkloadState] = {}
     self.waiting_workloads: deque[str] = deque()
-    # Per group, the workload holding the grant (acquire..release).
+    # Per claim, the workload holding the grant (acquire..release).
     self.running: dict[str, str] = {}
     self.condition = asyncio.Condition()
     self.last_release_time: dict[str, float] = {}
 
-  def next_waiter(self, group: str) -> str | None:
+  def next_waiter(self, claim: str) -> str | None:
     """The earliest waiter under fifo, the least recently served otherwise."""
-    waiting = [self.workloads[key].workload for key in self.waiting_workloads if self.workloads[key].workload.group == group]
+    waiting = [self.workloads[name].workload for name in self.waiting_workloads if self.workloads[name].workload.claim == claim]
     if not waiting:
       return None
     if self.scheduling_policy == "fifo" or len(waiting) == 1:
-      return waiting[0].key
-    return min(waiting, key=lambda w: self.last_release_time.get(w.key, 0.0)).key
+      return waiting[0].name
+    return min(waiting, key=lambda w: self.last_release_time.get(w.name, 0.0)).name
 
   async def register(self, workload: WorkloadRef, connection_id: int | None = None) -> dict[str, Any]:
     async with self.condition:
-      state = self.workloads.get(workload.key)
+      state = self.workloads.get(workload.name)
       if state is None:
-        self.workloads[workload.key] = WorkloadState(connection_id=connection_id, workload=workload)
+        self.workloads[workload.name] = WorkloadState(connection_id=connection_id, workload=workload)
       else:
         # A registration is a live process announcing itself, so a failure
         # recorded against an earlier process under this name is cleared.
@@ -60,40 +60,40 @@ class SingleNodeTimeSlicer(TimeSlicer):
 
   async def acquire(self, workload: WorkloadRef) -> dict[str, Any]:
     async with self.condition:
-      key, group = workload.key, workload.group
-      state = self.workloads.get(key)
+      name, claim = workload.name, workload.claim
+      state = self.workloads.get(name)
       if state is None:
         state = WorkloadState(connection_id=None, workload=workload)
-        self.workloads[key] = state
+        self.workloads[name] = state
       if state.failed:
-        return {"ok": False, "error": f"workload {key} is failed"}
-      if key in self.waiting_workloads or self.running.get(group) == key:
-        return {"ok": False, "error": f"workload {key} already has a pending or active acquire"}
+        return {"ok": False, "error": f"workload {name} is failed"}
+      if name in self.waiting_workloads or self.running.get(claim) == name:
+        return {"ok": False, "error": f"workload {name} already has a pending or active acquire"}
 
-      self.waiting_workloads.append(key)
+      self.waiting_workloads.append(name)
       try:
-        while key in self.waiting_workloads and (group in self.running or self.next_waiter(group) != key):
+        while name in self.waiting_workloads and (claim in self.running or self.next_waiter(claim) != name):
           await self.condition.wait()
       except BaseException:
-        if key in self.waiting_workloads:
-          self.waiting_workloads.remove(key)
+        if name in self.waiting_workloads:
+          self.waiting_workloads.remove(name)
         self.condition.notify_all()
         raise
 
-      state = self.workloads.get(key)
-      if state is None or state.failed or key not in self.waiting_workloads:
-        self.clear_workload(key)
+      state = self.workloads.get(name)
+      if state is None or state.failed or name not in self.waiting_workloads:
+        self.clear_workload(name)
         self.condition.notify_all()
-        return {"ok": False, "error": f"workload {key} is not available"}
+        return {"ok": False, "error": f"workload {name} is not available"}
 
-      self.waiting_workloads.remove(key)
-      self.running[group] = key
+      self.waiting_workloads.remove(name)
+      self.running[claim] = name
       self.condition.notify_all()
 
     if state.checkpointed:
       await self.run_restore(state)
       async with self.condition:
-        state = self.workloads.get(key)
+        state = self.workloads.get(name)
         if state is not None:
           state.checkpointed = False
         self.condition.notify_all()
@@ -101,52 +101,52 @@ class SingleNodeTimeSlicer(TimeSlicer):
 
   async def release(self, workload: WorkloadRef) -> dict[str, Any]:
     async with self.condition:
-      key, group = workload.key, workload.group
-      state = self.workloads.get(key)
-      if state is None or self.running.get(group) != key:
-        return {"ok": False, "error": f"workload {key} does not hold an active acquire"}
+      name, claim = workload.name, workload.claim
+      state = self.workloads.get(name)
+      if state is None or self.running.get(claim) != name:
+        return {"ok": False, "error": f"workload {name} does not hold an active acquire"}
 
     # The grant is held through the checkpoint, so the next waiter is not
     # granted until this workload is off the devices.
     checkpointed = await self.run_checkpoint(state)
 
     async with self.condition:
-      state = self.workloads.get(key)
+      state = self.workloads.get(name)
       if state is not None:
         state.checkpointed = checkpointed is not False
-      self.last_release_time[workload.key] = time.time()
-      self.clear_workload(key)
+      self.last_release_time[workload.name] = time.time()
+      self.clear_workload(name)
       self.condition.notify_all()
       return {"ok": True}
 
   async def unregister(self, workload: WorkloadRef) -> dict[str, Any]:
     async with self.condition:
-      key = workload.key
-      if key not in self.workloads:
-        return {"ok": False, "error": f"workload {key} is not registered"}
+      name = workload.name
+      if name not in self.workloads:
+        return {"ok": False, "error": f"workload {name} is not registered"}
 
-      self.clear_workload(key)
-      del self.workloads[key]
+      self.clear_workload(name)
+      del self.workloads[name]
       self.condition.notify_all()
       return {"ok": True}
 
   async def connection_closed(self, connection_id: int) -> None:
     async with self.condition:
-      for key, state in self.workloads.items():
+      for name, state in self.workloads.items():
         if state.connection_id != connection_id:
           continue
-        self.clear_workload(key)
+        self.clear_workload(name)
         state.failed = True
         state.checkpointed = False
         state.connection_id = None
       self.condition.notify_all()
 
-  def clear_workload(self, key: str) -> None:
-    if key in self.waiting_workloads:
-      self.waiting_workloads.remove(key)
-    for group, holder in list(self.running.items()):
-      if holder == key:
-        del self.running[group]
+  def clear_workload(self, name: str) -> None:
+    if name in self.waiting_workloads:
+      self.waiting_workloads.remove(name)
+    for claim, holder in list(self.running.items()):
+      if holder == name:
+        del self.running[claim]
 
   async def run_checkpoint(self, state: WorkloadState) -> bool | None:
     workload = state.workload
@@ -154,12 +154,12 @@ class SingleNodeTimeSlicer(TimeSlicer):
     try:
       checkpointed = await asyncio.to_thread(self.restorer.checkpoint, workload)
       if checkpointed is False:
-        logger.info("released workload %s group %s without checkpoint in %.2fs", workload.key, workload.group, time.monotonic() - start)
+        logger.info("released workload %s claim %s without checkpoint in %.2fs", workload.name, workload.claim, time.monotonic() - start)
       else:
-        logger.info("checkpointed workload %s group %s in %.2fs", workload.key, workload.group, time.monotonic() - start)
+        logger.info("checkpointed workload %s claim %s in %.2fs", workload.name, workload.claim, time.monotonic() - start)
       return checkpointed
     except Exception as exc:
-      logger.warning("checkpoint failed for workload %s group %s: %s", workload.key, workload.group, exc)
+      logger.warning("checkpoint failed for workload %s claim %s: %s", workload.name, workload.claim, exc)
       return False
 
   async def run_restore(self, state: WorkloadState) -> None:
@@ -167,6 +167,6 @@ class SingleNodeTimeSlicer(TimeSlicer):
     start = time.monotonic()
     try:
       await asyncio.to_thread(self.restorer.restore, workload)
-      logger.info("restored workload %s group %s in %.2fs", workload.key, workload.group, time.monotonic() - start)
+      logger.info("restored workload %s claim %s in %.2fs", workload.name, workload.claim, time.monotonic() - start)
     except Exception as exc:
-      logger.warning("restore failed for workload %s group %s: %s", workload.key, workload.group, exc)
+      logger.warning("restore failed for workload %s claim %s: %s", workload.name, workload.claim, exc)

--- a/src/accel_timeslicer/single_node.py
+++ b/src/accel_timeslicer/single_node.py
@@ -21,56 +21,58 @@ class WorkloadState:
 
 
 class SingleNodeTimeSlicer(TimeSlicer):
+  """Grants accelerator turns. Groups are independent; within a group one
+  workload holds the grant at a time. A release checkpoints the workload off
+  the devices and its next acquire restores it."""
+
   def __init__(self, restorer: CheckpointRestorer, scheduling_policy: str = "lrs"):
     self.restorer = restorer
     self.scheduling_policy = scheduling_policy.lower()
     self.workloads: dict[str, WorkloadState] = {}
     self.waiting_workloads: deque[str] = deque()
-    self.active_workload: str | None = None
+    # Per group, the workload holding the grant (acquire..release).
+    self.running: dict[str, str] = {}
     self.condition = asyncio.Condition()
     self.last_release_time: dict[str, float] = {}
 
-  def _get_next_workload_key(self) -> str | None:
-    if not self.waiting_workloads:
+  def next_waiter(self, group: str) -> str | None:
+    """The earliest waiter under fifo, the least recently served otherwise."""
+    waiting = [self.workloads[key].workload for key in self.waiting_workloads if self.workloads[key].workload.group == group]
+    if not waiting:
       return None
-    if self.scheduling_policy == "fifo" or len(self.waiting_workloads) == 1:
-      return self.waiting_workloads[0]
-    best_key = None
-    oldest_time = float("inf")
-    for key in self.waiting_workloads:
-      t = self.last_release_time.get(key, 0.0)
-      if t < oldest_time:
-        oldest_time = t
-        best_key = key
-    return best_key or self.waiting_workloads[0]
+    if self.scheduling_policy == "fifo" or len(waiting) == 1:
+      return waiting[0].key
+    return min(waiting, key=lambda w: self.last_release_time.get(w.key, 0.0)).key
 
   async def register(self, workload: WorkloadRef, connection_id: int | None = None) -> dict[str, Any]:
     async with self.condition:
-      key = workload.key
-      if key in self.workloads:
-        self.workloads[key].connection_id = connection_id
-        self.workloads[key].workload = workload
-        return {"ok": True}
-
-      self.workloads[key] = WorkloadState(connection_id=connection_id, workload=workload)
+      state = self.workloads.get(workload.key)
+      if state is None:
+        self.workloads[workload.key] = WorkloadState(connection_id=connection_id, workload=workload)
+      else:
+        # A registration is a live process announcing itself, so a failure
+        # recorded against an earlier process under this name is cleared.
+        state.connection_id = connection_id
+        state.workload = workload
+        state.failed = False
       self.condition.notify_all()
       return {"ok": True}
 
   async def acquire(self, workload: WorkloadRef) -> dict[str, Any]:
     async with self.condition:
-      key = workload.key
+      key, group = workload.key, workload.group
       state = self.workloads.get(key)
       if state is None:
         state = WorkloadState(connection_id=None, workload=workload)
         self.workloads[key] = state
       if state.failed:
         return {"ok": False, "error": f"workload {key} is failed"}
-      if key in self.waiting_workloads or self.active_workload == key:
+      if key in self.waiting_workloads or self.running.get(group) == key:
         return {"ok": False, "error": f"workload {key} already has a pending or active acquire"}
 
       self.waiting_workloads.append(key)
       try:
-        while self.active_workload is not None or (key in self.waiting_workloads and self._get_next_workload_key() != key):
+        while key in self.waiting_workloads and (group in self.running or self.next_waiter(group) != key):
           await self.condition.wait()
       except BaseException:
         if key in self.waiting_workloads:
@@ -85,13 +87,13 @@ class SingleNodeTimeSlicer(TimeSlicer):
         return {"ok": False, "error": f"workload {key} is not available"}
 
       self.waiting_workloads.remove(key)
-      self.active_workload = key
+      self.running[group] = key
       self.condition.notify_all()
 
     if state.checkpointed:
       await self.run_restore(state)
       async with self.condition:
-        state = self.workloads.get(workload.key)
+        state = self.workloads.get(key)
         if state is not None:
           state.checkpointed = False
         self.condition.notify_all()
@@ -99,22 +101,21 @@ class SingleNodeTimeSlicer(TimeSlicer):
 
   async def release(self, workload: WorkloadRef) -> dict[str, Any]:
     async with self.condition:
-      key = workload.key
+      key, group = workload.key, workload.group
       state = self.workloads.get(key)
-      if state is None:
-        state = WorkloadState(connection_id=None, workload=workload)
-        self.workloads[key] = state
-      if self.active_workload != key:
+      if state is None or self.running.get(group) != key:
         return {"ok": False, "error": f"workload {key} does not hold an active acquire"}
 
+    # The grant is held through the checkpoint, so the next waiter is not
+    # granted until this workload is off the devices.
     checkpointed = await self.run_checkpoint(state)
 
     async with self.condition:
-      state = self.workloads.get(workload.key)
+      state = self.workloads.get(key)
       if state is not None:
         state.checkpointed = checkpointed is not False
       self.last_release_time[workload.key] = time.time()
-      self.clear_workload(workload.key)
+      self.clear_workload(key)
       self.condition.notify_all()
       return {"ok": True}
 
@@ -143,8 +144,9 @@ class SingleNodeTimeSlicer(TimeSlicer):
   def clear_workload(self, key: str) -> None:
     if key in self.waiting_workloads:
       self.waiting_workloads.remove(key)
-    if self.active_workload == key:
-      self.active_workload = None
+    for group, holder in list(self.running.items()):
+      if holder == key:
+        del self.running[group]
 
   async def run_checkpoint(self, state: WorkloadState) -> bool | None:
     workload = state.workload

--- a/src/accel_timeslicer/time_slicer.py
+++ b/src/accel_timeslicer/time_slicer.py
@@ -5,7 +5,7 @@ from collections.abc import AsyncIterator
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from typing import Any, Protocol
 
-from .workload import DEFAULT_TIME_SLICE_GROUP, WorkloadRef
+from .workload import DEFAULT_CLAIM, WorkloadRef
 
 DEFAULT_SOCKET_PATH = "/tmp/open-rl/accel-timeslicer.sock"
 DEFAULT_TCP_PORT = 9753
@@ -104,19 +104,18 @@ class SocketTimeSlicerClient:
       raise
 
 
-def workload_from_env(pid: int | None = None, job_id: str | None = None, group: str = DEFAULT_TIME_SLICE_GROUP) -> WorkloadRef:
-  # The launcher's stamps win over the caller's defaults. The scheduler sets
-  # the group to the ResourceClaim name and OPEN_RL_WORKLOAD_ID to the
-  # Workload name; TIME_SLICE_JOB_ID is the older spelling, kept as a fallback.
-  group = os.getenv("OPEN_RL_TIME_SLICE_GROUP") or group
-  env_job_id = os.getenv("OPEN_RL_WORKLOAD_ID") or os.getenv("OPEN_RL_TIME_SLICE_JOB_ID")
-  if env_job_id:
-    return WorkloadRef(job_id=env_job_id, group=group)
-  if job_id:
-    return WorkloadRef(job_id=job_id, group=group)
+def workload_from_env(pid: int | None = None, name: str | None = None, claim: str = DEFAULT_CLAIM) -> WorkloadRef:
+  # The launcher's stamps win over the caller's defaults. OPEN_RL_TIME_SLICE_GROUP
+  # and OPEN_RL_TIME_SLICE_JOB_ID are the older spellings the scheduler still stamps.
+  claim = os.getenv("OPEN_RL_CLAIM") or os.getenv("OPEN_RL_TIME_SLICE_GROUP") or claim
+  env_name = os.getenv("OPEN_RL_WORKLOAD_ID") or os.getenv("OPEN_RL_TIME_SLICE_JOB_ID")
+  if env_name:
+    return WorkloadRef(env_name, claim)
+  if name:
+    return WorkloadRef(name, claim)
   if pid is None:
-    raise ValueError("workload requires job_id")
-  return WorkloadRef(job_id=str(pid), group=group)
+    raise ValueError("workload requires a name")
+  return WorkloadRef(str(pid), claim)
 
 
 def time_slicer_client_from_env() -> TimeSlicerClient:

--- a/src/accel_timeslicer/time_slicer.py
+++ b/src/accel_timeslicer/time_slicer.py
@@ -105,7 +105,11 @@ class SocketTimeSlicerClient:
 
 
 def workload_from_env(pid: int | None = None, job_id: str | None = None, group: str = DEFAULT_TIME_SLICE_GROUP) -> WorkloadRef:
-  env_job_id = os.getenv("OPEN_RL_TIME_SLICE_JOB_ID")
+  # The launcher's stamps win over the caller's defaults. The scheduler sets
+  # the group to the ResourceClaim name and OPEN_RL_WORKLOAD_ID to the
+  # Workload name; TIME_SLICE_JOB_ID is the older spelling, kept as a fallback.
+  group = os.getenv("OPEN_RL_TIME_SLICE_GROUP") or group
+  env_job_id = os.getenv("OPEN_RL_WORKLOAD_ID") or os.getenv("OPEN_RL_TIME_SLICE_JOB_ID")
   if env_job_id:
     return WorkloadRef(job_id=env_job_id, group=group)
   if job_id:

--- a/src/accel_timeslicer/workload.py
+++ b/src/accel_timeslicer/workload.py
@@ -11,6 +11,10 @@ def workload_job_id(role: str, model_id: str) -> str:
 
 @dataclass(frozen=True)
 class WorkloadRef:
+  """One process's identity to the time slicer, in the snapshot agent's words.
+  job_id is the timeslice.io/job-id pod label (under the scheduler, the
+  Workload name) and group is the devices it shares (the ResourceClaim)."""
+
   job_id: str
   group: str = DEFAULT_TIME_SLICE_GROUP
 

--- a/src/accel_timeslicer/workload.py
+++ b/src/accel_timeslicer/workload.py
@@ -1,30 +1,32 @@
 from dataclasses import dataclass
 
-DEFAULT_TIME_SLICE_GROUP = "shared-accelerator"
-TRAINER_TIME_SLICE_GROUP = "trainers"
-SAMPLER_TIME_SLICE_GROUP = "samplers"
+DEFAULT_CLAIM = "shared-accelerator"
+TRAINER_CLAIM = "trainers"
+SAMPLER_CLAIM = "samplers"
 
 
-def workload_job_id(role: str, model_id: str) -> str:
+def local_workload_name(role: str, model_id: str) -> str:
   return f"{role}-{model_id}"
+
+
+# Old names, until the launchers stop using them.
+DEFAULT_TIME_SLICE_GROUP = DEFAULT_CLAIM
+TRAINER_TIME_SLICE_GROUP = TRAINER_CLAIM
+SAMPLER_TIME_SLICE_GROUP = SAMPLER_CLAIM
+workload_job_id = local_workload_name
 
 
 @dataclass(frozen=True)
 class WorkloadRef:
-  """One process's identity to the time slicer, in the snapshot agent's words.
-  job_id is the timeslice.io/job-id pod label (under the scheduler, the
-  Workload name) and group is the devices it shares (the ResourceClaim)."""
+  """One process's identity to the time slicer. name is the Workload name
+  (the timeslice.io/job-id pod label); claim is the devices it shares."""
 
-  job_id: str
-  group: str = DEFAULT_TIME_SLICE_GROUP
+  name: str
+  claim: str = DEFAULT_CLAIM
 
   def __post_init__(self) -> None:
-    if not self.job_id:
-      raise ValueError("workload requires job_id")
-
-  @property
-  def key(self) -> str:
-    return f"{self.group}:{self.job_id}"
+    if not self.name:
+      raise ValueError("workload requires a name")
 
   def as_payload(self) -> dict[str, str]:
-    return {"job_id": self.job_id, "group": self.group}
+    return {"name": self.name, "claim": self.claim}

--- a/src/server/training_requests_processor.py
+++ b/src/server/training_requests_processor.py
@@ -15,7 +15,7 @@ from opentelemetry import context as otel_context
 from opentelemetry import propagate, trace
 
 from accel_timeslicer.time_slicer import TimeSlicerClient, time_slicer_client_from_env, workload_from_env
-from accel_timeslicer.workload import TRAINER_TIME_SLICE_GROUP, workload_job_id
+from accel_timeslicer.workload import TRAINER_CLAIM, local_workload_name
 from server.store import RequestStore, get_store
 from training.fft_trainer_worker import FFTConfig, FFTTrainingWorker
 from training.lora_trainer_worker import LoraConfig, LoraTrainingWorker
@@ -306,7 +306,7 @@ class FFTTrainingRequestsProcessor(TrainingRequestsProcessor):
     self.store = store
     self.worker = worker
     self.model_id = model_id
-    self.workload = workload_from_env(os.getpid(), job_id=workload_job_id("trainer", model_id), group=TRAINER_TIME_SLICE_GROUP)
+    self.workload = workload_from_env(os.getpid(), name=local_workload_name("trainer", model_id), claim=TRAINER_CLAIM)
     self.time_slicer = time_slicer
     self.snapshot_registered = False
 

--- a/src/server/vllm_sampler.py
+++ b/src/server/vllm_sampler.py
@@ -66,7 +66,7 @@ def is_fft_enabled() -> bool:
 time_slicer: Any = None
 if is_fft_enabled():
   from accel_timeslicer.time_slicer import time_slicer_client_from_env, workload_from_env
-  from accel_timeslicer.workload import SAMPLER_TIME_SLICE_GROUP, workload_job_id
+  from accel_timeslicer.workload import SAMPLER_CLAIM, local_workload_name
 
   time_slicer = time_slicer_client_from_env()
 
@@ -302,12 +302,12 @@ async def run_sampling_worker(model_id: str) -> None:
   snapshot_registered = False
   workload = None
   if time_slicer is not None:
-    workload = workload_from_env(os.getpid(), job_id=workload_job_id("sampler", model_id), group=SAMPLER_TIME_SLICE_GROUP)
+    workload = workload_from_env(os.getpid(), name=local_workload_name("sampler", model_id), claim=SAMPLER_CLAIM)
 
   if time_slicer is not None:
     assert workload is not None
     try:
-      print(f"[vLLM Worker] Registering workload {workload.key} for initialization lock...")
+      print(f"[vLLM Worker] Registering workload {workload.name} for initialization lock...")
       await time_slicer.register(workload)
       snapshot_registered = True
       async with time_slicer.acquire(workload):

--- a/tests/test_accel_timeslicer.py
+++ b/tests/test_accel_timeslicer.py
@@ -303,7 +303,7 @@ class SingleNodeTimeSlicerSocketTest(unittest.IsolatedAsyncioTestCase):
       server.close()
       await server.wait_closed()
 
-  async def test_env_client_registers_time_slice_job_id(self) -> None:
+  async def test_env_client_registers_time_slice_job_id_and_group(self) -> None:
     restorer = RecordingRestorer()
     agent = SingleNodeTimeSlicer(restorer)
     server = await start_tcp_time_slicer(agent, "127.0.0.1", 0)
@@ -312,7 +312,8 @@ class SingleNodeTimeSlicerSocketTest(unittest.IsolatedAsyncioTestCase):
       "OPEN_RL_ACCEL_TIMESLICER_HOST": "127.0.0.1",
       "OPEN_RL_ACCEL_TIMESLICER_PORT": str(port),
       "OPEN_RL_TIME_SLICE_JOB_ID": "job-a",
-      "OPEN_RL_TIME_SLICE_GROUP": "ignored-group",
+      # The launcher's stamp wins: under the scheduler this is the claim name.
+      "OPEN_RL_TIME_SLICE_GROUP": "claim-a",
     }
     with patch.dict("os.environ", env, clear=True):
       client = time_slicer_client_from_env()
@@ -321,19 +322,33 @@ class SingleNodeTimeSlicerSocketTest(unittest.IsolatedAsyncioTestCase):
       await client.register(workload)
       async with client.acquire(workload):
         pass
+      # A successor in the same group forces the handoff, which must name the
+      # env-derived job id and group to the backend.
+      successor = WorkloadRef(job_id="job-b", group="claim-a")
+      await client.register(successor)
+      async with client.acquire(successor):
+        pass
 
-      self.assertEqual(restorer.labels(), [("checkpoint", "job-a", "shared-accelerator")])
+      self.assertEqual(restorer.labels(), [("checkpoint", "job-a", "claim-a"), ("checkpoint", "job-b", "claim-a")])
     finally:
       await client.close()
       server.close()
       await server.wait_closed()
 
-  async def test_workload_from_env_uses_fixed_group_and_model_id_when_job_id_env_is_absent(self) -> None:
-    with patch.dict("os.environ", {"OPEN_RL_TIME_SLICE_GROUP": "ignored-group"}, clear=True):
+  async def test_workload_from_env_prefers_the_launchers_group(self) -> None:
+    env = {"OPEN_RL_TIME_SLICE_GROUP": "claim-a"}
+    with patch.dict("os.environ", env, clear=True):
       workload = workload_from_env(101, job_id="model-a")
 
     self.assertEqual(workload.job_id, "model-a")
-    self.assertEqual(workload.group, "shared-accelerator")
+    self.assertEqual(workload.group, "claim-a")
+
+  async def test_workload_from_env_falls_back_to_the_callers_group(self) -> None:
+    with patch.dict("os.environ", {}, clear=True):
+      workload = workload_from_env(101, job_id="model-a", group="trainers")
+
+    self.assertEqual(workload.job_id, "model-a")
+    self.assertEqual(workload.group, "trainers")
 
 
 class CudaCheckpointRestorerTest(unittest.TestCase):

--- a/tests/test_accel_timeslicer.py
+++ b/tests/test_accel_timeslicer.py
@@ -26,10 +26,10 @@ class RecordingRestorer:
     self.calls.append(("restore", target))
 
   def labels(self) -> list[tuple[str, str, str]]:
-    return [(op, target.job_id, target.group) for op, target in self.calls]
+    return [(op, target.name, target.claim) for op, target in self.calls]
 
   def simple_labels(self) -> list[tuple[str, str]]:
-    return [(op, target.job_id) for op, target in self.calls]
+    return [(op, target.name) for op, target in self.calls]
 
 
 class BlockingRestorer(RecordingRestorer):
@@ -65,73 +65,73 @@ class SingleNodeTimeSlicerTest(unittest.IsolatedAsyncioTestCase):
   async def test_agent_grants_only_one_active_process_at_a_time(self) -> None:
     restorer = RecordingRestorer()
     agent = SingleNodeTimeSlicer(restorer)
-    await agent.register(WorkloadRef(job_id="101"))
-    await agent.register(WorkloadRef(job_id="202"))
+    await agent.register(WorkloadRef(name="101"))
+    await agent.register(WorkloadRef(name="202"))
 
-    self.assertTrue((await agent.acquire(WorkloadRef(job_id="101")))["ok"])
-    blocked = asyncio.create_task(agent.acquire(WorkloadRef(job_id="202")))
+    self.assertTrue((await agent.acquire(WorkloadRef(name="101")))["ok"])
+    blocked = asyncio.create_task(agent.acquire(WorkloadRef(name="202")))
     await asyncio.sleep(0.05)
     self.assertFalse(blocked.done())
 
-    release = await agent.release(WorkloadRef(job_id="101"))
+    release = await agent.release(WorkloadRef(name="101"))
     self.assertTrue(release["ok"])
     granted_b = await asyncio.wait_for(blocked, timeout=1.0)
     self.assertTrue(granted_b["ok"])
     self.assertEqual(restorer.simple_labels(), [("checkpoint", "101")])
-    self.assertEqual(agent.running, {"shared-accelerator": "shared-accelerator:202"})
+    self.assertEqual(agent.running, {"shared-accelerator": "202"})
 
   async def test_groups_do_not_wait_on_each_other(self) -> None:
     restorer = RecordingRestorer()
     agent = SingleNodeTimeSlicer(restorer)
-    claim_a = WorkloadRef(job_id="trainer-a", group="claim-a")
-    claim_b = WorkloadRef(job_id="trainer-b", group="claim-b")
+    claim_a = WorkloadRef(name="trainer-a", claim="claim-a")
+    claim_b = WorkloadRef(name="trainer-b", claim="claim-b")
     await agent.register(claim_a)
     await agent.register(claim_b)
 
     self.assertTrue((await agent.acquire(claim_a))["ok"])
     granted = await asyncio.wait_for(agent.acquire(claim_b), timeout=1.0)
     self.assertTrue(granted["ok"])
-    self.assertEqual(agent.running, {"claim-a": "claim-a:trainer-a", "claim-b": "claim-b:trainer-b"})
+    self.assertEqual(agent.running, {"claim-a": "trainer-a", "claim-b": "trainer-b"})
 
   async def test_first_acquire_is_cold_and_later_acquire_restores_after_checkpoint(self) -> None:
     restorer = RecordingRestorer()
     agent = SingleNodeTimeSlicer(restorer)
-    await agent.register(WorkloadRef(job_id="101"))
-    await agent.register(WorkloadRef(job_id="202"))
+    await agent.register(WorkloadRef(name="101"))
+    await agent.register(WorkloadRef(name="202"))
 
-    self.assertTrue((await agent.acquire(WorkloadRef(job_id="101")))["ok"])
-    self.assertTrue((await agent.release(WorkloadRef(job_id="101")))["ok"])
+    self.assertTrue((await agent.acquire(WorkloadRef(name="101")))["ok"])
+    self.assertTrue((await agent.release(WorkloadRef(name="101")))["ok"])
     self.assertEqual(restorer.simple_labels(), [("checkpoint", "101")])
 
-    self.assertTrue((await agent.acquire(WorkloadRef(job_id="202")))["ok"])
-    self.assertTrue((await agent.release(WorkloadRef(job_id="202")))["ok"])
-    self.assertTrue((await agent.acquire(WorkloadRef(job_id="101")))["ok"])
+    self.assertTrue((await agent.acquire(WorkloadRef(name="202")))["ok"])
+    self.assertTrue((await agent.release(WorkloadRef(name="202")))["ok"])
+    self.assertTrue((await agent.acquire(WorkloadRef(name="101")))["ok"])
 
     self.assertEqual(restorer.simple_labels(), [("checkpoint", "101"), ("checkpoint", "202"), ("restore", "101")])
 
   async def test_release_with_no_waiters_checkpoints_process(self) -> None:
     restorer = RecordingRestorer()
     agent = SingleNodeTimeSlicer(restorer)
-    await agent.register(WorkloadRef(job_id="101"))
+    await agent.register(WorkloadRef(name="101"))
 
-    self.assertTrue((await agent.acquire(WorkloadRef(job_id="101")))["ok"])
-    release = await agent.release(WorkloadRef(job_id="101"))
+    self.assertTrue((await agent.acquire(WorkloadRef(name="101")))["ok"])
+    release = await agent.release(WorkloadRef(name="101"))
 
     self.assertTrue(release["ok"])
     self.assertFalse(agent.running)
-    self.assertTrue(agent.workloads["shared-accelerator:101"].checkpointed)
-    self.assertFalse(agent.workloads["shared-accelerator:101"].failed)
+    self.assertTrue(agent.workloads["101"].checkpointed)
+    self.assertFalse(agent.workloads["101"].failed)
     self.assertEqual(restorer.simple_labels(), [("checkpoint", "101")])
 
   async def test_release_without_snapshot_does_not_restore_later(self) -> None:
     restorer = NoSnapshotRestorer()
     agent = SingleNodeTimeSlicer(restorer)
-    workload = WorkloadRef(job_id="101")
+    workload = WorkloadRef(name="101")
 
     await agent.register(workload)
     self.assertTrue((await agent.acquire(workload))["ok"])
     self.assertTrue((await agent.release(workload))["ok"])
-    self.assertFalse(agent.workloads[workload.key].checkpointed)
+    self.assertFalse(agent.workloads[workload.name].checkpointed)
 
     self.assertTrue((await agent.acquire(workload))["ok"])
 
@@ -141,16 +141,16 @@ class SingleNodeTimeSlicerTest(unittest.IsolatedAsyncioTestCase):
     restorer = BlockingRestorer()
     restorer.block_checkpoint = True
     agent = SingleNodeTimeSlicer(restorer)
-    await agent.register(WorkloadRef(job_id="101"))
-    await agent.register(WorkloadRef(job_id="202"))
+    await agent.register(WorkloadRef(name="101"))
+    await agent.register(WorkloadRef(name="202"))
 
-    self.assertTrue((await agent.acquire(WorkloadRef(job_id="101")))["ok"])
-    release_a = asyncio.create_task(agent.release(WorkloadRef(job_id="101")))
+    self.assertTrue((await agent.acquire(WorkloadRef(name="101")))["ok"])
+    release_a = asyncio.create_task(agent.release(WorkloadRef(name="101")))
 
     checkpoint_started = await asyncio.to_thread(restorer.checkpoint_started.wait, 1.0)
     self.assertTrue(checkpoint_started)
 
-    acquire_b = asyncio.create_task(agent.acquire(WorkloadRef(job_id="202")))
+    acquire_b = asyncio.create_task(agent.acquire(WorkloadRef(name="202")))
     await asyncio.sleep(0.05)
     self.assertFalse(release_a.done())
     self.assertFalse(acquire_b.done())
@@ -164,13 +164,13 @@ class SingleNodeTimeSlicerTest(unittest.IsolatedAsyncioTestCase):
   async def test_checkpointed_process_is_not_granted_until_restore_finishes(self) -> None:
     restorer = BlockingRestorer()
     agent = SingleNodeTimeSlicer(restorer)
-    await agent.register(WorkloadRef(job_id="101"))
+    await agent.register(WorkloadRef(name="101"))
 
-    self.assertTrue((await agent.acquire(WorkloadRef(job_id="101")))["ok"])
-    self.assertTrue((await agent.release(WorkloadRef(job_id="101")))["ok"])
+    self.assertTrue((await agent.acquire(WorkloadRef(name="101")))["ok"])
+    self.assertTrue((await agent.release(WorkloadRef(name="101")))["ok"])
 
     restorer.block_restore = True
-    acquire_a = asyncio.create_task(agent.acquire(WorkloadRef(job_id="101")))
+    acquire_a = asyncio.create_task(agent.acquire(WorkloadRef(name="101")))
 
     restore_started = await asyncio.to_thread(restorer.restore_started.wait, 1.0)
     self.assertTrue(restore_started)
@@ -179,21 +179,21 @@ class SingleNodeTimeSlicerTest(unittest.IsolatedAsyncioTestCase):
     restorer.finish_restore.set()
 
     self.assertTrue((await asyncio.wait_for(acquire_a, timeout=1.0))["ok"])
-    self.assertFalse(agent.workloads["shared-accelerator:101"].checkpointed)
+    self.assertFalse(agent.workloads["101"].checkpointed)
     self.assertEqual(restorer.simple_labels(), [("checkpoint", "101"), ("restore", "101")])
 
   async def test_unregister_waiting_process_prevents_later_grant(self) -> None:
     agent = SingleNodeTimeSlicer(RecordingRestorer())
-    await agent.register(WorkloadRef(job_id="101"))
-    await agent.register(WorkloadRef(job_id="202"))
+    await agent.register(WorkloadRef(name="101"))
+    await agent.register(WorkloadRef(name="202"))
 
-    self.assertTrue((await agent.acquire(WorkloadRef(job_id="101")))["ok"])
-    acquire_b = asyncio.create_task(agent.acquire(WorkloadRef(job_id="202")))
+    self.assertTrue((await agent.acquire(WorkloadRef(name="101")))["ok"])
+    acquire_b = asyncio.create_task(agent.acquire(WorkloadRef(name="202")))
     await asyncio.sleep(0.05)
     self.assertFalse(acquire_b.done())
 
-    self.assertTrue((await agent.unregister(WorkloadRef(job_id="202")))["ok"])
-    self.assertTrue((await agent.release(WorkloadRef(job_id="101")))["ok"])
+    self.assertTrue((await agent.unregister(WorkloadRef(name="202")))["ok"])
+    self.assertTrue((await agent.release(WorkloadRef(name="101")))["ok"])
 
     result = await asyncio.wait_for(acquire_b, timeout=1.0)
     self.assertFalse(result["ok"])
@@ -201,27 +201,27 @@ class SingleNodeTimeSlicerTest(unittest.IsolatedAsyncioTestCase):
 
   async def test_duplicate_commands_return_explicit_errors(self) -> None:
     agent = SingleNodeTimeSlicer(RecordingRestorer())
-    await agent.register(WorkloadRef(job_id="101"))
+    await agent.register(WorkloadRef(name="101"))
 
-    self.assertTrue((await agent.register(WorkloadRef(job_id="101")))["ok"])
-    self.assertTrue((await agent.acquire(WorkloadRef(job_id="101")))["ok"])
-    self.assertFalse((await agent.acquire(WorkloadRef(job_id="101")))["ok"])
-    self.assertTrue((await agent.release(WorkloadRef(job_id="101")))["ok"])
-    self.assertFalse((await agent.release(WorkloadRef(job_id="101")))["ok"])
-    self.assertTrue((await agent.unregister(WorkloadRef(job_id="101")))["ok"])
-    self.assertFalse((await agent.unregister(WorkloadRef(job_id="101")))["ok"])
+    self.assertTrue((await agent.register(WorkloadRef(name="101")))["ok"])
+    self.assertTrue((await agent.acquire(WorkloadRef(name="101")))["ok"])
+    self.assertFalse((await agent.acquire(WorkloadRef(name="101")))["ok"])
+    self.assertTrue((await agent.release(WorkloadRef(name="101")))["ok"])
+    self.assertFalse((await agent.release(WorkloadRef(name="101")))["ok"])
+    self.assertTrue((await agent.unregister(WorkloadRef(name="101")))["ok"])
+    self.assertFalse((await agent.unregister(WorkloadRef(name="101")))["ok"])
 
   async def test_waiters_are_granted_in_fifo_order(self) -> None:
     agent = SingleNodeTimeSlicer(RecordingRestorer())
     for pid in [101, 202, 303, 404]:
-      await agent.register(WorkloadRef(job_id=str(pid)))
+      await agent.register(WorkloadRef(name=str(pid)))
 
-    self.assertTrue((await agent.acquire(WorkloadRef(job_id="101")))["ok"])
+    self.assertTrue((await agent.acquire(WorkloadRef(name="101")))["ok"])
 
     grant_order: list[int] = []
 
     async def acquire_then_release(pid: int) -> None:
-      workload = WorkloadRef(job_id=str(pid))
+      workload = WorkloadRef(name=str(pid))
       await agent.acquire(workload)
       grant_order.append(pid)
       await agent.release(workload)
@@ -231,25 +231,25 @@ class SingleNodeTimeSlicerTest(unittest.IsolatedAsyncioTestCase):
       waiters.append(asyncio.create_task(acquire_then_release(pid)))
       await asyncio.sleep(0.01)
 
-    self.assertTrue((await agent.release(WorkloadRef(job_id="101")))["ok"])
+    self.assertTrue((await agent.release(WorkloadRef(name="101")))["ok"])
     await asyncio.wait_for(asyncio.gather(*waiters), timeout=1.0)
 
     self.assertEqual(grant_order, [303, 202, 404])
 
   async def test_reregister_clears_a_previous_failure(self) -> None:
     agent = SingleNodeTimeSlicer(RecordingRestorer())
-    await agent.register(WorkloadRef(job_id="101"), connection_id=7)
+    await agent.register(WorkloadRef(name="101"), connection_id=7)
     await agent.connection_closed(7)
-    self.assertFalse((await agent.acquire(WorkloadRef(job_id="101")))["ok"])
+    self.assertFalse((await agent.acquire(WorkloadRef(name="101")))["ok"])
 
     # The restarted process announces itself again and is servable.
-    await agent.register(WorkloadRef(job_id="101"), connection_id=8)
-    self.assertTrue((await agent.acquire(WorkloadRef(job_id="101")))["ok"])
+    await agent.register(WorkloadRef(name="101"), connection_id=8)
+    self.assertTrue((await agent.acquire(WorkloadRef(name="101")))["ok"])
 
   async def test_register_can_use_stable_snapshot_id_for_backend_calls(self) -> None:
     restorer = RecordingRestorer()
     agent = SingleNodeTimeSlicer(restorer)
-    workload = WorkloadRef(job_id="job-a")
+    workload = WorkloadRef(name="job-a")
     await agent.register(workload)
 
     self.assertTrue((await agent.acquire(workload))["ok"])
@@ -268,11 +268,11 @@ class SingleNodeTimeSlicerSocketTest(unittest.IsolatedAsyncioTestCase):
       client_a = SocketTimeSlicerClient(socket_path)
       client_b = SocketTimeSlicerClient(socket_path)
       try:
-        await client_a.register(WorkloadRef(job_id="101"))
-        await client_b.register(WorkloadRef(job_id="202"))
+        await client_a.register(WorkloadRef(name="101"))
+        await client_b.register(WorkloadRef(name="202"))
 
-        async with client_a.acquire(WorkloadRef(job_id="101")):
-          blocked = asyncio.create_task(acquire_once(client_b, WorkloadRef(job_id="202")))
+        async with client_a.acquire(WorkloadRef(name="101")):
+          blocked = asyncio.create_task(acquire_once(client_b, WorkloadRef(name="202")))
           await asyncio.sleep(0.05)
           self.assertFalse(blocked.done())
 
@@ -293,13 +293,13 @@ class SingleNodeTimeSlicerSocketTest(unittest.IsolatedAsyncioTestCase):
       server = await start_time_slicer(agent, socket_path)
       client = SocketTimeSlicerClient(socket_path)
       try:
-        await client.register(WorkloadRef(job_id="101"))
+        await client.register(WorkloadRef(name="101"))
         await client.request({"command": "ACQUIRE", "job_id": "101"})
         await client.close()
         await asyncio.sleep(0.05)
 
         self.assertFalse(agent.running)
-        self.assertTrue(agent.workloads["shared-accelerator:101"].failed)
+        self.assertTrue(agent.workloads["101"].failed)
       finally:
         server.close()
         await server.wait_closed()
@@ -312,11 +312,11 @@ class SingleNodeTimeSlicerSocketTest(unittest.IsolatedAsyncioTestCase):
     client_a = SocketTimeSlicerClient(host="127.0.0.1", port=port)
     client_b = SocketTimeSlicerClient(host="127.0.0.1", port=port)
     try:
-      await client_a.register(WorkloadRef(job_id="101"))
-      await client_b.register(WorkloadRef(job_id="202"))
+      await client_a.register(WorkloadRef(name="101"))
+      await client_b.register(WorkloadRef(name="202"))
 
-      async with client_a.acquire(WorkloadRef(job_id="101")):
-        blocked = asyncio.create_task(acquire_once(client_b, WorkloadRef(job_id="202")))
+      async with client_a.acquire(WorkloadRef(name="101")):
+        blocked = asyncio.create_task(acquire_once(client_b, WorkloadRef(name="202")))
         await asyncio.sleep(0.05)
         self.assertFalse(blocked.done())
 
@@ -349,7 +349,7 @@ class SingleNodeTimeSlicerSocketTest(unittest.IsolatedAsyncioTestCase):
         pass
       # A successor in the same group forces the handoff, which must name the
       # env-derived job id and group to the backend.
-      successor = WorkloadRef(job_id="job-b", group="claim-a")
+      successor = WorkloadRef(name="job-b", claim="claim-a")
       await client.register(successor)
       async with client.acquire(successor):
         pass
@@ -363,23 +363,23 @@ class SingleNodeTimeSlicerSocketTest(unittest.IsolatedAsyncioTestCase):
   async def test_workload_from_env_prefers_the_launchers_group(self) -> None:
     env = {"OPEN_RL_TIME_SLICE_GROUP": "claim-a"}
     with patch.dict("os.environ", env, clear=True):
-      workload = workload_from_env(101, job_id="model-a")
+      workload = workload_from_env(101, name="model-a")
 
-    self.assertEqual(workload.job_id, "model-a")
-    self.assertEqual(workload.group, "claim-a")
+    self.assertEqual(workload.name, "model-a")
+    self.assertEqual(workload.claim, "claim-a")
 
   async def test_workload_from_env_falls_back_to_the_callers_group(self) -> None:
     with patch.dict("os.environ", {}, clear=True):
-      workload = workload_from_env(101, job_id="model-a", group="trainers")
+      workload = workload_from_env(101, name="model-a", claim="trainers")
 
-    self.assertEqual(workload.job_id, "model-a")
-    self.assertEqual(workload.group, "trainers")
+    self.assertEqual(workload.name, "model-a")
+    self.assertEqual(workload.claim, "trainers")
 
 
 class CudaCheckpointRestorerTest(unittest.TestCase):
   def test_checkpoint_discovers_pids_from_workload_identity(self) -> None:
     restorer = CudaCheckpointRestorer("cuda-checkpoint")
-    workload = WorkloadRef(job_id="trainer-model-a")
+    workload = WorkloadRef(name="trainer-model-a")
 
     with (
       patch.object(restorer, "discover_pids", return_value=[101, 202]),
@@ -399,7 +399,7 @@ class CudaCheckpointRestorerTest(unittest.TestCase):
 
   def test_restore_uses_checkpointed_pids_without_rediscovery(self) -> None:
     restorer = CudaCheckpointRestorer("cuda-checkpoint")
-    workload = WorkloadRef(job_id="trainer-model-a")
+    workload = WorkloadRef(name="trainer-model-a")
 
     with (
       patch.object(restorer, "discover_pids", return_value=[101, 202]) as discover_pids,
@@ -427,7 +427,7 @@ class CudaCheckpointRestorerTest(unittest.TestCase):
 
   def test_checkpoint_with_no_gpu_pids_skips_snapshot(self) -> None:
     restorer = CudaCheckpointRestorer("cuda-checkpoint")
-    workload = WorkloadRef(job_id="trainer-model-a")
+    workload = WorkloadRef(name="trainer-model-a")
 
     with (
       patch.object(restorer, "discover_pids", return_value=[]),
@@ -440,7 +440,7 @@ class CudaCheckpointRestorerTest(unittest.TestCase):
 
   def test_restore_without_prior_checkpoint_fails(self) -> None:
     restorer = CudaCheckpointRestorer("cuda-checkpoint")
-    workload = WorkloadRef(job_id="trainer-model-a")
+    workload = WorkloadRef(name="trainer-model-a")
 
     with self.assertRaisesRegex(RuntimeError, "no checkpointed PIDs"):
       restorer.restore(workload)
@@ -448,7 +448,7 @@ class CudaCheckpointRestorerTest(unittest.TestCase):
   def test_process_discovery_checks_gpu_pids_and_process_group_leaders(self) -> None:
     from accel_timeslicer.process_discovery import discover_workload_gpu_pids, workload_root_pids
 
-    workload = WorkloadRef(job_id="trainer-model-a")
+    workload = WorkloadRef(name="trainer-model-a")
 
     def environ(pid: int) -> dict[str, str]:
       if pid == 11:
@@ -511,7 +511,7 @@ class LlmDCheckpointRestorerTest(unittest.TestCase):
     cuda_config = object()
     restorer = LlmDCheckpointRestorer(client, cuda_config, 0.25)
 
-    target = WorkloadRef(job_id="job-a")
+    target = WorkloadRef(name="job-a")
     restorer.checkpoint(target)
     restorer.restore(target)
 
@@ -523,24 +523,24 @@ class LlmDCheckpointRestorerTest(unittest.TestCase):
       ],
     )
 
-  def test_workload_requires_job_id(self) -> None:
+  def test_workload_requires_a_name(self) -> None:
     class Client:
       def snapshot_and_wait(self, *_args, **_kwargs):
-        raise AssertionError("must not call llm-d without job id")
+        raise AssertionError("must not call llm-d without a name")
 
       def restore_and_wait(self, *_args, **_kwargs):
-        raise AssertionError("must not call llm-d without job id")
+        raise AssertionError("must not call llm-d without a name")
 
       def close(self):
         pass
 
-    with self.assertRaisesRegex(ValueError, "job_id"):
-      WorkloadRef(job_id="")
+    with self.assertRaisesRegex(ValueError, "name"):
+      WorkloadRef(name="")
 
 
 async def acquire_once(client: SocketTimeSlicerClient, workload: WorkloadRef) -> str:
   async with client.acquire(workload):
-    return workload.job_id
+    return workload.name
 
 
 if __name__ == "__main__":

--- a/tests/test_accel_timeslicer.py
+++ b/tests/test_accel_timeslicer.py
@@ -78,7 +78,20 @@ class SingleNodeTimeSlicerTest(unittest.IsolatedAsyncioTestCase):
     granted_b = await asyncio.wait_for(blocked, timeout=1.0)
     self.assertTrue(granted_b["ok"])
     self.assertEqual(restorer.simple_labels(), [("checkpoint", "101")])
-    self.assertEqual(agent.active_workload, "shared-accelerator:202")
+    self.assertEqual(agent.running, {"shared-accelerator": "shared-accelerator:202"})
+
+  async def test_groups_do_not_wait_on_each_other(self) -> None:
+    restorer = RecordingRestorer()
+    agent = SingleNodeTimeSlicer(restorer)
+    claim_a = WorkloadRef(job_id="trainer-a", group="claim-a")
+    claim_b = WorkloadRef(job_id="trainer-b", group="claim-b")
+    await agent.register(claim_a)
+    await agent.register(claim_b)
+
+    self.assertTrue((await agent.acquire(claim_a))["ok"])
+    granted = await asyncio.wait_for(agent.acquire(claim_b), timeout=1.0)
+    self.assertTrue(granted["ok"])
+    self.assertEqual(agent.running, {"claim-a": "claim-a:trainer-a", "claim-b": "claim-b:trainer-b"})
 
   async def test_first_acquire_is_cold_and_later_acquire_restores_after_checkpoint(self) -> None:
     restorer = RecordingRestorer()
@@ -105,7 +118,7 @@ class SingleNodeTimeSlicerTest(unittest.IsolatedAsyncioTestCase):
     release = await agent.release(WorkloadRef(job_id="101"))
 
     self.assertTrue(release["ok"])
-    self.assertIsNone(agent.active_workload)
+    self.assertFalse(agent.running)
     self.assertTrue(agent.workloads["shared-accelerator:101"].checkpointed)
     self.assertFalse(agent.workloads["shared-accelerator:101"].failed)
     self.assertEqual(restorer.simple_labels(), [("checkpoint", "101")])
@@ -184,7 +197,7 @@ class SingleNodeTimeSlicerTest(unittest.IsolatedAsyncioTestCase):
 
     result = await asyncio.wait_for(acquire_b, timeout=1.0)
     self.assertFalse(result["ok"])
-    self.assertIsNone(agent.active_workload)
+    self.assertFalse(agent.running)
 
   async def test_duplicate_commands_return_explicit_errors(self) -> None:
     agent = SingleNodeTimeSlicer(RecordingRestorer())
@@ -223,6 +236,16 @@ class SingleNodeTimeSlicerTest(unittest.IsolatedAsyncioTestCase):
 
     self.assertEqual(grant_order, [303, 202, 404])
 
+  async def test_reregister_clears_a_previous_failure(self) -> None:
+    agent = SingleNodeTimeSlicer(RecordingRestorer())
+    await agent.register(WorkloadRef(job_id="101"), connection_id=7)
+    await agent.connection_closed(7)
+    self.assertFalse((await agent.acquire(WorkloadRef(job_id="101")))["ok"])
+
+    # The restarted process announces itself again and is servable.
+    await agent.register(WorkloadRef(job_id="101"), connection_id=8)
+    self.assertTrue((await agent.acquire(WorkloadRef(job_id="101")))["ok"])
+
   async def test_register_can_use_stable_snapshot_id_for_backend_calls(self) -> None:
     restorer = RecordingRestorer()
     agent = SingleNodeTimeSlicer(restorer)
@@ -254,6 +277,8 @@ class SingleNodeTimeSlicerSocketTest(unittest.IsolatedAsyncioTestCase):
           self.assertFalse(blocked.done())
 
         self.assertEqual(await asyncio.wait_for(blocked, timeout=1.0), "202")
+        # 101 was suspended on the handoff; 202 stays resident after its
+        # release because nobody follows it.
         self.assertEqual(restorer.simple_labels(), [("checkpoint", "101"), ("checkpoint", "202")])
       finally:
         await client_a.close()
@@ -273,7 +298,7 @@ class SingleNodeTimeSlicerSocketTest(unittest.IsolatedAsyncioTestCase):
         await client.close()
         await asyncio.sleep(0.05)
 
-        self.assertIsNone(agent.active_workload)
+        self.assertFalse(agent.running)
         self.assertTrue(agent.workloads["shared-accelerator:101"].failed)
       finally:
         server.close()

--- a/tests/test_trainer_optimizer_correctness.py
+++ b/tests/test_trainer_optimizer_correctness.py
@@ -508,8 +508,8 @@ class TestTrainingRequestsProcessorFullMode(unittest.IsolatedAsyncioTestCase):
     self.assertEqual([event[0] for event in time_slicer.events], ["register", "acquire", "release", "unregister", "close"])
     for event in time_slicer.events:
       if len(event) >= 2 and event[0] != "close":
-        self.assertEqual(event[1].job_id, "trainer-model-a")
-        self.assertEqual(event[1].group, "trainers")
+        self.assertEqual(event[1].name, "trainer-model-a")
+        self.assertEqual(event[1].claim, "trainers")
     self.assertEqual(worker.created_models[0][0], "base-model")
     self.assertEqual(store.results["req-a"]["model_id"], "model-a")
 


### PR DESCRIPTION
Previously the single-node time slicer assumed that workloads are serialized against the entire node (i.e a workload would use all GPU's in the node). As part of the scheduler integration we will need the ability to isolate groups of gpu's on a node and have those groups be time sliced against, this PR adds support for that. The grant is now keyed by group instead of one slot per node. The scheduler will stamp each pod with its ResourceClaim name as the group, so workers on the same claim take turns and workers on different claims never wait on each other.