### PR TITLE
Slim server image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,17 +136,17 @@ require-gcp-project:
 	@test -n "$(GCP_PROJECT)" || { echo "Set GCP_PROJECT=<your-project> for private image builds/deploys"; exit 2; }
 
 build-images: require-gcp-project
-	DOCKER_BUILDKIT=1 docker build -t gcr.io/$(GCP_PROJECT)/open-rl-server:$(IMAGE_TAG) -f src/server/Dockerfile .
-	DOCKER_BUILDKIT=1 docker build -t gcr.io/$(GCP_PROJECT)/open-rl-gateway:$(IMAGE_TAG) -f src/server/Dockerfile.gateway .
-	DOCKER_BUILDKIT=1 docker build -t gcr.io/$(GCP_PROJECT)/open-rl-client:$(IMAGE_TAG) -f src/server/Dockerfile.client .
+	DOCKER_BUILDKIT=1 docker build -t $(CLOUD_REGISTRY)/open-rl-server:$(IMAGE_TAG) -f src/server/Dockerfile .
+	DOCKER_BUILDKIT=1 docker build -t $(CLOUD_REGISTRY)/open-rl-gateway:$(IMAGE_TAG) -f src/server/Dockerfile.gateway .
+	DOCKER_BUILDKIT=1 docker build -t $(CLOUD_REGISTRY)/open-rl-client:$(IMAGE_TAG) -f src/server/Dockerfile.client .
 
 push-images: require-gcp-project
-	docker push gcr.io/$(GCP_PROJECT)/open-rl-server:$(IMAGE_TAG)
-	docker push gcr.io/$(GCP_PROJECT)/open-rl-gateway:$(IMAGE_TAG)
-	docker push gcr.io/$(GCP_PROJECT)/open-rl-client:$(IMAGE_TAG)
-	kubectl set image deployment/open-rl-gateway gateway=gcr.io/$(GCP_PROJECT)/open-rl-gateway:$(IMAGE_TAG) 2>/dev/null || true
-	kubectl set image daemonset/open-rl-accel-timeslicer accel-timeslicer=gcr.io/$(GCP_PROJECT)/open-rl-server:$(IMAGE_TAG) 2>/dev/null || true
-	kubectl set env deployment/open-rl-gateway OPEN_RL_WORKER_IMAGE=gcr.io/$(GCP_PROJECT)/open-rl-server:$(IMAGE_TAG) 2>/dev/null || true
+	docker push $(CLOUD_REGISTRY)/open-rl-server:$(IMAGE_TAG)
+	docker push $(CLOUD_REGISTRY)/open-rl-gateway:$(IMAGE_TAG)
+	docker push $(CLOUD_REGISTRY)/open-rl-client:$(IMAGE_TAG)
+	kubectl set image deployment/open-rl-gateway gateway=$(CLOUD_REGISTRY)/open-rl-gateway:$(IMAGE_TAG) 2>/dev/null || true
+	kubectl set image daemonset/open-rl-accel-timeslicer accel-timeslicer=$(CLOUD_REGISTRY)/open-rl-server:$(IMAGE_TAG) 2>/dev/null || true
+	kubectl set env deployment/open-rl-gateway OPEN_RL_WORKER_IMAGE=$(CLOUD_REGISTRY)/open-rl-server:$(IMAGE_TAG) 2>/dev/null || true
 
 # --- Cloud Build ------------------------------------------------------------
 # Builds in GCP instead of locally: `gcloud builds submit` uploads only the
@@ -167,28 +167,34 @@ CLOUD_IMAGE_TAG ?= $(shell test -z "$$(git status --porcelain 2>/dev/null)" && e
 # time -- on every reference within a single make invocation.
 CLOUD_IMAGE_TAG := $(CLOUD_IMAGE_TAG)
 
+# Registry the cloud images are pushed to and deployed from. gcr.io is the
+# historical default; a regional Artifact Registry repo (for example
+# us-central1-docker.pkg.dev/$(GCP_PROJECT)/open-rl) is what GKE image
+# streaming requires.
+CLOUD_REGISTRY ?= gcr.io/$(GCP_PROJECT)
+
 CLOUD_BUILD = gcloud builds submit --project=$(GCP_PROJECT) --config=cloudbuild.yaml
 
 cloud-build-gateway: require-gcp-project
-	$(CLOUD_BUILD) --substitutions=_IMAGE=gcr.io/$(GCP_PROJECT)/open-rl-gateway,_DOCKERFILE=src/server/Dockerfile.gateway,_TAG=$(CLOUD_IMAGE_TAG) .
+	$(CLOUD_BUILD) --substitutions=_IMAGE=$(CLOUD_REGISTRY)/open-rl-gateway,_DOCKERFILE=src/server/Dockerfile.gateway,_TAG=$(CLOUD_IMAGE_TAG) .
 
 cloud-build-server: require-gcp-project
-	$(CLOUD_BUILD) --substitutions=_IMAGE=gcr.io/$(GCP_PROJECT)/open-rl-server,_DOCKERFILE=src/server/Dockerfile,_TAG=$(CLOUD_IMAGE_TAG) .
+	$(CLOUD_BUILD) --substitutions=_IMAGE=$(CLOUD_REGISTRY)/open-rl-server,_DOCKERFILE=src/server/Dockerfile,_TAG=$(CLOUD_IMAGE_TAG) .
 
 cloud-build-client: require-gcp-project
-	$(CLOUD_BUILD) --substitutions=_IMAGE=gcr.io/$(GCP_PROJECT)/open-rl-client,_DOCKERFILE=src/server/Dockerfile.client,_TAG=$(CLOUD_IMAGE_TAG) .
+	$(CLOUD_BUILD) --substitutions=_IMAGE=$(CLOUD_REGISTRY)/open-rl-client,_DOCKERFILE=src/server/Dockerfile.client,_TAG=$(CLOUD_IMAGE_TAG) .
 
 # Point the running workloads at the freshly built tag. Split from the build
 # steps so a tag built earlier can be re-deployed with
 # `make cloud-deploy-gateway CLOUD_IMAGE_TAG=<tag>`.
 cloud-deploy-gateway: require-gcp-project
-	kubectl set image deployment/open-rl-gateway gateway=gcr.io/$(GCP_PROJECT)/open-rl-gateway:$(CLOUD_IMAGE_TAG)
-	@echo "gateway -> gcr.io/$(GCP_PROJECT)/open-rl-gateway:$(CLOUD_IMAGE_TAG)"
+	kubectl set image deployment/open-rl-gateway gateway=$(CLOUD_REGISTRY)/open-rl-gateway:$(CLOUD_IMAGE_TAG)
+	@echo "gateway -> $(CLOUD_REGISTRY)/open-rl-gateway:$(CLOUD_IMAGE_TAG)"
 
 cloud-deploy-server: require-gcp-project
-	kubectl set image daemonset/open-rl-accel-timeslicer accel-timeslicer=gcr.io/$(GCP_PROJECT)/open-rl-server:$(CLOUD_IMAGE_TAG) 2>/dev/null || true
-	kubectl set env deployment/open-rl-gateway OPEN_RL_WORKER_IMAGE=gcr.io/$(GCP_PROJECT)/open-rl-server:$(CLOUD_IMAGE_TAG)
-	@echo "workers -> gcr.io/$(GCP_PROJECT)/open-rl-server:$(CLOUD_IMAGE_TAG)"
+	kubectl set image daemonset/open-rl-accel-timeslicer accel-timeslicer=$(CLOUD_REGISTRY)/open-rl-server:$(CLOUD_IMAGE_TAG) 2>/dev/null || true
+	kubectl set env deployment/open-rl-gateway OPEN_RL_WORKER_IMAGE=$(CLOUD_REGISTRY)/open-rl-server:$(CLOUD_IMAGE_TAG)
+	@echo "workers -> $(CLOUD_REGISTRY)/open-rl-server:$(CLOUD_IMAGE_TAG)"
 
 cloud-rollout-gateway: cloud-build-gateway cloud-deploy-gateway
 cloud-rollout-server: cloud-build-server cloud-deploy-server

--- a/src/server/Dockerfile
+++ b/src/server/Dockerfile
@@ -1,5 +1,17 @@
-# Use NVIDIA CUDA 12.9.0 devel base image for PyTorch/vLLM runtime compilation
-FROM nvidia/cuda:12.9.0-devel-ubuntu22.04
+# NVIDIA CUDA 12.9.0 *base* image (driver shim + cudart only, ~0.45 GB).
+#
+# The devel image this used to build on is ~10 GB, almost all of it a second
+# copy of the CUDA libraries: torch and vLLM link against the pip-installed
+# nvidia-*-cu12 wheels inside /app/.venv, not /usr/local/cuda. The only pieces
+# of the toolkit the image needs from outside the venv are the ones the runtime
+# JIT compilers (FlashInfer, tilelang, torch cpp extensions) shell out to: the
+# 12.9 `nvcc` and the cudart/driver headers and stubs. Those are installed
+# below from the CUDA apt repo the base image already configures, so that
+# CUDA_HOME=/usr/local/cuda stays a complete, version-matched toolchain root.
+# (The pip nvidia-cuda-nvcc-cu12 wheel ships only ptxas; the only nvcc binary
+# in the venv is the CUDA 13.2 one under nvidia/cu13, which cannot drive
+# 12.9 builds.)
+FROM nvidia/cuda:12.9.0-base-ubuntu22.04
 
 # Set environment variables
 ENV PYTHONUNBUFFERED=1 \
@@ -7,7 +19,13 @@ ENV PYTHONUNBUFFERED=1 \
     DEBIAN_FRONTEND=noninteractive \
     UV_FROZEN=1
 
-# Install dependencies
+# Install dependencies. python3-dev is required for compiling Triton runtime
+# kernels during vLLM engine initialization. cuda-nvcc-12-9 (nvcc, cicc,
+# ptxas, nvvm) and cuda-cudart-dev-12-9 (cuda.h, cuda_runtime.h, cuda_bf16.h,
+# CCCL headers, libcudart.so and the libcuda.so link stub) are the runtime-JIT
+# subset of the devel image; versions are pinned like the upstream images do.
+ARG NV_CUDA_NVCC_VERSION=12.9.86-1
+ARG NV_CUDA_CUDART_DEV_VERSION=12.9.79-1
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     ca-certificates \
@@ -15,6 +33,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     python3-dev \
     ninja-build \
+    cuda-nvcc-12-9=${NV_CUDA_NVCC_VERSION} \
+    cuda-cudart-dev-12-9=${NV_CUDA_CUDART_DEV_VERSION} \
     && rm -rf /var/lib/apt/lists/*
 
 # Install uv
@@ -56,6 +76,32 @@ ENV UV_LINK_MODE=copy \
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-install-project --extra gpu --extra vllm --extra cluster
 
+# Expose the pip CUDA wheels' headers and link-time library names through
+# CUDA_HOME. The devel image supplied these via the lib*-dev debs; runtime JIT
+# needs them (FlashInfer's sampling kernels include curand.h, its GEMM modules
+# cublas_v2.h, fused MoE links -lnvrtc; tilelang also reaches for cudnn.h and
+# nvshmem.h). Symlinks only, so the libraries are not duplicated and existing
+# apt-provided files (cudart, driver, CCCL, crt) win. nvidia/cu13 is skipped:
+# it is the CUDA 13 toolkit cuda-tile drags in and must not shadow 12.9.
+# Both the SONAME (lib*.so.N) and the unversioned link name are mirrored, as
+# in the devel image: ld resolves DT_NEEDED entries such as libcublas ->
+# libcublasLt.so.12 by the versioned name. At runtime the symlinks resolve to
+# the very files torch already loads, and glibc dedups by inode.
+RUN set -eu; \
+    sp=/app/.venv/lib/python3.12/site-packages/nvidia; \
+    inc=/usr/local/cuda/include; lib=/usr/local/cuda/lib64; \
+    for d in "$sp"/*/; do \
+        case "$d" in */cu13/) continue;; esac; \
+        if [ -d "$d/include" ]; then cp -rsn "$d/include/." "$inc/"; fi; \
+        [ -d "$d/lib" ] || continue; \
+        for so in "$d"lib/lib*.so.*; do \
+            [ -e "$so" ] || continue; \
+            name=$(basename "$so"); base="${name%%.so.*}.so"; \
+            [ -e "$lib/$name" ] || ln -s "$so" "$lib/$name"; \
+            [ -e "$lib/$base" ] || ln -s "$so" "$lib/$base"; \
+        done; \
+    done
+
 # Copy patch script specifically
 COPY src/server/scripts/patch_vllm_lora_dedup.py /app/src/server/scripts/patch_vllm_lora_dedup.py
 
@@ -67,6 +113,9 @@ COPY . .
 
 ENV PATH="/usr/local/cuda/bin:$PATH" \
     CUDA_HOME="/usr/local/cuda" \
+    # The devel image exported this so JIT-built extensions can link -lcuda
+    # against the driver stub; the base image does not.
+    LIBRARY_PATH="/usr/local/cuda/lib64/stubs" \
     PYTHONPATH="/app/src:/app:$PYTHONPATH" \
     # GKE's device plugin mounts the NVIDIA driver (libcuda.so) at
     # /usr/local/nvidia; the 12.9.0-devel base image dropped it from


### PR DESCRIPTION
## Slim server image + configurable cloud registry

**Server image: 24.5 GB → 15.4 GB unpacked (12.1 → 6.8 GB compressed)**

The server image built on `nvidia/cuda:12.9.0-devel`, a 10 GB base that is almost entirely a second copy of the CUDA libraries. torch and vLLM never load it: they link against the `nvidia-*-cu12` wheels inside the venv.

This switches to the 0.45 GB `base` image and adds back only what runtime JIT compilers (FlashInfer, tilelang, torch cpp extensions) reach for outside the venv:

- the pinned 12.9 `nvcc` and `cudart-dev` debs from the CUDA apt repo the base image already configures
- symlinks from the wheels' `include/` and `lib*.so*` into `/usr/local/cuda`, so `CUDA_HOME` stays a complete, version-matched toolchain root without duplicating libraries (the CUDA 13 toolkit that `cuda-tile` pulls in is skipped so it cannot shadow 12.9)

**Validated:** kind 2x L4 (tiny-rl LoRA, tiny-fft-rl); GKE tiny-fft-rl on L4, fft-gsm8k-rl Qwen3-8B on H100, fft-gsm8k-rl-x3-hetero-8b-0.6b with time-sliced H100 claims. **Not yet exercised:** a kernel actually compiled by the installed nvcc at runtime; prebuilt FlashInfer cubins covered every run.

**Makefile: `CLOUD_REGISTRY`**

New variable used by `cloud-build-*`, `cloud-deploy-*`, `build-images`, `push-images`. Defaults to the existing `gcr.io/$(GCP_PROJECT)`, so nothing changes unless you set it, e.g. `CLOUD_REGISTRY=us-central1-docker.pkg.dev/$(GCP_PROJECT)/open-rl` for Artifact Registry.