### PR TITLE
Make kind scheduler smoke isolated and repeatable

### DIFF
--- a/scheduler/README.md
+++ b/scheduler/README.md
@@ -71,9 +71,20 @@ a kind smoke test that needs no hardware (the DRA example driver publishes
 fake GPUs):
 
 ```
-make smoke                                # kind + fake GPUs
-USE_EXISTING_CLUSTER=1 DEVICE_CLASS=gpu.nvidia.com ./hack/kind-smoke.sh   # real GPUs
+make -C scheduler/controller smoke        # kind + fake GPUs
+USE_EXISTING_CLUSTER=1 DEVICE_CLASS=gpu.nvidia.com scheduler/hack/kind-smoke.sh   # real GPUs
 ```
+
+The smoke test pins Kubernetes and the fake driver, selects `spread` explicitly,
+and uses a private kubeconfig so it does not change your current context.
+`KEEP=1` preserves the cluster and prints commands to inspect it. Existing-cluster
+runs require an empty `openrl-system` namespace. Failures print controller events
+and logs; failed cluster creation also exports kind diagnostics.
+
+Kubernetes 1.35 requires cgroup v2 by default. On older hosts, use
+`KIND_NODE_IMAGE=kindest/node:v1.34.0 make -C scheduler/controller smoke`.
+To test a different checkout without switching branches, set
+`SCHEDULER_DIR=/absolute/path/to/checkout/scheduler`.
 
 The controller only ever reads ResourceSlices and node labels, so fake and
 real devices exercise the identical path; only the two env values differ.

--- a/scheduler/controller/Makefile
+++ b/scheduler/controller/Makefile
@@ -84,7 +84,7 @@ run:
 # example driver. No hardware needed. See hack/kind-smoke.sh for the knobs.
 .PHONY: smoke
 smoke:
-	./hack/kind-smoke.sh
+	../hack/kind-smoke.sh
 
 .PHONY: docker-build
 docker-build:

--- a/scheduler/hack/kind-smoke.sh
+++ b/scheduler/hack/kind-smoke.sh
@@ -9,10 +9,17 @@
 # real hardware exercises the identical path:
 #
 #   ./hack/kind-smoke.sh                      # kind + fake GPUs
+#   SCHEDULER_DIR=/path/to/other/checkout/scheduler ./hack/kind-smoke.sh
+#                                             # test another checkout
 #   KEEP=1 ./hack/kind-smoke.sh               # leave the cluster up afterwards
 #   USE_EXISTING_CLUSTER=1 LOAD_INTO=<kind-cluster> \
 #     DEVICE_CLASS=gpu.nvidia.com GPUS=2 MEMORY=10Gi ./hack/kind-smoke.sh
 #                                             # current kubectl context, real DRA
+#
+# Hosts with cgroup v1 can use KIND_NODE_IMAGE=kindest/node:v1.34.0.
+# KIND_NODE_IMAGE pins Kubernetes; DRA_DRIVER_COMMIT pins the fake driver.
+# The spread policy is explicit: the standalone controller defaults to binpack.
+# A private kubeconfig is used; existing-cluster runs require an empty namespace.
 #
 # GPUS is how many devices the target node exposes (the fake driver's 8 by
 # default); MEMORY must fit one of its devices. The run asks for GPUS+1
@@ -25,7 +32,9 @@
 # immutability, pod binding, and watch-driven status flow.
 set -euo pipefail
 
-CLUSTER=${CLUSTER:-openrl-smoke}
+CLUSTER=${CLUSTER:-openrl-smoke-$$}
+KIND_NODE_IMAGE=${KIND_NODE_IMAGE:-kindest/node:v1.35.5}
+DRA_DRIVER_COMMIT=bab2dce4b045e729565c9a3b85554738247cda30 # v0.4.0
 DEVICE_CLASS=${DEVICE_CLASS:-gpu.example.com}
 DEVICE_DRIVER=${DEVICE_DRIVER:-$DEVICE_CLASS}
 USE_EXISTING_CLUSTER=${USE_EXISTING_CLUSTER:-0}
@@ -37,16 +46,53 @@ NS=openrl-system
 # The smoke overlay pins this tag; it is not overridable for that reason.
 IMG=open-rl/scheduler:smoke
 
-scheduler=$(cd "$(dirname "$0")/.." && pwd)
+scheduler=${SCHEDULER_DIR:-$(cd "$(dirname "$0")/.." && pwd)}
 
 say() { printf '\n== %s\n' "$*"; }
 
-if [ "$USE_EXISTING_CLUSTER" != 1 ]; then
-  say "creating kind cluster $CLUSTER"
-  kind create cluster --name "$CLUSTER" --wait 120s
-  if [ "$KEEP" != 1 ]; then
-    trap 'kind delete cluster --name "$CLUSTER"' EXIT
+# A private kubeconfig keeps both kind and kubectl off the caller's context.
+umask 077
+tmp=$(mktemp -d)
+created=0
+cleanup() {
+  result=$?
+  if [ "$result" != 0 ] && [ "$created" = 1 ]; then
+    kind export logs "$tmp/logs" --name "$CLUSTER" || true
   fi
+  if [ "$result" != 0 ] && [ -s "$KUBECONFIG" ]; then
+    kubectl -n "$NS" get workloads,pods,resourceclaims,claimledgers -o wide || true
+    kubectl -n "$NS" get events --sort-by=.lastTimestamp | tail -40 || true
+    kubectl -n "$NS" logs deployment/open-rl-scheduler --tail=80 || true
+  fi
+  if [ "$KEEP" = 1 ]; then
+    echo "Kept kubeconfig: $tmp/kubeconfig"
+    echo "Inspect with: KUBECONFIG=$tmp/kubeconfig kubectl -n $NS get workloads,pods,resourceclaims"
+    [ "$created" != 1 ] || echo "Clean up with: kind delete cluster --name $CLUSTER"
+  else
+    if [ "$created" = 1 ]; then kind delete cluster --name "$CLUSTER"; fi
+    rm -rf "$tmp"
+  fi
+  exit "$result"
+}
+if [ "$USE_EXISTING_CLUSTER" = 1 ]; then
+  context=${CONTEXT:-$(kubectl config current-context)}
+  kubectl --context "$context" config view --minify --flatten > "$tmp/kubeconfig"
+fi
+export KUBECONFIG="$tmp/kubeconfig"
+trap cleanup EXIT
+if [ "$USE_EXISTING_CLUSTER" != 1 ]; then
+  say "creating kind cluster $CLUSTER ($KIND_NODE_IMAGE)"
+  # Reject name collisions before recording ownership for cleanup.
+  if kind get clusters | grep -Fxq "$CLUSTER"; then
+    echo "FAIL: cluster $CLUSTER already exists; choose a fresh CLUSTER name"
+    exit 1
+  fi
+  created=1
+  kind create cluster --name "$CLUSTER" --image "$KIND_NODE_IMAGE" --kubeconfig "$KUBECONFIG" --retain --wait 120s
+fi
+if kubectl get namespace "$NS" >/dev/null 2>&1; then
+  echo "FAIL: namespace $NS already exists; use an empty test cluster"
+  exit 1
 fi
 
 # Fake GPUs. The example driver is the reference DRA implementation: it
@@ -54,17 +100,27 @@ fi
 # the NVIDIA driver, without needing hardware.
 if [ "$DEVICE_CLASS" = gpu.example.com ]; then
   say "installing the DRA example driver (fake GPUs)"
-  tmp=$(mktemp -d)
-  git clone --quiet --depth 1 https://github.com/kubernetes-sigs/dra-example-driver "$tmp/driver"
+  git init --quiet "$tmp/driver"
+  git -C "$tmp/driver" fetch --quiet --depth 1 https://github.com/kubernetes-sigs/dra-example-driver "$DRA_DRIVER_COMMIT"
+  git -C "$tmp/driver" checkout --quiet --detach FETCH_HEAD
   helm upgrade --install dra-example-driver "$tmp/driver/deployments/helm/dra-example-driver" \
-    --create-namespace --namespace dra-example-driver --wait --timeout 180s
+    --create-namespace --namespace dra-example-driver --wait --timeout 180s \
+    --set kubeletPlugin.numDevices="$GPUS"
 fi
 
 say "waiting for ResourceSlices from $DEVICE_DRIVER"
+ready=0
 for _ in $(seq 60); do
-  kubectl get resourceslices -o jsonpath='{.items[*].spec.driver}' 2>/dev/null | grep -q "$DEVICE_DRIVER" && break
+  if kubectl get resourceslices -o jsonpath='{range .items[*]}{.spec.driver}{"\n"}{end}' | grep -Fxq "$DEVICE_DRIVER"; then
+    ready=1
+    break
+  fi
   sleep 2
 done
+if [ "$ready" != 1 ]; then
+  echo "FAIL: no ResourceSlices from $DEVICE_DRIVER"
+  exit 1
+fi
 kubectl get resourceslices
 
 say "building and loading the controller image"
@@ -76,7 +132,8 @@ elif [ -n "$LOAD_INTO" ]; then
 fi
 
 say "deploying the scheduler (smoke overlay)"
-kubectl apply -k "$scheduler/deploy/overlays/smoke"
+kubectl apply --server-side -k "$scheduler/deploy/overlays/smoke"
+kubectl -n "$NS" set env deployment/open-rl-scheduler OPEN_RL_PLACEMENT_STRATEGY=spread
 if [ "$DEVICE_CLASS" != gpu.example.com ]; then
   # The overlay defaults to the fake driver; real-hardware runs override it.
   kubectl -n "$NS" set env deployment/open-rl-scheduler \
@@ -123,20 +180,7 @@ EOF
 done
 
 say "waiting for every worker to run"
-for i in $(seq "$WORKERS"); do
-  ok=0
-  for _ in $(seq 90); do
-    phase=$(kubectl -n "$NS" get workload "smoke-$i" -o jsonpath='{.status.phase}' 2>/dev/null || true)
-    [ "$phase" = Running ] && ok=1 && break
-    sleep 2
-  done
-  if [ "$ok" != 1 ]; then
-    echo "FAIL: smoke-$i never reached Running (phase: ${phase:-none})"
-    kubectl -n "$NS" get workloads
-    kubectl -n "$NS" get pods,resourceclaims
-    exit 1
-  fi
-done
+kubectl -n "$NS" wait workloads --all --for=jsonpath='{.status.phase}'=Running --timeout=240s
 
 say "asserting dedicated claims, the sharing fallback, and real allocations"
 claims=$(kubectl -n "$NS" get workloads -o jsonpath='{range .items[*]}{.status.claimName}{"\n"}{end}')


### PR DESCRIPTION
The kind scheduler smoke expected spread placement while running the controller's binpack default. It also changed the user's kubeconfig, followed the DRA driver's main branch, could continue after a ResourceSlice timeout, and was neither executable nor reachable through `make smoke`.

Select spread explicitly, pin Kubernetes and the fake driver, use a private kubeconfig and unique cluster name, fail on missing DRA inventory, and use server-side apply for the large Workload CRD. Wait for all workers with one bounded Kubernetes wait. Clean up temporary files and owned clusters, print diagnostics on failure, and support testing another checkout through `SCHEDULER_DIR`. Existing-cluster runs require an empty OpenRL namespace.

Validation: repository lint, shell syntax, and a complete `KIND_NODE_IMAGE=kindest/node:v1.34.0 make -C scheduler/controller smoke` run passed on this branch: nine Running workers on eight allocated claims, including the sharing fallback. The cluster was removed automatically and the original kubectl context remained unchanged. Default Kubernetes 1.35 was attempted; this host uses cgroup v1, so the documented 1.34 override was used.

This branch is based directly on main and is independent of the LoRA scheduler-release PR #226.
