### PR TITLE
feat: make binpack aware of worker kind

### DIFF
--- a/scheduler/controller/api/v1alpha1/claimledger_types.go
+++ b/scheduler/controller/api/v1alpha1/claimledger_types.go
@@ -27,9 +27,9 @@ type Seat struct {
 	// Copied from the workload's spec.ownerID.
 	OwnerID string `json:"ownerID,omitempty"`
 
-	// TrainingKind is copied from the workload. Only FFT seats may share;
-	// a missing kind prevents new joins until the workload refreshes its seat.
-	TrainingKind TrainingKind `json:"trainingKind,omitempty"`
+	// Exclusive is copied from the workload. A claim holding an exclusive
+	// seat admits no other, and an exclusive worker joins no claim.
+	Exclusive bool `json:"exclusive,omitempty"`
 
 	// HostRequest is the pod's host memory request. Copied here so
 	// placement can add up a node's load without reading every workload.

--- a/scheduler/controller/api/v1alpha1/claimledger_types.go
+++ b/scheduler/controller/api/v1alpha1/claimledger_types.go
@@ -27,6 +27,10 @@ type Seat struct {
 	// Copied from the workload's spec.ownerID.
 	OwnerID string `json:"ownerID,omitempty"`
 
+	// TrainingKind is copied from the workload. Only FFT seats may share;
+	// a missing kind prevents new joins until the workload refreshes its seat.
+	TrainingKind TrainingKind `json:"trainingKind,omitempty"`
+
 	// HostRequest is the pod's host memory request. Copied here so
 	// placement can add up a node's load without reading every workload.
 	HostRequest resource.Quantity `json:"hostRequest,omitempty"`

--- a/scheduler/controller/api/v1alpha1/workload_types.go
+++ b/scheduler/controller/api/v1alpha1/workload_types.go
@@ -41,8 +41,8 @@ const (
 	ConditionPlaced = "Placed"
 )
 
-// TrainingKind is how the workload trains. Identity and reuse are decided
-// by the API server before placement; the controller does not branch on it.
+// TrainingKind is how the workload trains. FFT workers can time-slice a
+// GPU; LoRA workers remain resident and receive exclusive claims.
 // +kubebuilder:validation:Enum=fft;lora
 type TrainingKind string
 
@@ -97,7 +97,7 @@ type WorkloadSpec struct {
 	OwnerID string `json:"ownerID,omitempty"`
 
 	// TrainingKind records whether this runtime is full fine-tuning or LoRA.
-	// Informational: reuse was already decided in the workload's name.
+	// Only FFT can share claims; LoRA and an unspecified kind stay exclusive.
 	TrainingKind TrainingKind `json:"trainingKind,omitempty"`
 
 	// Accelerator is the estimator's requirement this workload is placed by.
@@ -190,7 +190,7 @@ type Workload struct {
 	// The spec is immutable: every field either places the worker or renders
 	// its pod, and V1 does not re-place or re-render a live worker. Change by
 	// deleting and recreating.
-	// +kubebuilder:validation:XValidation:rule="self.role == oldSelf.role && self.modelID == oldSelf.modelID && has(self.ownerID) == has(oldSelf.ownerID) && (!has(self.ownerID) || self.ownerID == oldSelf.ownerID) && self.accelerator == oldSelf.accelerator",message="placement fields are immutable; delete and recreate the workload"
+	// +kubebuilder:validation:XValidation:rule="self.role == oldSelf.role && self.modelID == oldSelf.modelID && has(self.ownerID) == has(oldSelf.ownerID) && (!has(self.ownerID) || self.ownerID == oldSelf.ownerID) && has(self.trainingKind) == has(oldSelf.trainingKind) && (!has(self.trainingKind) || self.trainingKind == oldSelf.trainingKind) && self.accelerator == oldSelf.accelerator",message="placement fields are immutable; delete and recreate the workload"
 	Spec   WorkloadSpec   `json:"spec"`
 	Status WorkloadStatus `json:"status,omitempty"`
 }

--- a/scheduler/controller/api/v1alpha1/workload_types.go
+++ b/scheduler/controller/api/v1alpha1/workload_types.go
@@ -41,8 +41,8 @@ const (
 	ConditionPlaced = "Placed"
 )
 
-// TrainingKind is how the workload trains. FFT workers can time-slice a
-// GPU; LoRA workers remain resident and receive exclusive claims.
+// TrainingKind is how the workload trains. Informational; placement reads
+// Exclusive.
 // +kubebuilder:validation:Enum=fft;lora
 type TrainingKind string
 
@@ -97,8 +97,16 @@ type WorkloadSpec struct {
 	OwnerID string `json:"ownerID,omitempty"`
 
 	// TrainingKind records whether this runtime is full fine-tuning or LoRA.
-	// Only FFT can share claims; LoRA and an unspecified kind stay exclusive.
+	// Placement does not read it.
 	TrainingKind TrainingKind `json:"trainingKind,omitempty"`
+
+	// Exclusive keeps this worker alone on its GPU. Two workers share a
+	// claim only when neither is exclusive. The gateway sets it from the
+	// training kind, true for LoRA workers because they cannot suspend
+	// between turns. Omitted means exclusive.
+	// +kubebuilder:default=true
+	// +optional
+	Exclusive bool `json:"exclusive"`
 
 	// Accelerator is the estimator's requirement this workload is placed by.
 	Accelerator AcceleratorSpec `json:"accelerator"`
@@ -190,7 +198,7 @@ type Workload struct {
 	// The spec is immutable: every field either places the worker or renders
 	// its pod, and V1 does not re-place or re-render a live worker. Change by
 	// deleting and recreating.
-	// +kubebuilder:validation:XValidation:rule="self.role == oldSelf.role && self.modelID == oldSelf.modelID && has(self.ownerID) == has(oldSelf.ownerID) && (!has(self.ownerID) || self.ownerID == oldSelf.ownerID) && has(self.trainingKind) == has(oldSelf.trainingKind) && (!has(self.trainingKind) || self.trainingKind == oldSelf.trainingKind) && self.accelerator == oldSelf.accelerator",message="placement fields are immutable; delete and recreate the workload"
+	// +kubebuilder:validation:XValidation:rule="self.role == oldSelf.role && self.modelID == oldSelf.modelID && has(self.ownerID) == has(oldSelf.ownerID) && (!has(self.ownerID) || self.ownerID == oldSelf.ownerID) && has(self.trainingKind) == has(oldSelf.trainingKind) && (!has(self.trainingKind) || self.trainingKind == oldSelf.trainingKind) && self.exclusive == oldSelf.exclusive && self.accelerator == oldSelf.accelerator",message="placement fields are immutable; delete and recreate the workload"
 	Spec   WorkloadSpec   `json:"spec"`
 	Status WorkloadStatus `json:"status,omitempty"`
 }

--- a/scheduler/controller/cmd/manager/main.go
+++ b/scheduler/controller/cmd/manager/main.go
@@ -61,7 +61,7 @@ func main() {
 	flag.DurationVar(&placementTimeout, "placement-timeout", envDuration("OPEN_RL_PLACEMENT_TIMEOUT", 15*time.Minute),
 		"How long a worker may go unplaced before the request is declared unsatisfiable. 0 waits forever.")
 	flag.StringVar(&strategy, "placement-strategy", env("OPEN_RL_PLACEMENT_STRATEGY", string(placement.StrategyBinPack)),
-		"binpack seats workers on existing claims before cutting new ones; spread cuts a dedicated claim per worker, sharing only as a fallback.")
+		"binpack shares eligible FFT claims first; spread requests a GPU first, then falls back to FFT sharing. LoRA never shares.")
 	flag.IntVar(&maxConcurrent, "max-concurrent-reconciles", envInt("OPEN_RL_MAX_CONCURRENT_RECONCILES", 4),
 		"How many workers place at once. Seat booking is CAS-arbitrated, so concurrency risks only transient over-cut claims, which the sharing fallback drains.")
 

--- a/scheduler/controller/internal/controller/fleet.go
+++ b/scheduler/controller/internal/controller/fleet.go
@@ -85,7 +85,7 @@ func (r *WorkloadReconciler) readFleet(ctx context.Context) (*placement.Fleet, e
 			continue
 		}
 		for _, seat := range ledger.Spec.Seats {
-			claim.Book(seat.Workload, seat.OwnerID, seat.HostRequest.Value(), seat.TrainingKind == openrlv1alpha1.TrainingKindFFT)
+			claim.Book(seat.Workload, seat.OwnerID, seat.HostRequest.Value(), !seat.Exclusive)
 		}
 	}
 	return fleet, nil
@@ -245,7 +245,7 @@ func isHostnameKey(key string) bool {
 func requestFrom(worker *openrlv1alpha1.Workload) placement.Request {
 	spec := worker.Spec
 	return placement.Request{
-		Shareable: spec.TrainingKind == openrlv1alpha1.TrainingKindFFT,
+		Shareable: !spec.Exclusive,
 		Role:      string(spec.Role),
 		Memory:    spec.Accelerator.Memory.Value(),
 		// Raw: the spec calls the owner ID opaque, and sanitizing here would

--- a/scheduler/controller/internal/controller/fleet.go
+++ b/scheduler/controller/internal/controller/fleet.go
@@ -85,7 +85,7 @@ func (r *WorkloadReconciler) readFleet(ctx context.Context) (*placement.Fleet, e
 			continue
 		}
 		for _, seat := range ledger.Spec.Seats {
-			claim.Book(seat.Workload, seat.OwnerID, seat.HostRequest.Value())
+			claim.Book(seat.Workload, seat.OwnerID, seat.HostRequest.Value(), seat.TrainingKind == openrlv1alpha1.TrainingKindFFT)
 		}
 	}
 	return fleet, nil
@@ -245,8 +245,9 @@ func isHostnameKey(key string) bool {
 func requestFrom(worker *openrlv1alpha1.Workload) placement.Request {
 	spec := worker.Spec
 	return placement.Request{
-		Role:   string(spec.Role),
-		Memory: spec.Accelerator.Memory.Value(),
+		Shareable: spec.TrainingKind == openrlv1alpha1.TrainingKindFFT,
+		Role:      string(spec.Role),
+		Memory:    spec.Accelerator.Memory.Value(),
 		// Raw: the spec calls the owner ID opaque, and sanitizing here would
 		// merge distinct owners ("A/B" and "a-b") into one fairness slot.
 		// Labels sanitize at the stamping site; env vars carry this exactly.

--- a/scheduler/controller/internal/controller/ledger.go
+++ b/scheduler/controller/internal/controller/ledger.go
@@ -20,9 +20,9 @@ import (
 // bookAttempts bounds the CAS retry loop; past it the reconcile requeues.
 const bookAttempts = 5
 
-// errBookingContended: the booking lost every CAS retry to concurrent
-// writers. Callers treat it as "no placement this pass", not a failure.
-var errBookingContended = fmt.Errorf("seat booking lost every CAS retry on the chosen ledger")
+// errBookingContended means the ledger no longer accepts this seat or the
+// booking exhausted its CAS retries. Callers retry placement on a later pass.
+var errBookingContended = fmt.Errorf("chosen ledger could not accept the seat")
 
 // ledgerNameFor derives the ClaimLedger name from the claim name; it is never
 // stored anywhere.
@@ -38,6 +38,7 @@ func newSeat(worker *openrlv1alpha1.Workload, request placement.Request) openrlv
 		WorkloadUID:  worker.UID,
 		AssignmentID: string(uuid.NewUUID()),
 		OwnerID:      request.OwnerKey(),
+		TrainingKind: worker.Spec.TrainingKind,
 		HostRequest:  *resource.NewQuantity(request.HostRequestBytes, resource.BinarySI),
 	}
 }
@@ -85,18 +86,27 @@ func (r *WorkloadReconciler) ensureSeat(ctx context.Context, claimName string, s
 			return nil, nil, fmt.Errorf("read ledger %s: %w", ledgerName, err)
 		}
 
-		if existing := findSeat(&claimLedger, seat.Workload); existing != nil {
-			if existing.WorkloadUID == seat.WorkloadUID {
-				return &claimLedger, existing, nil // already booked; adopt it
+		existing := findSeat(&claimLedger, seat.Workload)
+		if existing != nil && existing.WorkloadUID == seat.WorkloadUID {
+			if existing.TrainingKind != "" || seat.TrainingKind == "" {
+				return &claimLedger, existing, nil
 			}
-			// A predecessor's seat under our name: replace it. Its pod may
-			// still be terminating, and that is tolerated by two guards: the
-			// deterministic pod name is a mutex (the successor pod cannot be
-			// created until the old one is gone), and the fresh assignment ID
-			// fences the old incarnation from ever regaining residency.
-			*existing = seat
+			// Upgrade an old seat without changing its assignment or running pod.
+			existing.TrainingKind = seat.TrainingKind
 		} else {
-			claimLedger.Spec.Seats = append(claimLedger.Spec.Seats, seat)
+			// Recheck compatibility on the consistent ledger inside the CAS loop.
+			// A stale fleet must not let an FFT worker join a resident LoRA worker,
+			// or let a recreated LoRA worker replace an FFT seat in a shared claim.
+			for _, other := range claimLedger.Spec.Seats {
+				if other.Workload != seat.Workload && (seat.TrainingKind != openrlv1alpha1.TrainingKindFFT || other.TrainingKind != openrlv1alpha1.TrainingKindFFT) {
+					return nil, nil, errBookingContended
+				}
+			}
+			if existing != nil {
+				*existing = seat
+			} else {
+				claimLedger.Spec.Seats = append(claimLedger.Spec.Seats, seat)
+			}
 		}
 
 		err = r.Update(ctx, &claimLedger)

--- a/scheduler/controller/internal/controller/ledger.go
+++ b/scheduler/controller/internal/controller/ledger.go
@@ -38,7 +38,7 @@ func newSeat(worker *openrlv1alpha1.Workload, request placement.Request) openrlv
 		WorkloadUID:  worker.UID,
 		AssignmentID: string(uuid.NewUUID()),
 		OwnerID:      request.OwnerKey(),
-		TrainingKind: worker.Spec.TrainingKind,
+		Exclusive:    worker.Spec.Exclusive,
 		HostRequest:  *resource.NewQuantity(request.HostRequestBytes, resource.BinarySI),
 	}
 }
@@ -88,25 +88,20 @@ func (r *WorkloadReconciler) ensureSeat(ctx context.Context, claimName string, s
 
 		existing := findSeat(&claimLedger, seat.Workload)
 		if existing != nil && existing.WorkloadUID == seat.WorkloadUID {
-			if existing.TrainingKind != "" || seat.TrainingKind == "" {
-				return &claimLedger, existing, nil
+			return &claimLedger, existing, nil
+		}
+		// Recheck compatibility on the consistent ledger inside the CAS loop.
+		// A stale fleet must not let a worker join a resident exclusive worker,
+		// or let a recreated exclusive worker replace a seat in a shared claim.
+		for _, other := range claimLedger.Spec.Seats {
+			if other.Workload != seat.Workload && (seat.Exclusive || other.Exclusive) {
+				return nil, nil, errBookingContended
 			}
-			// Upgrade an old seat without changing its assignment or running pod.
-			existing.TrainingKind = seat.TrainingKind
+		}
+		if existing != nil {
+			*existing = seat
 		} else {
-			// Recheck compatibility on the consistent ledger inside the CAS loop.
-			// A stale fleet must not let an FFT worker join a resident LoRA worker,
-			// or let a recreated LoRA worker replace an FFT seat in a shared claim.
-			for _, other := range claimLedger.Spec.Seats {
-				if other.Workload != seat.Workload && (seat.TrainingKind != openrlv1alpha1.TrainingKindFFT || other.TrainingKind != openrlv1alpha1.TrainingKindFFT) {
-					return nil, nil, errBookingContended
-				}
-			}
-			if existing != nil {
-				*existing = seat
-			} else {
-				claimLedger.Spec.Seats = append(claimLedger.Spec.Seats, seat)
-			}
+			claimLedger.Spec.Seats = append(claimLedger.Spec.Seats, seat)
 		}
 
 		err = r.Update(ctx, &claimLedger)

--- a/scheduler/controller/internal/controller/ledger_test.go
+++ b/scheduler/controller/internal/controller/ledger_test.go
@@ -122,6 +122,70 @@ func TestRebookingAdoptsTheRecordedSeat(t *testing.T) {
 	}
 }
 
+func TestSharingRechecksTheLedgerAfterSelection(t *testing.T) {
+	resident, incoming := trainerWorker("resident", "model-a"), trainerWorker("incoming", "model-b")
+	r := newReconciler(t, append(enabledNode(), resident, incoming)...)
+	settle(t, r, resident.Name)
+	claim := claimOf(t, r, resident.Name)
+	allocateClaim(t, r, claim)
+	fleet, err := r.readFleet(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := requestFrom(incoming)
+	if placement.SelectClaim(request, fleet) == nil {
+		t.Fatal("snapshot should offer the FFT claim")
+	}
+	// The current ledger now holds a LoRA process, while the informer snapshot
+	// still offers an FFT-only claim. The consistent booking must refuse it.
+	ledger := getLedger(t, r, ledgerNameFor(claim))
+	ledger.Spec.Seats[0].TrainingKind = openrlv1alpha1.TrainingKindLoRA
+	if err := r.Update(context.Background(), ledger); err != nil {
+		t.Fatal(err)
+	}
+	joined, _, err := r.joinExistingClaim(context.Background(), incoming, request, fleet, "")
+	if err != nil || joined != nil {
+		t.Fatalf("stale selection joined=%v, error=%v", joined, err)
+	}
+	if got := len(getLedger(t, r, ledger.Name).Spec.Seats); got != 1 {
+		t.Fatalf("refused join changed occupancy to %d seats", got)
+	}
+}
+
+func TestLegacySeatRefreshPreservesAssignment(t *testing.T) {
+	r := newReconciler(t, append(enabledNode(), trainerWorker("resident", "model-a"))...)
+	settle(t, r, "resident")
+	w := getWorker(t, r, "resident")
+	allocateClaim(t, r, w.Status.ClaimName)
+	podVersion := getPod(t, r, "orw-resident").ResourceVersion
+	ledger := getLedger(t, r, ledgerNameFor(w.Status.ClaimName))
+	ledger.Spec.Seats[0].TrainingKind = ""
+	if err := r.Update(context.Background(), ledger); err != nil {
+		t.Fatal(err)
+	}
+	incoming := trainerWorker("incoming", "model-b")
+	assertJoinable := func(want bool) {
+		t.Helper()
+		fleet, err := r.readFleet(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := placement.SelectClaim(requestFrom(incoming), fleet) != nil; got != want {
+			t.Fatalf("legacy claim joinable=%v, want %v", got, want)
+		}
+	}
+	assertJoinable(false)
+	runReconcile(t, r, w.Name)
+	assertJoinable(true)
+	seat := getLedger(t, r, ledger.Name).Spec.Seats[0]
+	if seat.AssignmentID != w.Status.AssignmentID || getWorker(t, r, w.Name).Status.AssignmentID != w.Status.AssignmentID {
+		t.Fatal("refresh replaced the assignment")
+	}
+	if getPod(t, r, "orw-resident").ResourceVersion != podVersion {
+		t.Fatal("refresh changed the running pod")
+	}
+}
+
 // Deleting a worker frees its seat only once the pod is verifiably gone, and
 // the same reconcile then retires the empty ledger and its claim.
 func TestTeardownReclaimsTheClaimAndGroupInline(t *testing.T) {

--- a/scheduler/controller/internal/controller/ledger_test.go
+++ b/scheduler/controller/internal/controller/ledger_test.go
@@ -136,10 +136,10 @@ func TestSharingRechecksTheLedgerAfterSelection(t *testing.T) {
 	if placement.SelectClaim(request, fleet) == nil {
 		t.Fatal("snapshot should offer the FFT claim")
 	}
-	// The current ledger now holds a LoRA process, while the informer snapshot
-	// still offers an FFT-only claim. The consistent booking must refuse it.
+	// The current ledger now holds an exclusive worker, while the informer
+	// snapshot still offers a shareable claim. The consistent booking must refuse it.
 	ledger := getLedger(t, r, ledgerNameFor(claim))
-	ledger.Spec.Seats[0].TrainingKind = openrlv1alpha1.TrainingKindLoRA
+	ledger.Spec.Seats[0].Exclusive = true
 	if err := r.Update(context.Background(), ledger); err != nil {
 		t.Fatal(err)
 	}
@@ -149,40 +149,6 @@ func TestSharingRechecksTheLedgerAfterSelection(t *testing.T) {
 	}
 	if got := len(getLedger(t, r, ledger.Name).Spec.Seats); got != 1 {
 		t.Fatalf("refused join changed occupancy to %d seats", got)
-	}
-}
-
-func TestLegacySeatRefreshPreservesAssignment(t *testing.T) {
-	r := newReconciler(t, append(enabledNode(), trainerWorker("resident", "model-a"))...)
-	settle(t, r, "resident")
-	w := getWorker(t, r, "resident")
-	allocateClaim(t, r, w.Status.ClaimName)
-	podVersion := getPod(t, r, "orw-resident").ResourceVersion
-	ledger := getLedger(t, r, ledgerNameFor(w.Status.ClaimName))
-	ledger.Spec.Seats[0].TrainingKind = ""
-	if err := r.Update(context.Background(), ledger); err != nil {
-		t.Fatal(err)
-	}
-	incoming := trainerWorker("incoming", "model-b")
-	assertJoinable := func(want bool) {
-		t.Helper()
-		fleet, err := r.readFleet(context.Background())
-		if err != nil {
-			t.Fatal(err)
-		}
-		if got := placement.SelectClaim(requestFrom(incoming), fleet) != nil; got != want {
-			t.Fatalf("legacy claim joinable=%v, want %v", got, want)
-		}
-	}
-	assertJoinable(false)
-	runReconcile(t, r, w.Name)
-	assertJoinable(true)
-	seat := getLedger(t, r, ledger.Name).Spec.Seats[0]
-	if seat.AssignmentID != w.Status.AssignmentID || getWorker(t, r, w.Name).Status.AssignmentID != w.Status.AssignmentID {
-		t.Fatal("refresh replaced the assignment")
-	}
-	if getPod(t, r, "orw-resident").ResourceVersion != podVersion {
-		t.Fatal("refresh changed the running pod")
 	}
 }
 

--- a/scheduler/controller/internal/controller/workload_controller.go
+++ b/scheduler/controller/internal/controller/workload_controller.go
@@ -279,12 +279,8 @@ func (r *WorkloadReconciler) ensurePlacementClaim(ctx context.Context, scope *pl
 			status.Reason = verb
 		})
 	}
-	if worker.Status.AssignmentID != "" && worker.Status.ClaimName == scope.claimName {
-		return placementPhaseResult{}, nil
-	}
-
-	// A retained or pod-adopted claim has no fresh booking: re-book
-	// idempotently so the seat list stays authoritative.
+	// Adopt the recorded seat, refreshing legacy seats' training kind without
+	// replacing their assignment. This also heals a retained or pod-adopted claim.
 	_, seat, err := r.ensureSeat(ctx, scope.claimName, newSeat(worker, scope.request), true)
 	if err == errBookingContended {
 		reason := "SeatLost: the ledger is contended; the booking will be retried"
@@ -292,6 +288,9 @@ func (r *WorkloadReconciler) ensurePlacementClaim(ctx context.Context, scope *pl
 	}
 	if err != nil {
 		return placementPhaseResult{}, err
+	}
+	if worker.Status.AssignmentID == seat.AssignmentID && worker.Status.ClaimName == scope.claimName {
+		return placementPhaseResult{}, nil
 	}
 	return placementPhaseResult{}, r.patchStatus(ctx, worker, func(status *openrlv1alpha1.WorkloadStatus) {
 		status.ClaimName = scope.claimName
@@ -533,7 +532,7 @@ func (r *WorkloadReconciler) joinExistingClaim(ctx context.Context, worker *open
 	if err != nil {
 		return nil, nil, err
 	}
-	target.Book(request.WorkerID, request.OwnerKey(), request.HostRequestBytes)
+	target.Book(request.WorkerID, request.OwnerKey(), request.HostRequestBytes, request.Shareable)
 	return target, seat, nil
 }
 
@@ -583,7 +582,7 @@ func (r *WorkloadReconciler) cutDedicatedClaim(ctx context.Context, worker *open
 	found := err == nil
 
 	claim := &placement.Claim{Name: name}
-	claim.Book(request.WorkerID, request.OwnerKey(), request.HostRequestBytes)
+	claim.Book(request.WorkerID, request.OwnerKey(), request.HostRequestBytes, request.Shareable)
 	claimLedger, seat, err := r.ensureSeat(ctx, name, newSeat(worker, request), true)
 	if err != nil {
 		return nil, nil, "", err
@@ -594,7 +593,7 @@ func (r *WorkloadReconciler) cutDedicatedClaim(ctx context.Context, worker *open
 	if found {
 		// Adopt the cluster's copy -- it may already be allocated.
 		adopted := claimFrom(&existing)
-		adopted.Book(request.WorkerID, request.OwnerKey(), request.HostRequestBytes)
+		adopted.Book(request.WorkerID, request.OwnerKey(), request.HostRequestBytes, request.Shareable)
 		fleet.Claims[adopted.Name] = adopted
 		return adopted, seat, verb, nil
 	}

--- a/scheduler/controller/internal/controller/workload_controller.go
+++ b/scheduler/controller/internal/controller/workload_controller.go
@@ -279,8 +279,7 @@ func (r *WorkloadReconciler) ensurePlacementClaim(ctx context.Context, scope *pl
 			status.Reason = verb
 		})
 	}
-	// Adopt the recorded seat, refreshing legacy seats' training kind without
-	// replacing their assignment. This also heals a retained or pod-adopted claim.
+	// Adopt the recorded seat. This also heals a retained or pod-adopted claim.
 	_, seat, err := r.ensureSeat(ctx, scope.claimName, newSeat(worker, scope.request), true)
 	if err == errBookingContended {
 		reason := "SeatLost: the ledger is contended; the booking will be retried"

--- a/scheduler/controller/internal/controller/workload_controller_test.go
+++ b/scheduler/controller/internal/controller/workload_controller_test.go
@@ -584,6 +584,7 @@ func TestLoRAKeepsTrainerAndSamplerSeparateUnderContention(t *testing.T) {
 	sampler := worker("sampler", "base-model", openrlv1alpha1.RoleSampler, "24Gi")
 	trainer.Spec.OwnerID, sampler.Spec.OwnerID = "base-model", "base-model"
 	trainer.Spec.TrainingKind, sampler.Spec.TrainingKind = openrlv1alpha1.TrainingKindLoRA, openrlv1alpha1.TrainingKindLoRA
+	trainer.Spec.Exclusive, sampler.Spec.Exclusive = true, true
 	r := newReconciler(t, append(enabledNode(), trainer, sampler)...)
 	r.PlacementStrategy = placement.StrategyBinPack
 
@@ -622,22 +623,22 @@ func TestLoRAKeepsTrainerAndSamplerSeparateUnderContention(t *testing.T) {
 	}
 }
 
-// Both initial packing and the capacity fallback require FFT on every seat,
-// regardless of which kind arrives first. Missing kinds stay exclusive.
-func TestSharingRequiresFFTOnBothSides(t *testing.T) {
+// Both initial packing and the capacity fallback require every seat to be
+// non-exclusive, whichever side arrives first.
+func TestSharingRequiresBothSidesNonExclusive(t *testing.T) {
 	for _, strategy := range []placement.Strategy{placement.StrategyBinPack, placement.StrategySpread} {
-		for _, residentKind := range []openrlv1alpha1.TrainingKind{openrlv1alpha1.TrainingKindFFT, openrlv1alpha1.TrainingKindLoRA, ""} {
-			for _, incomingKind := range []openrlv1alpha1.TrainingKind{openrlv1alpha1.TrainingKindFFT, openrlv1alpha1.TrainingKindLoRA, ""} {
-				t.Run(fmt.Sprintf("%s/%s-then-%s", strategy, residentKind, incomingKind), func(t *testing.T) {
+		for _, residentExclusive := range []bool{false, true} {
+			for _, incomingExclusive := range []bool{false, true} {
+				t.Run(fmt.Sprintf("%s/exclusive=%v-then-%v", strategy, residentExclusive, incomingExclusive), func(t *testing.T) {
 					resident, incoming := trainerWorker("resident", "model-a"), trainerWorker("incoming", "model-b")
-					resident.Spec.TrainingKind, incoming.Spec.TrainingKind = residentKind, incomingKind
+					resident.Spec.Exclusive, incoming.Spec.Exclusive = residentExclusive, incomingExclusive
 					r := newReconciler(t, append(enabledNode(), resident, incoming)...)
 					r.PlacementStrategy = strategy
 					settle(t, r, resident.Name)
 					claim := claimOf(t, r, resident.Name)
 					allocateClaim(t, r, claim)
 					settle(t, r, incoming.Name)
-					canShare := residentKind == openrlv1alpha1.TrainingKindFFT && incomingKind == openrlv1alpha1.TrainingKindFFT
+					canShare := !residentExclusive && !incomingExclusive
 					if got := claimOf(t, r, incoming.Name) == claim; got != (canShare && strategy == placement.StrategyBinPack) {
 						t.Fatalf("initial placement shared=%v", got)
 					}

--- a/scheduler/controller/internal/controller/workload_controller_test.go
+++ b/scheduler/controller/internal/controller/workload_controller_test.go
@@ -113,10 +113,11 @@ func worker(name, modelID string, role openrlv1alpha1.WorkerRole, memory string)
 			CreationTimestamp: metav1.Now(),
 		},
 		Spec: openrlv1alpha1.WorkloadSpec{
-			Role:        role,
-			ModelID:     modelID,
-			Accelerator: openrlv1alpha1.AcceleratorSpec{Memory: resource.MustParse(memory)},
-			Template:    testPodTemplate(),
+			Role:         role,
+			TrainingKind: openrlv1alpha1.TrainingKindFFT,
+			ModelID:      modelID,
+			Accelerator:  openrlv1alpha1.AcceleratorSpec{Memory: resource.MustParse(memory)},
+			Template:     testPodTemplate(),
 		},
 	}
 }
@@ -576,9 +577,84 @@ func TestReconcileSpreadsThenSharesUnderContention(t *testing.T) {
 	}
 }
 
-// Under the binpack strategy the order flips: a worker seats on an eligible
-// allocated claim before cutting one at all, even while a device sits free.
-// Only a worker the node's host memory refuses gets a claim of its own.
+// Always-resident LoRA processes cannot fall back to a shared GPU, even when
+// the trainer and sampler belong to the same base-model runtime.
+func TestLoRAKeepsTrainerAndSamplerSeparateUnderContention(t *testing.T) {
+	trainer := trainerWorker("trainer", "base-model")
+	sampler := worker("sampler", "base-model", openrlv1alpha1.RoleSampler, "24Gi")
+	trainer.Spec.OwnerID, sampler.Spec.OwnerID = "base-model", "base-model"
+	trainer.Spec.TrainingKind, sampler.Spec.TrainingKind = openrlv1alpha1.TrainingKindLoRA, openrlv1alpha1.TrainingKindLoRA
+	r := newReconciler(t, append(enabledNode(), trainer, sampler)...)
+	r.PlacementStrategy = placement.StrategyBinPack
+
+	settle(t, r, "trainer")
+	trainerClaim := claimOf(t, r, "trainer")
+	allocateClaim(t, r, trainerClaim)
+	settle(t, r, "sampler")
+	samplerClaim := claimOf(t, r, "sampler")
+	if samplerClaim == trainerClaim {
+		t.Fatal("LoRA sampler shared the trainer's claim")
+	}
+
+	// A real kube-scheduler refusal must leave the sampler waiting for its
+	// own allocation. Repeated reconciles must not join the available ledger.
+	markUnschedulable(t, r, "sampler", time.Now())
+	for range 3 {
+		runReconcile(t, r, "sampler")
+	}
+	if got := claimOf(t, r, "sampler"); got != samplerClaim {
+		t.Fatalf("waiting sampler moved to claim %q, want %q", got, samplerClaim)
+	}
+	if got := getWorker(t, r, "sampler").Status.Phase; got != openrlv1alpha1.PhasePending {
+		t.Fatalf("unallocated sampler phase %q, want Pending", got)
+	}
+
+	// Once capacity arrives, the original claim is used. A controller restart
+	// must preserve both independent assignments.
+	allocateClaim(t, r, samplerClaim)
+	runReconcile(t, r, "sampler")
+	restarted := newReconciler(t)
+	restarted.Client = r.Client
+	restarted.PlacementStrategy = placement.StrategyBinPack
+	settle(t, restarted, "trainer", "sampler")
+	if claimOf(t, restarted, "trainer") != trainerClaim || claimOf(t, restarted, "sampler") != samplerClaim {
+		t.Fatal("LoRA assignments changed after restart")
+	}
+}
+
+// Both initial packing and the capacity fallback require FFT on every seat,
+// regardless of which kind arrives first. Missing kinds stay exclusive.
+func TestSharingRequiresFFTOnBothSides(t *testing.T) {
+	for _, strategy := range []placement.Strategy{placement.StrategyBinPack, placement.StrategySpread} {
+		for _, residentKind := range []openrlv1alpha1.TrainingKind{openrlv1alpha1.TrainingKindFFT, openrlv1alpha1.TrainingKindLoRA, ""} {
+			for _, incomingKind := range []openrlv1alpha1.TrainingKind{openrlv1alpha1.TrainingKindFFT, openrlv1alpha1.TrainingKindLoRA, ""} {
+				t.Run(fmt.Sprintf("%s/%s-then-%s", strategy, residentKind, incomingKind), func(t *testing.T) {
+					resident, incoming := trainerWorker("resident", "model-a"), trainerWorker("incoming", "model-b")
+					resident.Spec.TrainingKind, incoming.Spec.TrainingKind = residentKind, incomingKind
+					r := newReconciler(t, append(enabledNode(), resident, incoming)...)
+					r.PlacementStrategy = strategy
+					settle(t, r, resident.Name)
+					claim := claimOf(t, r, resident.Name)
+					allocateClaim(t, r, claim)
+					settle(t, r, incoming.Name)
+					canShare := residentKind == openrlv1alpha1.TrainingKindFFT && incomingKind == openrlv1alpha1.TrainingKindFFT
+					if got := claimOf(t, r, incoming.Name) == claim; got != (canShare && strategy == placement.StrategyBinPack) {
+						t.Fatalf("initial placement shared=%v", got)
+					}
+					if claimOf(t, r, incoming.Name) != claim {
+						fallBackToSharing(t, r, incoming.Name)
+					}
+					if got := claimOf(t, r, incoming.Name) == claim; got != canShare {
+						t.Fatalf("after capacity refusal shared=%v, want %v", got, canShare)
+					}
+				})
+			}
+		}
+	}
+}
+
+// Eligible FFT workers pack even while a device sits free. Host memory still
+// limits sharing, so a worker that cannot fit gets its own claim.
 func TestReconcileBinPacksOntoExistingClaims(t *testing.T) {
 	// 128Gi each on a 340Gi node: two park together, a third does not.
 	r := newReconciler(t, append(enabledNode(),

--- a/scheduler/controller/internal/placement/behavior_test.go
+++ b/scheduler/controller/internal/placement/behavior_test.go
@@ -67,14 +67,14 @@ func (c *cluster) arrive(req Request) string {
 				continue
 			}
 			claim := &Claim{Name: "claim-" + req.WorkerID, DeviceCount: tier.Count, Node: node.Name}
-			claim.Book(req.WorkerID, req.OwnerKey(), req.HostRequestBytes)
+			claim.Book(req.WorkerID, req.OwnerKey(), req.HostRequestBytes, req.Shareable)
 			c.fleet.Claims[claim.Name] = claim
 			c.placed[req.WorkerID] = claim
 			return claim.Name
 		}
 	}
 	if join := SelectClaim(req, c.fleet); join != nil {
-		join.Book(req.WorkerID, req.OwnerKey(), req.HostRequestBytes)
+		join.Book(req.WorkerID, req.OwnerKey(), req.HostRequestBytes, req.Shareable)
 		c.placed[req.WorkerID] = join
 		return join.Name
 	}
@@ -169,7 +169,7 @@ func TestWorkersShareAClaimWhetherOrNotTheirSumFits(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			c := newCluster(t, gpu80("gpu", "trainer", "sampler"))
 			first := c.arrive(trainer("trainer", pair[0]))
-			second := c.arrive(Request{Role: "sampler", WorkerID: "sampler", Memory: gib(pair[1])})
+			second := c.arrive(Request{Shareable: true, Role: "sampler", WorkerID: "sampler", Memory: gib(pair[1])})
 			if first == "" || first != second {
 				t.Fatalf("placed on %q and %q, want one shared claim", first, second)
 			}
@@ -199,7 +199,7 @@ func TestAFullNodeMakesTheNextWorkerWaitForHostMemory(t *testing.T) {
 func TestRoleLabelsHideFreeHardware(t *testing.T) {
 	c := newCluster(t, gpu80("trainer-only", "trainer"))
 
-	sampler := Request{Role: "sampler", WorkerID: "sampler", Memory: gib(10)}
+	sampler := Request{Shareable: true, Role: "sampler", WorkerID: "sampler", Memory: gib(10)}
 	if got := c.arrive(sampler); got != "" {
 		t.Fatalf("sampler landed on %q, but the operator allowed no sampler nodes", got)
 	}

--- a/scheduler/controller/internal/placement/placement.go
+++ b/scheduler/controller/internal/placement/placement.go
@@ -19,8 +19,8 @@ const GiB int64 = 1 << 30
 
 // Strategy orders the two placement moves. BinPack seats a worker on an
 // existing ledger first and cuts a claim only when none can hold it; Spread
-// cuts a dedicated claim first and shares when the cluster says no. The
-// zero value reads as binpack.
+// cuts a dedicated claim first and shares when the cluster says no.
+// The zero value reads as binpack.
 type Strategy string
 
 const (
@@ -35,7 +35,7 @@ func ParseStrategy(name string) (Strategy, error) {
 	case "", StrategyBinPack:
 		return StrategyBinPack, nil
 	case StrategySpread:
-		return StrategySpread, nil
+		return Strategy(name), nil
 	}
 	return "", fmt.Errorf("unknown placement strategy %q: want %q or %q", name, StrategySpread, StrategyBinPack)
 }
@@ -79,11 +79,11 @@ func (n *Node) Describe() string {
 type booking struct {
 	owner     string
 	hostBytes int64
+	shareable bool
 }
 
 // Claim is a ResourceClaim, plus what is already sitting on it. Claims are
-// not partitioned by role or workload type: anything the node accepts may
-// join and take turns.
+// shareable only when every seated worker can suspend between GPU turns.
 type Claim struct {
 	Name string
 	// DeviceCount is how many devices DRA allocated, 0 until it has.
@@ -102,11 +102,25 @@ func (c *Claim) Allocated() bool { return c.Node != "" }
 func (c *Claim) Workers() int { return len(c.booked) }
 
 // Book accepts a placement: one more assigned worker and its footprint.
-func (c *Claim) Book(workerID, owner string, hostBytes int64) {
+func (c *Claim) Book(workerID, owner string, hostBytes int64, shareable bool) {
 	if c.booked == nil {
 		c.booked = map[string]booking{}
 	}
-	c.booked[workerID] = booking{owner: owner, hostBytes: hostBytes}
+	c.booked[workerID] = booking{owner: owner, hostBytes: hostBytes, shareable: shareable}
+}
+
+// Shareable requires every existing worker to participate in time slicing.
+// An empty snapshot or a worker with unknown capability is not shareable.
+func (c *Claim) Shareable() bool {
+	if len(c.booked) == 0 {
+		return false
+	}
+	for _, b := range c.booked {
+		if !b.shareable {
+			return false
+		}
+	}
+	return true
 }
 
 // Release gives back a worker's seat and the memory that came with it.
@@ -158,6 +172,8 @@ func (f *Fleet) NodeHostBytes(node *Node) int64 {
 
 // Request is one worker's needs, parsed out of its spec once.
 type Request struct {
+	// Shareable means the worker can suspend between GPU turns.
+	Shareable bool
 	// Role selects node pools and nothing else; it does not partition claims.
 	Role string
 	// Memory is the total accelerator memory the worker needs, across however
@@ -242,6 +258,9 @@ func candidateNodes(req Request, fleet *Fleet) map[string]int {
 // then fewest workers, then name. Advisory -- the ledger's CAS booking is what
 // makes it stick.
 func SelectClaim(req Request, fleet *Fleet) *Claim {
+	if !req.Shareable {
+		return nil
+	}
 	// One pass over the fleet up front: summing bookings per candidate would
 	// rescan every claim for every claim, and SelectClaim runs on every
 	// reconcile of an unplaced worker under BinPack.
@@ -258,7 +277,7 @@ func SelectClaim(req Request, fleet *Fleet) *Claim {
 	var best *Claim
 	for _, claim := range fleet.Claims {
 		node := fleet.Nodes[claim.Node]
-		if !claim.Allocated() || node == nil || !node.Accepts(req.Role) {
+		if !claim.Shareable() || !claim.Allocated() || node == nil || !node.Accepts(req.Role) {
 			continue
 		}
 		if claim.DeviceCount != 1 || req.DevicesOn(node) != 1 {

--- a/scheduler/controller/internal/placement/placement.go
+++ b/scheduler/controller/internal/placement/placement.go
@@ -110,7 +110,7 @@ func (c *Claim) Book(workerID, owner string, hostBytes int64, shareable bool) {
 }
 
 // Shareable requires every existing worker to participate in time slicing.
-// An empty snapshot or a worker with unknown capability is not shareable.
+// An empty snapshot is not shareable.
 func (c *Claim) Shareable() bool {
 	if len(c.booked) == 0 {
 		return false

--- a/scheduler/controller/internal/placement/placement_test.go
+++ b/scheduler/controller/internal/placement/placement_test.go
@@ -48,14 +48,14 @@ func trainer(id string, memoryGiB int64) Request {
 	// that declared it can shard; the single-device default is pinned where
 	// it matters. The host request mirrors the memory figure: the template
 	// asks the node for at least the footprint it may park.
-	return Request{Role: "trainer", WorkerID: id, Memory: gib(memoryGiB), MaxDevices: 8, HostRequestBytes: gib(memoryGiB)}
+	return Request{Shareable: true, Role: "trainer", WorkerID: id, Memory: gib(memoryGiB), MaxDevices: 8, HostRequestBytes: gib(memoryGiB)}
 }
 
 // booked is a claim with workers already assigned to it, charged worker by
 // worker the way readFleet rebuilds one from its ledger's seats.
 func booked(c *Claim, workers ...string) *Claim {
 	for _, worker := range workers {
-		c.Book(worker, worker, 0)
+		c.Book(worker, worker, 0, true)
 	}
 	return c
 }
@@ -137,8 +137,8 @@ func TestSelectClaimRejectsWhenHostMemoryIsFull(t *testing.T) {
 	fleet := NewFleet()
 	fleet.Nodes["n"] = l4Node("n", "trainer") // 94Gi allocatable
 	full := &Claim{Name: "full", DeviceCount: 1, Node: "n"}
-	full.Book("job-a", "job-a", gib(45))
-	full.Book("job-b", "job-b", gib(45))
+	full.Book("job-a", "job-a", gib(45), true)
+	full.Book("job-b", "job-b", gib(45), true)
 	fleet.Claims["full"] = full
 
 	if got := SelectClaim(trainer("job-c", 6), fleet); got != nil {
@@ -206,8 +206,8 @@ func TestTiersPreferTheTightestFit(t *testing.T) {
 // Fairness counts distinct owners, not workers.
 func TestOwnersCountFairnessUnits(t *testing.T) {
 	claim := &Claim{Name: "c", DeviceCount: 1, Node: "n"}
-	claim.Book("trainer-a", "job-a", gib(40))
-	claim.Book("sampler-a", "job-a", gib(20))
+	claim.Book("trainer-a", "job-a", gib(40), true)
+	claim.Book("sampler-a", "job-a", gib(20), true)
 
 	if got := claim.Owners(); got != 1 {
 		t.Errorf("Owners = %d, want 1: a trainer and sampler of one job are one fairness unit", got)

--- a/scheduler/deploy/base/00-claimledger-crd.yaml
+++ b/scheduler/deploy/base/00-claimledger-crd.yaml
@@ -94,6 +94,14 @@ spec:
                         it (the job for FFT workers, the shared base model for LoRA workers).
                         Copied from the workload's spec.ownerID.
                       type: string
+                    trainingKind:
+                      description: |-
+                        TrainingKind is copied from the workload. Only FFT seats may share;
+                        a missing kind prevents new joins until the workload refreshes its seat.
+                      enum:
+                      - fft
+                      - lora
+                      type: string
                     workload:
                       description: |-
                         Workload is the name of the Workload that holds this seat.

--- a/scheduler/deploy/base/00-claimledger-crd.yaml
+++ b/scheduler/deploy/base/00-claimledger-crd.yaml
@@ -79,6 +79,11 @@ spec:
                         the workload status and its pod; a pod carrying an old value is
                         refused GPU access.
                       type: string
+                    exclusive:
+                      description: |-
+                        Exclusive is copied from the workload. A claim holding an exclusive
+                        seat admits no other, and an exclusive worker joins no claim.
+                      type: boolean
                     hostRequest:
                       anyOf:
                       - type: integer
@@ -93,14 +98,6 @@ spec:
                         OwnerID groups workloads that share one GPU turn; the API server sets
                         it (the job for FFT workers, the shared base model for LoRA workers).
                         Copied from the workload's spec.ownerID.
-                      type: string
-                    trainingKind:
-                      description: |-
-                        TrainingKind is copied from the workload. Only FFT seats may share;
-                        a missing kind prevents new joins until the workload refreshes its seat.
-                      enum:
-                      - fft
-                      - lora
                       type: string
                     workload:
                       description: |-

--- a/scheduler/deploy/base/00-workload-crd.yaml
+++ b/scheduler/deploy/base/00-workload-crd.yaml
@@ -95,6 +95,14 @@ spec:
                 required:
                 - memory
                 type: object
+              exclusive:
+                default: true
+                description: |-
+                  Exclusive keeps this worker alone on its GPU. Two workers share a
+                  claim only when neither is exclusive. The gateway sets it from the
+                  training kind, true for LoRA workers because they cannot suspend
+                  between turns. Omitted means exclusive.
+                type: boolean
               modelID:
                 description: |-
                   ModelID names the model this worker serves: configuration for the
@@ -8610,7 +8618,7 @@ spec:
               trainingKind:
                 description: |-
                   TrainingKind records whether this runtime is full fine-tuning or LoRA.
-                  Only FFT can share claims; LoRA and an unspecified kind stay exclusive.
+                  Placement does not read it.
                 enum:
                 - fft
                 - lora
@@ -8633,7 +8641,7 @@ spec:
                 has(self.ownerID) == has(oldSelf.ownerID) && (!has(self.ownerID) ||
                 self.ownerID == oldSelf.ownerID) && has(self.trainingKind) == has(oldSelf.trainingKind)
                 && (!has(self.trainingKind) || self.trainingKind == oldSelf.trainingKind)
-                && self.accelerator == oldSelf.accelerator
+                && self.exclusive == oldSelf.exclusive && self.accelerator == oldSelf.accelerator
           status:
             description: WorkloadStatus is what the controller decided and what came
               of it.

--- a/scheduler/deploy/base/00-workload-crd.yaml
+++ b/scheduler/deploy/base/00-workload-crd.yaml
@@ -8610,7 +8610,7 @@ spec:
               trainingKind:
                 description: |-
                   TrainingKind records whether this runtime is full fine-tuning or LoRA.
-                  Informational: reuse was already decided in the workload's name.
+                  Only FFT can share claims; LoRA and an unspecified kind stay exclusive.
                 enum:
                 - fft
                 - lora
@@ -8631,7 +8631,9 @@ spec:
             - message: placement fields are immutable; delete and recreate the workload
               rule: self.role == oldSelf.role && self.modelID == oldSelf.modelID &&
                 has(self.ownerID) == has(oldSelf.ownerID) && (!has(self.ownerID) ||
-                self.ownerID == oldSelf.ownerID) && self.accelerator == oldSelf.accelerator
+                self.ownerID == oldSelf.ownerID) && has(self.trainingKind) == has(oldSelf.trainingKind)
+                && (!has(self.trainingKind) || self.trainingKind == oldSelf.trainingKind)
+                && self.accelerator == oldSelf.accelerator
           status:
             description: WorkloadStatus is what the controller decided and what came
               of it.

--- a/scheduler/docs/design.md
+++ b/scheduler/docs/design.md
@@ -42,12 +42,12 @@ flowchart TD
     G --> H["node-local time-slicing"]
 ```
 
-Sharing is allowed only between workers whose `trainingKind` is `fft`, because
-those workers participate in suspension. LoRA and unspecified kinds receive
-exclusive claims under either strategy. Each ledger seat records its training
-kind; selection checks every occupant and booking repeats that check inside
-the ledger CAS loop. Old seats without a kind block new joins until their own
-workloads reconcile and refresh them. Existing assignments are preserved.
+Sharing is allowed only between workers whose `spec.exclusive` is false.
+The gateway sets it from the training kind: false for FFT workers, which
+suspend between turns, true for LoRA workers, which stay resident. An
+omitted field is exclusive. Each ledger seat records the flag; selection
+checks every occupant and booking repeats that check inside the ledger CAS
+loop.
 
 A new worker can be placed by exactly two moves: cut a dedicated claim of
 its own, or book a seat on an existing allocated `ClaimLedger` and share. A
@@ -292,6 +292,7 @@ metadata:
 spec:
   role: trainer
   trainingKind: fft
+  exclusive: false
   modelID: job-123
   ownerID: job-123
 

--- a/scheduler/docs/design.md
+++ b/scheduler/docs/design.md
@@ -42,6 +42,13 @@ flowchart TD
     G --> H["node-local time-slicing"]
 ```
 
+Sharing is allowed only between workers whose `trainingKind` is `fft`, because
+those workers participate in suspension. LoRA and unspecified kinds receive
+exclusive claims under either strategy. Each ledger seat records its training
+kind; selection checks every occupant and booking repeats that check inside
+the ledger CAS loop. Old seats without a kind block new joins until their own
+workloads reconcile and refresh them. Existing assignments are preserved.
+
 A new worker can be placed by exactly two moves: cut a dedicated claim of
 its own, or book a seat on an existing allocated `ClaimLedger` and share. A
 flag specifies the strategy. Under `spread`, the worker asks
@@ -619,9 +626,8 @@ that goes wrong is unwound.
 *Dedicated* means the claim is requested for one workload alone. Its
 ClaimLedger starts with a single seat. If the claim allocates, the worker has
 the whole GPU and no time-slicing occurs. Dedicated is a state, not a kind
-of claim: every claim starts dedicated, and the ledger becomes shared if a
-workload that could not get its own GPU books a seat on it. Nothing
-guarantees the GPU stays exclusive. The workload only starts alone on it.
+of claim: every claim starts dedicated. An FFT ledger may become shared when
+another FFT worker books a seat on it. LoRA claims remain exclusive.
 
 A workload without an assignment first receives a dedicated placement attempt:
 
@@ -777,8 +783,7 @@ the dedicated-first arc described above.
 
 * **Claim-affinity first (`binpack`):** book a seat on an eligible ledger
   before cutting a claim at all; only a workload no ledger can seat cuts a
-  dedicated claim. Simpler to reason about and consistent between FFT and
-  LoRA, at the cost of leaving GPUs idle on a fixed fleet. Eligibility and
+  dedicated claim. FFT can share; LoRA always cuts its own claim. Eligibility and
   preference are the shared-ledger rules below, unchanged; a booking that
   loses the last seat to a race falls through to a dedicated claim.
 
@@ -1152,7 +1157,8 @@ mechanism.
 | Two compatible LoRA jobs                | One trainer workload and one sampler workload; the second request receives `AlreadyExists`. |
 | Two FFT jobs                            | Separate trainer and sampler workloads for each job.                                        |
 | Two free GPUs                           | Dedicated claims allocate independently.                                                    |
-| One GPU and two workers                 | One dedicated claim allocates; the other worker joins that ledger on the unschedulable verdict. |
+| One GPU and two FFT workers (`spread`)   | One dedicated claim allocates; the other worker joins that ledger on the unschedulable verdict. |
+| One GPU and two LoRA workers             | One claim allocates; the other worker waits for a free GPU. |
 | Co-located trainer and sampler (one node, one GPU) | The trainer allocates the GPU; the sampler's own claim goes unschedulable and it seats on the trainer's ledger; the two take turns, one fairness owner. |
 | Two concurrent joins                    | One ClaimLedger update succeeds; the other conflicts and retries.                            |
 | Same workload booked into two ledgers    | Only one workload-assignment update succeeds; the losing provisional seat is removed.       |

--- a/scheduler/hack/kind-smoke.sh
+++ b/scheduler/hack/kind-smoke.sh
@@ -110,6 +110,7 @@ metadata: {name: smoke-$i, namespace: $NS}
 spec:
   role: trainer
   trainingKind: fft
+  exclusive: false
   modelID: smoke-$i
   ownerID: smoke
   accelerator: {memory: $MEMORY}

--- a/scheduler/hack/kind-smoke.sh
+++ b/scheduler/hack/kind-smoke.sh
@@ -109,6 +109,7 @@ kind: Workload
 metadata: {name: smoke-$i, namespace: $NS}
 spec:
   role: trainer
+  trainingKind: fft
   modelID: smoke-$i
   ownerID: smoke
   accelerator: {memory: $MEMORY}

--- a/scheduler/hack/stress.sh
+++ b/scheduler/hack/stress.sh
@@ -78,6 +78,7 @@ kind: Workload
 metadata: {name: stress-$i, namespace: $NS}
 spec:
   role: trainer
+  trainingKind: fft
   modelID: stress-$i
   ownerID: stress-$((i % 3))
   accelerator: {memory: $MEMORY}

--- a/scheduler/hack/stress.sh
+++ b/scheduler/hack/stress.sh
@@ -79,6 +79,7 @@ metadata: {name: stress-$i, namespace: $NS}
 spec:
   role: trainer
   trainingKind: fft
+  exclusive: false
   modelID: stress-$i
   ownerID: stress-$((i % 3))
   accelerator: {memory: $MEMORY}

--- a/src/server/estimator.py
+++ b/src/server/estimator.py
@@ -44,8 +44,11 @@ def parameter_count(base_model: str) -> int | None:
 
 
 # On the device: fft trainer 8 B/param (bf16 weights + grads + fp32 master),
-# frozen base 2 B/param; plus activations (trainer) or KV cache (sampler).
-DEVICE_BYTES_PER_PARAM = {("full", "trainer"): 8, ("lora", "trainer"): 2, ("full", "sampler"): 2, ("lora", "sampler"): 2}
+# frozen base 2 B/param; plus activations (trainer). A sampler holds bf16
+# weights plus a KV cache that has to grow with the model: with a flat reserve
+# an 8B sampler on an L4 had 0.23 GiB of KV left after vLLM's own overhead and
+# crash-looped, so it gets 1 B/param of KV on top of the fixed reserve.
+DEVICE_BYTES_PER_PARAM = {("full", "trainer"): 8, ("lora", "trainer"): 2, ("full", "sampler"): 3, ("lora", "sampler"): 3}
 DEVICE_RESERVE_BYTES = {"trainer": 4 * GIB, "sampler": 6 * GIB}
 # Parked in host memory: fft trainer 12 B/param + a weight copy in flight;
 # plus process overhead. Measured: 0.5B trainer 28Gi, sampler 20Gi; 7B FFT

--- a/src/server/estimator.py
+++ b/src/server/estimator.py
@@ -23,7 +23,25 @@ MODEL_TO_PARAM_COUNT: dict[str, int] = {
   "gemma-4-e2b": 5_440_000_000,
   "gemma-4-e4b": 8_000_000_000,
 }
-UNKNOWN_MODEL_PARAMS = 8_000_000_000  # unknown models are sized large, not small
+# bf16 KV cache per token: 2 * full-attention layers * kv heads * head dim * 2
+# bytes, from each model's config.json. Sliding-window and linear-attention
+# layers hold a fixed per-sequence state instead and are left out. Checked
+# against vLLM's "GPU KV cache size" for qwen3-0.6b and qwen3-8b.
+MODEL_TO_KV_BYTES_PER_TOKEN: dict[str, int] = {
+  "qwen2.5-0.5b": 12_288,  # 24 layers, 2 kv heads, head dim 64
+  "qwen3-0.6b": 114_688,  # 28 layers, 8 kv heads, head dim 128
+  "qwen2.5-1.5b": 28_672,  # 28 layers, 2 kv heads, head dim 128
+  "qwen3-1.7b": 114_688,  # 28 layers, 8 kv heads, head dim 128
+  "qwen3-4b": 147_456,  # 36 layers, 8 kv heads, head dim 128
+  "qwen2.5-7b": 57_344,  # 28 layers, 4 kv heads, head dim 128
+  "qwen3-8b": 147_456,  # 36 layers, 8 kv heads, head dim 128
+  "qwen3.5-9b": 32_768,  # 8 of 32 layers are full attention, 4 kv heads, head dim 256
+  "qwen3.5-27b": 65_536,  # 16 of 64 layers are full attention, 4 kv heads, head dim 256
+  "gemma-3-1b": 4_096,  # 4 of 26 layers are global, 1 kv head, head dim 256
+  "gemma-4-e2b": 7_168,  # 7 of 35 layers are full attention, 1 kv head, head dim 256
+  "gemma-4-e4b": 14_336,  # 7 of 42 layers are full attention, 2 kv heads, head dim 256
+}
+UNKNOWN_MODEL = "qwen3-8b"  # unknown models are sized large, not small
 VARIANT_SUFFIXES = ("-instruct", "-it", "-pt", "-base", "-chat")
 
 
@@ -43,13 +61,22 @@ def parameter_count(base_model: str) -> int | None:
   return MODEL_TO_PARAM_COUNT.get(normalize_model_id(base_model))
 
 
-# On the device: fft trainer 8 B/param (bf16 weights + grads + fp32 master),
-# frozen base 2 B/param; plus activations (trainer). A sampler holds bf16
-# weights plus a KV cache that has to grow with the model: with a flat reserve
-# an 8B sampler on an L4 had 0.23 GiB of KV left after vLLM's own overhead and
-# crash-looped, so it gets 1 B/param of KV on top of the fixed reserve.
-DEVICE_BYTES_PER_PARAM = {("full", "trainer"): 8, ("lora", "trainer"): 2, ("full", "sampler"): 3, ("lora", "sampler"): 3}
-DEVICE_RESERVE_BYTES = {"trainer": 4 * GIB, "sampler": 6 * GIB}
+# Trainer on the device: fft 8 B/param (bf16 weights + grads + fp32 master),
+# frozen base 2 B/param; plus activations.
+TRAINER_DEVICE_BYTES_PER_PARAM = {"full": 8, "lora": 2}
+TRAINER_DEVICE_RESERVE_BYTES = 4 * GIB
+# Sampler on the device: bf16 weights, vLLM's activation peak and CUDA graphs,
+# LoRA slot buffers (max_loras 8, rank 64) for a LoRA sampler, and a KV cache
+# sized for SAMPLER_KV_TOKENS. The budget is exactly what vLLM is handed, so
+# whatever the overheads do not use becomes KV cache. Overheads measured on
+# the live samplers: activation peak 0.5 GiB at 0.6B and 1.4 GiB at 8B; LoRA
+# slots 1.05 GiB at 0.6B and 2.9 GiB at 8B.
+SAMPLER_WEIGHT_BYTES_PER_PARAM = 2
+SAMPLER_OVERHEAD_BYTES = GIB // 2
+SAMPLER_OVERHEAD_BYTES_PER_PARAM = 0.125
+SAMPLER_LORA_SLOT_BYTES = GIB
+SAMPLER_LORA_SLOT_BYTES_PER_PARAM = 0.25
+SAMPLER_KV_TOKENS = 8 * 8192  # eight max-length requests in flight
 # Parked in host memory: fft trainer 12 B/param + a weight copy in flight;
 # plus process overhead. Measured: 0.5B trainer 28Gi, sampler 20Gi; 7B FFT
 # trainer OOM-killed at 110Gi.
@@ -77,12 +104,24 @@ class Footprint:
     return {"requests": {"memory": gib(self.host_request_bytes)}, "limits": {"memory": gib(self.host_limit_bytes)}}
 
 
+def sampler_device_bytes(params: int, kv_bytes_per_token: int, kind: str) -> int:
+  device = params * SAMPLER_WEIGHT_BYTES_PER_PARAM
+  device += SAMPLER_OVERHEAD_BYTES + int(params * SAMPLER_OVERHEAD_BYTES_PER_PARAM)
+  if kind == "lora":
+    device += SAMPLER_LORA_SLOT_BYTES + int(params * SAMPLER_LORA_SLOT_BYTES_PER_PARAM)
+  return device + kv_bytes_per_token * SAMPLER_KV_TOKENS
+
+
 def footprint(base_model: str, fine_tuning_type: str, role: str) -> Footprint:
-  params = parameter_count(base_model)
-  if params is None:
-    logger.warning("No known parameter count for %r; sizing it as %.0fB.", base_model, UNKNOWN_MODEL_PARAMS / 1e9)
-    params = UNKNOWN_MODEL_PARAMS
+  model = normalize_model_id(base_model)
+  if model not in MODEL_TO_PARAM_COUNT:
+    logger.warning("No known parameter count for %r; sizing it as %s.", base_model, UNKNOWN_MODEL)
+    model = UNKNOWN_MODEL
+  params = MODEL_TO_PARAM_COUNT[model]
   kind = "lora" if fine_tuning_type == "lora" else "full"
-  device = params * DEVICE_BYTES_PER_PARAM[(kind, role)] + DEVICE_RESERVE_BYTES[role]
+  if role == "trainer":
+    device = params * TRAINER_DEVICE_BYTES_PER_PARAM[kind] + TRAINER_DEVICE_RESERVE_BYTES
+  else:
+    device = sampler_device_bytes(params, MODEL_TO_KV_BYTES_PER_TOKEN[model], kind)
   host = params * HOST_BYTES_PER_PARAM[(kind, role)] + HOST_OVERHEAD_BYTES[role]
   return Footprint(device, host, int(host * HOST_LIMIT_FACTOR))

--- a/src/server/gateway.py
+++ b/src/server/gateway.py
@@ -644,7 +644,9 @@ async def create_sampling_session(req: dict):
   ready_check_id = (model_meta.get("base_model") or target_model_id) if (fine_tuning_type == "lora" and model_meta) else target_model_id
 
   if get_sampler_backend() == "vllm" and ready_check_id:
-    await ensure_sampler_launched(ready_check_id)
+    # Launch by model ID so the worker manager retains the training kind.
+    # LoRA readiness is still reported under the shared base-model runtime.
+    await ensure_sampler_launched(target_model_id)
     s = get_store()
     if hasattr(s, "redis"):
       print(f"[GATEWAY] Waiting for dynamic vLLM sampler worker to be ready for model {ready_check_id}...")

--- a/src/server/scheduler_worker_manager.py
+++ b/src/server/scheduler_worker_manager.py
@@ -58,6 +58,7 @@ class Worker:
   runtime: str
   base_model: str
   is_lora: bool
+  exclusive: bool
   meta: Any
   footprint: Footprint
 
@@ -73,7 +74,9 @@ class Worker:
 def describe_worker(model_id: str, role: str) -> Worker:
   meta, runtime, is_lora = runtime_of(model_id)
   base_model = base_model_of(meta, runtime)
-  return Worker(role, runtime, base_model, is_lora, meta, footprint(base_model, meta.fine_tuning_type, role))
+  # LoRA workers stay resident on the GPU, so they never share one. FFT
+  # workers suspend between turns and may.
+  return Worker(role, runtime, base_model, is_lora, is_lora, meta, footprint(base_model, meta.fine_tuning_type, role))
 
 
 def pod_env(worker: Worker) -> list[dict[str, Any]]:
@@ -137,6 +140,7 @@ def workload_body(worker: Worker) -> dict[str, Any]:
     "spec": {
       "role": worker.role,
       "trainingKind": "lora" if worker.is_lora else "fft",
+      "exclusive": worker.exclusive,
       "modelID": worker.runtime,
       "ownerID": worker.owner,
       "accelerator": {"mode": "SingleGPU", "memory": worker.footprint.accelerator},

--- a/tests/test_estimator.py
+++ b/tests/test_estimator.py
@@ -21,6 +21,13 @@ class FootprintTest(unittest.TestCase):
     self.assertLess(footprint("Qwen/Qwen3-4B", "lora", "trainer").accelerator_bytes, 22 * GIB)
     self.assertGreater(footprint("Qwen/Qwen3-4B", "full", "trainer").accelerator_bytes, 22 * GIB)
 
+  def test_sampler_kv_cache_grows_with_the_model(self) -> None:
+    # An 8B LoRA sampler sized at 22Gi landed on an L4 with 0.23 GiB of KV
+    # cache left and crash-looped; it belongs on the 80GB tier. 4B still fits.
+    self.assertGreater(footprint("Qwen/Qwen3-8B", "lora", "sampler").accelerator_bytes, 22 * GIB)
+    self.assertGreater(footprint("Qwen/Qwen2.5-7B", "lora", "sampler").accelerator_bytes, 22 * GIB)
+    self.assertLess(footprint("Qwen/Qwen3-4B", "lora", "sampler").accelerator_bytes, 22 * GIB)
+
   def test_host_memory_matches_the_measured_points(self) -> None:
     # Qwen2.5-0.5B trial runs measured 28Gi (trainer) and 20Gi (sampler).
     trainer = footprint("Qwen/Qwen2.5-0.5B", "full", "trainer")

--- a/tests/test_estimator.py
+++ b/tests/test_estimator.py
@@ -2,7 +2,11 @@ import sys
 import unittest
 from unittest.mock import patch
 
-from server.estimator import GIB, footprint, parameter_count
+from server.estimator import GIB, MODEL_TO_KV_BYTES_PER_TOKEN, SAMPLER_KV_TOKENS, footprint, normalize_model_id, parameter_count
+
+
+def kv_cache_bytes(model: str) -> int:
+  return MODEL_TO_KV_BYTES_PER_TOKEN[normalize_model_id(model)] * SAMPLER_KV_TOKENS
 
 
 class FootprintTest(unittest.TestCase):
@@ -21,12 +25,23 @@ class FootprintTest(unittest.TestCase):
     self.assertLess(footprint("Qwen/Qwen3-4B", "lora", "trainer").accelerator_bytes, 22 * GIB)
     self.assertGreater(footprint("Qwen/Qwen3-4B", "full", "trainer").accelerator_bytes, 22 * GIB)
 
+  def test_sampler_matches_the_live_samplers(self) -> None:
+    # vLLM on the sweep: handed 7.11 GiB, a Qwen3-0.6B LoRA sampler loaded
+    # 2.17 GiB and had 4.39 GiB of KV cache; handed 21.25 GiB, a Qwen3-8B
+    # LoRA sampler loaded 18.17 GiB and had 1.49 GiB. The model must land
+    # within 0.3 GiB of the KV cache each actually got.
+    for model, budget, kv in (("Qwen/Qwen3-0.6B", 7.11, 4.39), ("Qwen/Qwen3-8B", 21.25, 1.49)):
+      fp = footprint(model, "lora", "sampler")
+      predicted_kv = kv_cache_bytes(model) - (fp.accelerator_bytes - budget * GIB)
+      self.assertAlmostEqual(predicted_kv / GIB, kv, delta=0.3, msg=model)
+
   def test_sampler_kv_cache_grows_with_the_model(self) -> None:
     # An 8B LoRA sampler sized at 22Gi landed on an L4 with 0.23 GiB of KV
-    # cache left and crash-looped; it belongs on the 80GB tier. 4B still fits.
+    # cache left and crash-looped; it belongs on the 80GB tier. 4B still fits,
+    # and a 27B sampler still fits one 80GB device.
     self.assertGreater(footprint("Qwen/Qwen3-8B", "lora", "sampler").accelerator_bytes, 22 * GIB)
-    self.assertGreater(footprint("Qwen/Qwen2.5-7B", "lora", "sampler").accelerator_bytes, 22 * GIB)
     self.assertLess(footprint("Qwen/Qwen3-4B", "lora", "sampler").accelerator_bytes, 22 * GIB)
+    self.assertLess(footprint("Qwen/Qwen3.5-27B", "lora", "sampler").accelerator_bytes, 79 * GIB)
 
   def test_host_memory_matches_the_measured_points(self) -> None:
     # Qwen2.5-0.5B trial runs measured 28Gi (trainer) and 20Gi (sampler).
@@ -55,8 +70,7 @@ class FootprintTest(unittest.TestCase):
   def test_unknown_models_are_sized_large(self) -> None:
     with self.assertLogs("server.estimator", level="WARNING"):
       unknown = footprint("meta-llama/Llama-3-70B", "lora", "sampler")
-    # gemma-4-e4b holds exactly UNKNOWN_MODEL_PARAMS raw weights.
-    self.assertEqual(unknown, footprint("google/gemma-4-e4b", "lora", "sampler"))
+    self.assertEqual(unknown, footprint("Qwen/Qwen3-8B", "lora", "sampler"))
 
   def test_restored_models_are_sized_as_full_fine_tunes(self) -> None:
     self.assertEqual(footprint("Qwen/Qwen3-4B", "restored", "trainer"), footprint("Qwen/Qwen3-4B", "full", "trainer"))

--- a/tests/test_scheduler_worker_manager.py
+++ b/tests/test_scheduler_worker_manager.py
@@ -68,6 +68,7 @@ class SchedulerWorkerManagerTest(unittest.TestCase):
     self.assertEqual(trainer["spec"]["ownerID"], "qwen-qwen2-5-0-5b")
     self.assertEqual(trainer["spec"]["ownerID"], sampler["spec"]["ownerID"])
     self.assertEqual(trainer["spec"]["trainingKind"], "lora")
+    self.assertTrue(trainer["spec"]["exclusive"])
     self.assertEqual(trainer["spec"]["accelerator"], {"mode": "SingleGPU", "memory": footprint("Qwen/Qwen2.5-0.5B", "lora", "trainer").accelerator})
     t_container = trainer["spec"]["template"]["spec"]["containers"][0]
     s_container = sampler["spec"]["template"]["spec"]["containers"][0]
@@ -87,6 +88,7 @@ class SchedulerWorkerManagerTest(unittest.TestCase):
     self.assertEqual(worker["metadata"]["name"], "fft-model-a-1-trainer")
     self.assertEqual(worker["spec"]["ownerID"], "model-a-1")
     self.assertEqual(worker["spec"]["trainingKind"], "fft")
+    self.assertFalse(worker["spec"]["exclusive"])
     self.assertEqual(worker["spec"]["accelerator"]["memory"], footprint("Qwen/Qwen3-8B", "full", "trainer").accelerator)
     container = worker["spec"]["template"]["spec"]["containers"][0]
     env = {e["name"]: e.get("value") for e in container["env"]}

--- a/tests/test_scheduler_worker_manager.py
+++ b/tests/test_scheduler_worker_manager.py
@@ -4,6 +4,7 @@ import unittest
 from typing import Any
 from unittest.mock import patch
 
+from server import gateway
 from server.estimator import footprint
 from server.scheduler_worker_manager import GROUP, PLURAL, VERSION, SchedulerWorkerManager
 from server.store import InMemoryStore
@@ -155,6 +156,30 @@ class SchedulerWorkerManagerTest(unittest.TestCase):
     ):
       create_worker_manager()
       manager_cls.assert_called_once()
+
+
+class MixedSamplingSessionTest(unittest.IsolatedAsyncioTestCase):
+  async def test_lora_and_fft_sessions_launch_their_own_sampler_types(self) -> None:
+    store = InMemoryStore()
+    for model_id, kind in (("lora-a", "lora"), ("lora-b", "lora"), ("fft-a", "full")):
+      await store.set_value(f"open_rl:model_meta:{model_id}", json.dumps({"base_model": "Qwen/Qwen2.5-0.5B", "fine_tuning_type": kind}))
+    api = _FakeCustomObjectsApi()
+    with (
+      patch.dict(os.environ, {"REDIS_URL": "redis://localhost:6379", "OPEN_RL_ENABLE_FFT": "true", "SAMPLING_BACKEND": "vllm"}),
+      patch("server.store.get_store", return_value=store),
+      patch.object(gateway, "store", store),
+      patch.object(gateway, "get_store", return_value=store),
+      patch.object(gateway, "worker_manager", SchedulerWorkerManager(custom_api=api)),
+    ):
+      for model_id in ("lora-a", "fft-a", "lora-b"):
+        await gateway.create_sampling_session({"model_path": f"tinker://{model_id}/sampler_weights/checkpoint"})
+
+    self.assertEqual(len(api.created), 2, "LoRA sessions should reuse one sampler while FFT gets its own")
+    lora, fft = api.created
+    self.assertEqual(lora["spec"]["trainingKind"], "lora")
+    self.assertEqual(lora["spec"]["template"]["spec"]["containers"][0]["command"][-1], "server.lora_sampler")
+    self.assertEqual(fft["spec"]["trainingKind"], "fft")
+    self.assertEqual(fft["metadata"]["name"], "fft-fft-a-sampler")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Because LoRA workers are not currently suspend-able they should be given exclusive access over a GPU and be torn down when done. This PR makes the scheduler aware of the kind of worker we are placing, FFT workers are suspendable so they can be timesliced against one another but LoRA cannot. Also changed the estimator to fix #230 