### PR TITLE
Fix Gemma tokenizer routing and delta name mapping, add a two-family e2e scenario

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -29,20 +29,22 @@ options:
 timeout: 3600s
 
 steps:
+  # buildx with the docker-container driver so the layer cache can live in a
+  # dedicated registry ref. The inline cache (BUILDKIT_INLINE_CACHE) embedded
+  # in :latest is lossy: a build that was itself fully cached publishes a
+  # manifest the next build cannot use, and the CUDA image rebuilds from
+  # scratch. mode=max records every layer, including intermediate ones, so an
+  # unchanged Dockerfile always hits.
   - name: gcr.io/cloud-builders/docker
-    env: ['DOCKER_BUILDKIT=1']
+    args: [buildx, create, --use, --driver, docker-container]
+  - name: gcr.io/cloud-builders/docker
     args:
+      - buildx
       - build
       - --file=${_DOCKERFILE}
       - --tag=${_IMAGE}:${_TAG}
       - --tag=${_IMAGE}:latest
-      # Warm-start from the previous build. BUILDKIT_INLINE_CACHE embeds the
-      # cache manifest in the pushed image so :latest is usable as --cache-from
-      # without a separate cache repository.
-      - --cache-from=${_IMAGE}:latest
-      - --build-arg=BUILDKIT_INLINE_CACHE=1
+      - --cache-from=type=registry,ref=${_IMAGE}:buildcache
+      - --cache-to=type=registry,ref=${_IMAGE}:buildcache,mode=max
+      - --push
       - .
-
-images:
-  - '${_IMAGE}:${_TAG}'
-  - '${_IMAGE}:latest'

--- a/docs/fft/fft.md
+++ b/docs/fft/fft.md
@@ -297,6 +297,10 @@ To verify two concurrent jobs on different model families (each job must get its
 ```bash
 make test e2e tiny-fft-rl-x2-families TRAINING_TEST_ARGS="sampling_backend=vllm trainer_gpu=0 sampler_gpu=1 base_model=Qwen/Qwen3-0.6B second_base_model=google/gemma-4-e2b"
 ```
+To run two Text-to-SQL FFT RL experiments side by side, give each job its own overrides with `extra_a=` / `extra_b=` (layered over `extra=`); setting `model.base_model` in one of them switches that job's model and tokenizer:
+```bash
+make test e2e fft-textsql-rl-x2 TRAINING_TEST_ARGS="sampling_backend=vllm trainer_gpu=0 sampler_gpu=1 steps=40 base_model=google/gemma-4-e2b extra_a='rl.learning_rate=1e-6' extra_b='rl.learning_rate=5e-6'"
+```
 
 ---
 

--- a/docs/fft/fft.md
+++ b/docs/fft/fft.md
@@ -293,6 +293,10 @@ To execute concurrent dual-job time-slicing verification:
 ```bash
 make test e2e tiny-fft-rl-x2 TRAINING_TEST_ARGS="sampling_backend=vllm trainer_gpu=0 sampler_gpu=1 steps=5"
 ```
+To verify two concurrent jobs on different model families (each job must get its own tokenizer, names and workers):
+```bash
+make test e2e tiny-fft-rl-x2-families TRAINING_TEST_ARGS="sampling_backend=vllm trainer_gpu=0 sampler_gpu=1 base_model=Qwen/Qwen3-0.6B second_base_model=google/gemma-4-e2b"
+```
 
 ---
 

--- a/examples/text-to-sql/texttosql_sft_grpo.py
+++ b/examples/text-to-sql/texttosql_sft_grpo.py
@@ -23,6 +23,7 @@ from typing import Any, cast
 import chz
 import tinker
 from tinker import types
+from tinker.lib.retry_handler import RetryConfig
 from tinker_cookbook.utils import ml_log
 from transformers import AutoTokenizer, PreTrainedTokenizerBase
 from utils.helpers import (
@@ -488,6 +489,9 @@ class Config:
   base_url: str = os.getenv("TINKER_BASE_URL", BASE_URL)
   seed: int = 30
   grad_clip_norm: float = 0.3
+  # Fail the run if no request makes progress for this long; a step takes
+  # seconds to a few minutes, so 15 minutes means something is lost or stuck.
+  progress_timeout_sec: int = 15 * 60
   log_dir: str = str(LOG_DIR)
   sft_adapter_name: str | None = None
   dataset: DatasetConfig = chz.field(default_factory=DatasetConfig)
@@ -539,6 +543,9 @@ if __name__ == "__main__":
     api_key=os.getenv("TINKER_API_KEY", "tml-dummy-key"),
     base_url=config.base_url,
     default_headers=default_headers,
+    # A request the backend loses would otherwise keep the run waiting for the
+    # SDK's two-hour default before it fails.
+    retry_config=RetryConfig(progress_timeout=config.progress_timeout_sec),
   )
   tokenizer = AutoTokenizer.from_pretrained(config.model.tokenizer_name)
 

--- a/examples/text-to-sql/texttosql_sft_grpo.py
+++ b/examples/text-to-sql/texttosql_sft_grpo.py
@@ -23,7 +23,6 @@ from typing import Any, cast
 import chz
 import tinker
 from tinker import types
-from tinker.lib.retry_handler import RetryConfig
 from tinker_cookbook.utils import ml_log
 from transformers import AutoTokenizer, PreTrainedTokenizerBase
 from utils.helpers import (
@@ -57,6 +56,18 @@ LossValue = float | int
 
 
 # *** Training phases (SFT + PPO+KL RL) ***
+async def bounded(awaitable: Any, what: str) -> Any:
+  """Awaits a backend round trip, failing the run instead of waiting on a lost request.
+
+  The tinker client retries a stuck request for two hours by default; a
+  training step here takes seconds to a few minutes, so a much shorter bound
+  turns a request the backend dropped into a clear error naming the step."""
+  try:
+    return await asyncio.wait_for(awaitable, timeout=config.progress_timeout_sec)
+  except TimeoutError as exc:
+    raise RuntimeError(f"No result for {what} within {config.progress_timeout_sec}s; the request was probably lost in the backend") from exc
+
+
 async def run_sft_phase(
   trainer: tinker.TrainingClient,
   train_examples: list[dict[str, Any]],
@@ -81,8 +92,8 @@ async def run_sft_phase(
     fwdbwd_future = await trainer.forward_backward_async(datums, "cross_entropy")
     optim_future = await trainer.optim_step_async(types.AdamParams(learning_rate=config.sft.learning_rate, grad_clip_norm=config.grad_clip_norm))
 
-    fwdbwd = await fwdbwd_future
-    await optim_future
+    fwdbwd = await bounded(fwdbwd_future, f"forward_backward sft step {local_step}")
+    await bounded(optim_future, f"optim_step sft step {local_step}")
 
     loss = float(fwdbwd.metrics.get("loss:sum", 0.0)) / max(1, active_tokens)
     losses.append(loss)
@@ -120,14 +131,16 @@ async def run_rl_phase(
   sampling_params = types.SamplingParams(max_tokens=config.rl.max_tokens, temperature=config.rl.temperature)
   for local_step in range(1, config.rl.steps + 1):
     # --- Rollout: save weights, sample N completions per prompt, score them ---
-    sampler = await trainer.save_weights_and_get_sampling_client_async(name=f"texttosql_rl_rollout_s{local_step}")
+    sampler = await bounded(
+      trainer.save_weights_and_get_sampling_client_async(name=f"texttosql_rl_rollout_s{local_step}"), f"save_weights step {local_step}"
+    )
     examples = next(batches)
 
     futures = []
     for ex in examples:
       prompt = types.ModelInput.from_ints(tokens=ex["prompt_tokens"])
       futures.append(sampler.sample_async(prompt=prompt, num_samples=config.rl.samples_per_prompt, sampling_params=sampling_params))
-    responses = await asyncio.gather(*futures)
+    responses = await bounded(asyncio.gather(*futures), f"sampling step {local_step}")
 
     datums: list[types.Datum] = []
     rollouts: list[dict[str, Any]] = []
@@ -166,8 +179,8 @@ async def run_rl_phase(
       datums, config.rl.loss_fn, loss_fn_config={"clip_range": config.rl.clip_range, "kl_coeff": config.rl.kl_coeff}
     )
     optim_future = await trainer.optim_step_async(types.AdamParams(learning_rate=config.rl.learning_rate, grad_clip_norm=config.grad_clip_norm))
-    fwdbwd = await fwdbwd_future
-    await optim_future
+    fwdbwd = await bounded(fwdbwd_future, f"forward_backward step {local_step}")
+    await bounded(optim_future, f"optim_step step {local_step}")
 
     # --- Log: best rollout sample, per-step metrics, periodic eval ---
     best = max(rollouts, key=lambda r: (r["reward"], r["execution_match"], r["compile"]))
@@ -489,8 +502,8 @@ class Config:
   base_url: str = os.getenv("TINKER_BASE_URL", BASE_URL)
   seed: int = 30
   grad_clip_norm: float = 0.3
-  # Fail the run if no request makes progress for this long; a step takes
-  # seconds to a few minutes, so 15 minutes means something is lost or stuck.
+  # Fail the run if a backend round trip takes longer than this; a step takes
+  # seconds to a few minutes, so 15 minutes means a request is lost or stuck.
   progress_timeout_sec: int = 15 * 60
   log_dir: str = str(LOG_DIR)
   sft_adapter_name: str | None = None
@@ -543,9 +556,6 @@ if __name__ == "__main__":
     api_key=os.getenv("TINKER_API_KEY", "tml-dummy-key"),
     base_url=config.base_url,
     default_headers=default_headers,
-    # A request the backend loses would otherwise keep the run waiting for the
-    # SDK's two-hour default before it fails.
-    retry_config=RetryConfig(progress_timeout=config.progress_timeout_sec),
   )
   tokenizer = AutoTokenizer.from_pretrained(config.model.tokenizer_name)
 

--- a/examples/tiny/tiny_rl.py
+++ b/examples/tiny/tiny_rl.py
@@ -99,7 +99,11 @@ def main(config: Config) -> None:
 
   try:
     tokenizer = trainer.get_tokenizer()
-    prompt_tokens = tokenizer.encode(config.prompt, add_special_tokens=False)
+    # The gateway names this tokenizer; a wrong one turns every sample below into token soup.
+    print(f"[tiny-rl] base_model={config.base_model} tokenizer={getattr(tokenizer, 'name_or_path', type(tokenizer).__name__)}")
+    # Keep the tokenizer's special tokens: Gemma degenerates into repeated
+    # fragments without its BOS token, and Qwen tokenizers add nothing here.
+    prompt_tokens = tokenizer.encode(config.prompt, add_special_tokens=True)
     prompt = types.ModelInput.from_ints(tokens=prompt_tokens)
     sampling_params = types.SamplingParams(max_tokens=config.max_tokens, temperature=config.temperature)
 
@@ -114,6 +118,7 @@ def main(config: Config) -> None:
         if not tokens or len(tokens) != len(logprobs):
           raise RuntimeError(f"Sampler must return aligned tokens and logprobs, got {len(tokens)} tokens and {len(logprobs)} logprobs")
         rewards.append(1.0 if config.target in tokenizer.decode(tokens) else 0.0)
+      print(f"[tiny-rl] step={step:02d} sample[0]={tokenizer.decode(list(sequences[0].tokens))[:160]!r}")
 
       # Group-centered advantages; when every reward ties, fall back to a uniform
       # positive advantage so the update still exercises a nonzero gradient.

--- a/scripts/run_training_e2e.py
+++ b/scripts/run_training_e2e.py
@@ -12,17 +12,23 @@ Scenarios ("tiny-" = minimal overfit/smoke tests; the rest are real workloads):
                         two concurrent tiny-rl jobs on base_model and
                         second_base_model, one per model family (asserts each
                         job earns a reward, i.e. got its own tokenizer)
+  fft-textsql-rl-x2     two concurrent Text-to-SQL FFT RL jobs; extra_a= and
+                        extra_b= override each job separately on top of extra=,
+                        so one run can compare two configs or two base models
 
 Examples:
   uv run --extra gpu python scripts/run_training_e2e.py scenario=tiny-lora
   uv run --extra gpu python scripts/run_training_e2e.py scenario=tiny-rl steps=4
   uv run --extra gpu python scripts/run_training_e2e.py scenario=lora-textsql
   uv run --extra gpu python scripts/run_training_e2e.py scenario=fft-gsm8k extra='batch=2 rank=32'
+  uv run --extra gpu python scripts/run_training_e2e.py scenario=fft-textsql-rl-x2 steps=40 \
+      base_model=google/gemma-4-e2b extra_a='rl.learning_rate=1e-6' extra_b='rl.learning_rate=5e-6'
 
 The example scripts validate their own results and exit nonzero on failure.
 `base_url=...` targets an existing backend instead of starting one. `steps=N`
 sets the example's step count and `extra='k=v ...'` forwards additional chz
-overrides to it. The examples uv environment is kept separate from the root
+overrides to it; two-job scenarios also take `extra_a=` / `extra_b=`, applied on
+top of `extra=` to job-a / job-b only. The examples uv environment is kept separate from the root
 server/eval uv environment; override that path with
 OPEN_RL_EXAMPLES_UV_PROJECT_ENVIRONMENT if needed.
 """
@@ -99,6 +105,10 @@ class RunConfig:
   min_accuracy: float = 0.05
   weight_sync_strategy: str = ""
   extra: str = ""
+  # Per-job overrides for the *-x2 scenarios, layered over `extra`. Setting
+  # model.base_model in one of them also switches that job's tokenizer.
+  extra_a: str = ""
+  extra_b: str = ""
   host: str = "127.0.0.1"
   port: int | None = None
   uv_extra: str = "gpu"
@@ -395,8 +405,30 @@ def run_command(command: list[str], env: dict[str, str] | None = None, watch: li
   return output
 
 
-def run_example(config: RunConfig, script: list[str], defaults: dict[str, str], watch: list[ManagedProcess] | None = None, prefix: str = "") -> str:
-  overrides = dict(item.split("=", 1) for item in shlex.split(config.extra))
+def parse_overrides(*specs: str) -> dict[str, str]:
+  """Merge `k=v ...` strings left to right; later specs win."""
+  overrides: dict[str, str] = {}
+  for spec in specs:
+    overrides.update(item.split("=", 1) for item in shlex.split(spec))
+  return overrides
+
+
+def job_overrides(config: RunConfig, job: str) -> dict[str, str]:
+  """`extra` plus the per-job `extra_a` / `extra_b` for job-a / job-b."""
+  per_job = {"job-a": config.extra_a, "job-b": config.extra_b}.get(job, "")
+  return parse_overrides(config.extra, per_job)
+
+
+def run_example(
+  config: RunConfig,
+  script: list[str],
+  defaults: dict[str, str],
+  watch: list[ManagedProcess] | None = None,
+  prefix: str = "",
+  overrides: dict[str, str] | None = None,
+) -> str:
+  if overrides is None:
+    overrides = parse_overrides(config.extra)
   args = [f"{key}={value}" for key, value in {**defaults, **overrides}.items()]
   return run_command(["uv", "--project", "examples", "run", "python", *script, *args], env=examples_env(config), watch=watch, prefix=prefix)
 
@@ -1092,7 +1124,11 @@ def run_textsql(config: RunConfig, base_url: str, watch: list[ManagedProcess]) -
 
 def run_textsql_rl_x2(config: RunConfig, base_url: str, watch: list[ManagedProcess]) -> None:
   """Two concurrent Text-to-SQL FFT RL jobs against the same backend: each create_model spawns
-  its own trainer and dedicated sampler worker, and the accel timeslicer time-slices them."""
+  its own trainer and dedicated sampler worker, and the accel timeslicer time-slices them.
+
+  `extra_a` / `extra_b` override job-a / job-b separately (on top of `extra`), so
+  one run can compare two learning rates, or two base models when a job's
+  overrides set model.base_model; that job's tokenizer follows its base model."""
   results: dict[str, str | BaseException] = {}
 
   def train(job: str) -> None:
@@ -1100,12 +1136,15 @@ def run_textsql_rl_x2(config: RunConfig, base_url: str, watch: list[ManagedProce
       log_dir = Path(config.log_dir) / f"{config.scenario.replace('-', '_')}_{job}"
       if log_dir.exists():
         shutil.rmtree(log_dir)
+      overrides = job_overrides(config, job)
+      base_model = overrides.get("model.base_model", config.base_model)
+      print(f"[training-e2e] {job}: base_model={base_model} overrides={overrides}")
       defaults = {
         "phase": "rl_only",
         "base_url": base_url,
         "log_dir": str(log_dir),
-        "model.base_model": config.base_model,
-        "model.tokenizer_name": config.base_model,
+        "model.base_model": base_model,
+        "model.tokenizer_name": base_model,
         "model.rank": "16",
         "dataset.train_limit": "64",
         "dataset.rl_train_limit": "64",
@@ -1124,6 +1163,7 @@ def run_textsql_rl_x2(config: RunConfig, base_url: str, watch: list[ManagedProce
         defaults,
         watch=watch,
         prefix=f"[{job}] ",
+        overrides=overrides,
       )
     except BaseException as exc:
       results[job] = exc

--- a/scripts/run_training_e2e.py
+++ b/scripts/run_training_e2e.py
@@ -8,9 +8,10 @@ Scenarios ("tiny-" = minimal overfit/smoke tests; the rest are real workloads):
   fft-gsm8k             examples/sft/gsm8k/gsm8k_sft.py + vLLM eval (min_accuracy gate)
   fft-gsm8k-x2          two concurrent fft-gsm8k jobs sharing one GPU through the
                         accel timeslicer (asserts both workers checkpoint/restore)
-
-There is no FFT RL scenario: the FFT backend does not support sampling during
-training yet (no vLLM sampling mid-training).
+  tiny-rl-x2-families / tiny-fft-rl-x2-families
+                        two concurrent tiny-rl jobs on base_model and
+                        second_base_model, one per model family (asserts each
+                        job earns a reward, i.e. got its own tokenizer)
 
 Examples:
   uv run --extra gpu python scripts/run_training_e2e.py scenario=tiny-lora
@@ -60,6 +61,8 @@ class RunConfig:
     "tiny-rl",
     "tiny-fft-rl",
     "tiny-fft-rl-x2",
+    "tiny-rl-x2-families",
+    "tiny-fft-rl-x2-families",
     "lora-textsql",
     "lora-gsm8k-rl",
     "lora-gsm8k-rl-x2",
@@ -81,6 +84,9 @@ class RunConfig:
   sampler_gpu: str = "1"
   base_url: str = ""
   base_model: str = "Qwen/Qwen2.5-0.5B"
+  # The other model family for the *-x2-families scenarios; must differ from
+  # base_model in vocabulary, not just in size.
+  second_base_model: str = "google/gemma-4-e2b"
   jitter_sec: int = 180
   steps: int | None = None
   group_size: int = 8
@@ -985,6 +991,55 @@ def run_tiny_fft_rl_x2(config: RunConfig, base_url: str, watch: list[ManagedProc
   check_snapshot_interleaving(config)
 
 
+def run_tiny_rl_x2_families(config: RunConfig, base_url: str, watch: list[ManagedProcess]) -> None:
+  """Two concurrent tiny RL jobs on base models from different families
+  (base_model and second_base_model), LoRA or FFT by scenario name.
+
+  One gateway, two vocabularies: anything that resolves a job's tokenizer,
+  parameter names or worker from a gateway-wide default instead of the job's
+  own metadata hands one job the other model's tokens. That does not crash
+  tiny_rl, the samples just turn into token soup and the reward stays at 0,
+  so each job must also earn a reward at least once."""
+  models = {"job-a": config.base_model, "job-b": config.second_base_model}
+  if len(set(models.values())) != 2:
+    raise RuntimeError(f"{config.scenario} needs two different base models, got {models}")
+  log_dirs = {job: Path(config.log_dir) / f"{config.scenario.replace('-', '_')}_{job}" for job in models}
+  results: dict[str, str | BaseException] = {}
+
+  def train(job: str) -> None:
+    try:
+      defaults = {"base_model": models[job], "base_url": base_url, "log_dir": str(log_dirs[job])}
+      if "fft" in config.scenario:
+        defaults["learning_rate"] = "1e-5"
+      if config.steps is not None:
+        defaults["steps"] = str(config.steps)
+      results[job] = run_example(config, ["examples/tiny/tiny_rl.py"], defaults, watch=watch, prefix=f"[{job}] ")
+    except BaseException as exc:
+      results[job] = exc
+
+  threads = [threading.Thread(target=train, args=(job,)) for job in models]
+  for thread in threads:
+    thread.start()
+  for thread in threads:
+    thread.join()
+
+  for job, result in sorted(results.items()):
+    if isinstance(result, BaseException):
+      raise RuntimeError(f"{config.scenario} {job} ({models[job]}) failed") from result
+
+  for job, model in models.items():
+    rows = [row for row in read_jsonl(log_dirs[job] / "metrics.jsonl") if row.get("phase") == "train"]
+    if not rows:
+      raise RuntimeError(f"{job} ({model}) logged no training steps in {log_dirs[job]}")
+    best = max(require_finite_metric(row, "mean_reward") for row in rows)
+    if best <= 0:
+      raise RuntimeError(
+        f"{job} ({model}) never earned a reward in {len(rows)} steps; its samples are most likely "
+        "token soup from the other model's tokenizer (check the gateway's per-model metadata)"
+      )
+    print(f"[training-e2e] {job} {model}: best mean_reward={best:.2f} over {len(rows)} steps")
+
+
 def read_jsonl(path: Path) -> list[dict]:
   if not path.exists() or path.stat().st_size == 0:
     raise RuntimeError(f"Expected {path} to exist and be non-empty")
@@ -1128,6 +1183,8 @@ def main() -> None:
       run_textsql_rl_x2(config, base_url, processes)
     elif config.scenario == "tiny-fft-rl-x2":
       run_tiny_fft_rl_x2(config, base_url, processes)
+    elif config.scenario in {"tiny-rl-x2-families", "tiny-fft-rl-x2-families"}:
+      run_tiny_rl_x2_families(config, base_url, processes)
     else:
       run_tiny(config, base_url, processes)
   finally:

--- a/scripts/run_training_e2e.py
+++ b/scripts/run_training_e2e.py
@@ -317,6 +317,19 @@ def clean_cli_extra(extra: str) -> list[str]:
   return [token for token in shlex.split(extra) if not (token.startswith("weight_sync_strategy=") or token.startswith("jitter_sec="))]
 
 
+def _set_fft_delta_apply(env: dict[str, str]) -> None:
+  """FFT scenarios default to in-place delta patching, but an apply method
+  already in the environment (run_cluster_e2e.py's
+  --weight-sync-delta-apply-method) wins. OPEN_RL_IN_PLACE_DELTA forces the
+  in-place path in the sampler regardless of the method, so it is only set
+  when in-place is what was asked for."""
+  method = env.setdefault("OPEN_RL_WEIGHT_SYNC_DELTA_APPLY_METHOD", "patch_in_place")
+  if method == "patch_in_place":
+    env["OPEN_RL_IN_PLACE_DELTA"] = "1"
+  else:
+    env.pop("OPEN_RL_IN_PLACE_DELTA", None)
+
+
 def examples_env(config: RunConfig) -> dict[str, str]:
   env = os.environ.copy()
   env["OPEN_RL_TMP_DIR"] = str(open_rl_tmp_dir(config))
@@ -329,8 +342,7 @@ def examples_env(config: RunConfig) -> dict[str, str]:
     env["OPEN_RL_WEIGHT_SYNC_STRATEGY"] = config.weight_sync_strategy
   if config.scenario.startswith("fft") or "fft" in config.scenario:
     env["OPEN_RL_FINE_TUNING_TYPE"] = "full"
-    env["OPEN_RL_IN_PLACE_DELTA"] = "1"
-    env["OPEN_RL_WEIGHT_SYNC_DELTA_APPLY_METHOD"] = "patch_in_place"
+    _set_fft_delta_apply(env)
   existing_path = env.get("PYTHONPATH", "")
   env["PYTHONPATH"] = f"examples:{existing_path}" if existing_path else "examples"
   return env
@@ -667,8 +679,7 @@ def run_gsm8k_rl_x4_mixed(config: RunConfig, base_url: str, watch: list[ManagedP
         env.pop("OPEN_RL_IN_PLACE_DELTA", None)
       else:
         env["OPEN_RL_FINE_TUNING_TYPE"] = "full"
-        env["OPEN_RL_IN_PLACE_DELTA"] = "1"
-        env["OPEN_RL_WEIGHT_SYNC_DELTA_APPLY_METHOD"] = "patch_in_place"
+        _set_fft_delta_apply(env)
 
       results[job] = run_command(
         ["uv", "--project", "examples", "run", "python", "-m", module_name, *args],

--- a/src/server/delta_weight_transfer_engine.py
+++ b/src/server/delta_weight_transfer_engine.py
@@ -244,6 +244,29 @@ class DeltaSnapshotWeightTransferEngine(WeightTransferEngine):
     """Static trainer-side hook for push engines (no-op for pull engines)."""
     pass
 
+  def _vllm_names(self, names: list[str]) -> list[str]:
+    """Maps checkpoint parameter names to the names self.model uses.
+
+    The trainer writes deltas under HuggingFace names. Most vLLM models keep
+    those names, but some rename a prefix on load (Gemma4ForCausalLM maps
+    "model.language_model." to "model."). vLLM publishes that rename as the
+    model's hf_to_vllm_mapper; applying it here keeps both the in-place GPU
+    path and the CPU snapshot keyed by the same names.
+    """
+    mapper = getattr(self.model, "hf_to_vllm_mapper", None)
+    if mapper is None:
+      return names
+    try:
+      mapped = mapper.apply_list(names)
+    except Exception:  # noqa: BLE001 - a mapper bug must not take down the sync
+      return names
+    if len(mapped) != len(names):
+      return names
+    renamed = sum(1 for old, new in zip(names, mapped, strict=True) if old != new)
+    if renamed:
+      logger.info(f"[DeltaSnapshotEngine] Mapped {renamed}/{len(names)} delta parameter names through {type(self.model).__name__}.hf_to_vllm_mapper")
+    return mapped
+
   def _resolve_gpu_param_and_offset(self, hf_name: str) -> tuple[torch.Tensor, int]:
     """Resolves a HuggingFace parameter name to (gpu_param, 1d_element_offset) on self.model."""
     if self.model is None:
@@ -563,6 +586,7 @@ class DeltaSnapshotWeightTransferEngine(WeightTransferEngine):
     is_sparse_delta = meta.get("format") == "sparse_delta"
     if is_sparse_delta:
       meta_names, split_indices, split_values, changed_elements = self._parse_sparse_delta_file(target_path, meta)
+      meta_names = self._vllm_names(meta_names)
 
       if changed_elements == 0:
         self.current_weights_path = target_path

--- a/src/server/delta_weight_transfer_engine.py
+++ b/src/server/delta_weight_transfer_engine.py
@@ -148,6 +148,25 @@ class DeltaSnapshotWeightTransferEngine(WeightTransferEngine):
           return buffers[p_name]
     return tensor
 
+  @staticmethod
+  def _check_index_bounds(name: str, indices: torch.Tensor, offset: int, numel: int) -> None:
+    """Rejects a sparse patch whose flat indices fall outside the target parameter.
+
+    Checked on the host before anything is copied to the device: an out-of-range
+    index in a CUDA index_copy_ is a device-side assert that kills the engine,
+    and a negative one on the CPU snapshot silently writes to the tensor's tail.
+    """
+    if indices.numel() == 0:
+      return
+    lo = int(indices.min()) + offset
+    hi = int(indices.max()) + offset
+    if lo < 0 or hi >= numel:
+      raise ValueError(
+        f"[DeltaSnapshotEngine] Sparse delta for '{name}' addresses flat indices {lo}..{hi} "
+        f"(offset {offset}) but the parameter has {numel} elements; the delta indices are corrupt "
+        "or were written in a dtype too narrow for this tensor."
+      )
+
   def _validate_patch(self, patch: SparseWeightPatch, param: torch.Tensor) -> None:
     """Defensive pre-condition guards before executing VRAM mutations."""
     if not param.data.is_contiguous():
@@ -328,22 +347,22 @@ class DeltaSnapshotWeightTransferEngine(WeightTransferEngine):
 
   def _build_bulk_tensor_slices(
     self,
-    resolved_ops: list[tuple[torch.Tensor, int, torch.Tensor, torch.Tensor]],
+    resolved_ops: list[tuple[str, torch.Tensor, int, torch.Tensor, torch.Tensor]],
     changed_elements: int,
     param_dtype: torch.dtype,
-  ) -> tuple[torch.Tensor, torch.Tensor, list[tuple[torch.Tensor, int, int]]]:
+  ) -> tuple[torch.Tensor, torch.Tensor, list[tuple[str, torch.Tensor, int, int]]]:
     """Allocates flat bulk 1D CPU index & value tensors and computes GPU parameter slice offsets (DRY helper)."""
     bulk_indices_cpu = torch.empty(changed_elements, dtype=torch.long)
     bulk_values_cpu = torch.empty(changed_elements, dtype=param_dtype)
 
     curr_offset = 0
-    op_slices: list[tuple[torch.Tensor, int, int]] = []
-    for gpu_param, offset, idx_cpu, val_cpu in resolved_ops:
+    op_slices: list[tuple[str, torch.Tensor, int, int]] = []
+    for name, gpu_param, offset, idx_cpu, val_cpu in resolved_ops:
       n = idx_cpu.numel()
       end_offset = curr_offset + n
       bulk_indices_cpu[curr_offset:end_offset] = idx_cpu.to(dtype=torch.long) + offset
       bulk_values_cpu[curr_offset:end_offset] = val_cpu.to(dtype=param_dtype)
-      op_slices.append((gpu_param, curr_offset, end_offset))
+      op_slices.append((name, gpu_param, curr_offset, end_offset))
       curr_offset = end_offset
 
     return bulk_indices_cpu, bulk_values_cpu, op_slices
@@ -373,14 +392,15 @@ class DeltaSnapshotWeightTransferEngine(WeightTransferEngine):
       if split_indices[i].numel() == 0:
         continue
       gpu_param, offset = self._resolve_gpu_param_and_offset(name)
-      resolved_ops.append((gpu_param, offset, split_indices[i], split_values[i]))
+      self._check_index_bounds(name, split_indices[i], offset, gpu_param.numel())
+      resolved_ops.append((name, gpu_param, offset, split_indices[i], split_values[i]))
 
     t_resolve_ms = (time.perf_counter() - t0_resolve) * 1000.0
 
     t0_copy = time.perf_counter()
     if resolved_ops:
-      target_device = self.device or resolved_ops[0][0].device
-      param_dtype = resolved_ops[0][0].dtype
+      target_device = self.device or resolved_ops[0][1].device
+      param_dtype = resolved_ops[0][1].dtype
 
       bulk_indices_cpu, bulk_values_cpu, op_slices = self._build_bulk_tensor_slices(resolved_ops, changed_elements, param_dtype)
 
@@ -394,11 +414,12 @@ class DeltaSnapshotWeightTransferEngine(WeightTransferEngine):
       bulk_values_gpu = bulk_values_cpu.to(device=target_device, non_blocking=True)
 
       # Mutate VRAM in-place using slices from the bulk GPU tensors
-      for gpu_param, start_idx, end_idx in op_slices:
+      for name, gpu_param, start_idx, end_idx in op_slices:
         flat_param = gpu_param.data.view(-1)
         idx_slice = bulk_indices_gpu[start_idx:end_idx]
         val_slice = bulk_values_gpu[start_idx:end_idx]
-        patch = SparseWeightPatch(name=str(gpu_param), indices=idx_slice, values=val_slice)
+        # The HF name, not str(gpu_param): repr formats the whole tensor on the device.
+        patch = SparseWeightPatch(name=name, indices=idx_slice, values=val_slice)
         self._validate_patch(patch, flat_param)
         flat_param.index_copy_(0, idx_slice, val_slice)
 
@@ -538,6 +559,7 @@ class DeltaSnapshotWeightTransferEngine(WeightTransferEngine):
         raise KeyError(f"Parameter '{name}' found in sparse delta but missing from CPU snapshot.")
       if i < len(split_indices) and split_indices[i].numel() > 0:
         snap_flat = self._cpu_snapshot[name].view(-1)
+        self._check_index_bounds(name, split_indices[i], 0, snap_flat.numel())
         snap_flat[split_indices[i]] = split_values[i]
 
     t_apply_ms = (time.perf_counter() - t0_apply) * 1000.0

--- a/src/server/estimator.py
+++ b/src/server/estimator.py
@@ -67,10 +67,11 @@ TRAINER_DEVICE_BYTES_PER_PARAM = {"full": 8, "lora": 2}
 TRAINER_DEVICE_RESERVE_BYTES = 4 * GIB
 # Sampler on the device: bf16 weights, vLLM's activation peak and CUDA graphs,
 # LoRA slot buffers (max_loras 8, rank 64) for a LoRA sampler, and a KV cache
-# sized for SAMPLER_KV_TOKENS. The budget is exactly what vLLM is handed, so
-# whatever the overheads do not use becomes KV cache. Overheads measured on
-# the live samplers: activation peak 0.5 GiB at 0.6B and 1.4 GiB at 8B; LoRA
-# slots 1.05 GiB at 0.6B and 2.9 GiB at 8B.
+# sized for SAMPLER_KV_TOKENS. This is a placement claim: it decides which
+# device the sampler may land on, not how much of it vLLM uses (see
+# vllm_options.gpu_memory_utilization). Overheads measured on the live
+# samplers: activation peak 0.5 GiB at 0.6B and 1.4 GiB at 8B; LoRA slots
+# 1.05 GiB at 0.6B and 2.9 GiB at 8B.
 SAMPLER_WEIGHT_BYTES_PER_PARAM = 2
 SAMPLER_OVERHEAD_BYTES = GIB // 2
 SAMPLER_OVERHEAD_BYTES_PER_PARAM = 0.125

--- a/src/server/gateway.py
+++ b/src/server/gateway.py
@@ -447,15 +447,23 @@ async def create_model_from_state(
 
 @app.post("/api/v1/get_info")
 async def get_info(req: dict):
-  """ServiceClient — model metadata for the training client."""
-  model_name = get_default_model_name()
+  """ServiceClient — model metadata for the training client.
+
+  TrainingClient.get_tokenizer() loads whatever tokenizer this names, so it
+  has to be the model's own base model; BASE_MODEL is only the fallback for
+  an id we have no metadata for. Answering with the gateway default sent a
+  Gemma job Qwen's tokenizer and every sample came back as token soup.
+  """
+  model_id = req.get("model_id")
+  meta = await store.get_model_metadata(base_model_id_from_sampling_ref(model_id) or model_id) if model_id else None
+  model_name = (meta or {}).get("base_model") or get_default_model_name()
   if not model_name:
     return JSONResponse(status_code=404, content={"error": "No base model is configured"})
   # SDK compatibility: the public client currently expects LoRA-shaped training metadata,
   # even when this process is running a full fine-tuning worker.
   result = {
     "model_data": {"arch": "unknown", "model_name": model_name, "tokenizer_id": model_name},
-    "model_id": req.get("model_id", "model-live-123"),
+    "model_id": model_id or "model-live-123",
     "is_lora": True,
     "lora_rank": 16,
     "model_name": model_name,

--- a/src/server/gateway.py
+++ b/src/server/gateway.py
@@ -208,6 +208,9 @@ async def enqueue(request: dict) -> str:
 
   active_set_id = await _resolve_active_set_id(request.get("model_id"))
   await store.put_request({**request, "trace_context": carrier}, active_set_id=active_set_id)
+  # One line per training request so a request that never reaches a worker can
+  # be traced end to end (the workers log the same id when they pop it).
+  print(f"[GATEWAY] enqueued op={request.get('op')} request_id={request_id} model_id={request.get('model_id')} active_set={active_set_id}")
   return request_id
 
 

--- a/src/server/training_requests_processor.py
+++ b/src/server/training_requests_processor.py
@@ -43,6 +43,11 @@ def parse_datum(raw: dict[str, Any]) -> Datum:
   return Datum(model_input=tokens, loss_fn_inputs=loss_fn_inputs)
 
 
+def describe_requests(batch: list[dict[str, Any]]) -> str:
+  """`op:request_id` per request, matching the gateway's enqueue log line."""
+  return ", ".join(f"{r.get('op')}:{r.get('request_id')}" for r in batch)
+
+
 class TrainingRequestsProcessor(Protocol):
   store: RequestStore
 
@@ -188,7 +193,7 @@ class LoraTrainingRequestsProcessor(TrainingRequestsProcessor):
       batch_span.set_attribute("batch_size", len(batch))
       batch_span.set_attribute("model_id", model_id)
 
-      print(f"\n[TRAINING REQUESTS] Popped {len(batch)} requests for model: {model_id}")
+      print(f"\n[TRAINING REQUESTS] Popped {len(batch)} requests for model: {model_id}: {describe_requests(batch)}")
       for request in batch:
         target_model_id = request.get("adapter_id") or request.get("model_id") or model_id
         await self.process_request(request, target_model_id)
@@ -365,7 +370,7 @@ class FFTTrainingRequestsProcessor(TrainingRequestsProcessor):
       batch_span.set_attribute("model_id", self.model_id)
 
       if training_reqs:
-        print(f"\n[TRAINING REQUESTS] Popped {len(training_reqs)} requests for model: {self.model_id}")
+        print(f"\n[TRAINING REQUESTS] Popped {len(training_reqs)} requests for model: {self.model_id}: {describe_requests(training_reqs)}")
         results = []
         save_ops = {"save_state", "save_weights", "save_weights_for_sampler"}
         gpu_reqs = [r for r in training_reqs if r.get("op") not in save_ops]

--- a/src/server/vllm_options.py
+++ b/src/server/vllm_options.py
@@ -36,19 +36,17 @@ def split_stop(stop: str | Sequence[str] | Sequence[int] | None) -> tuple[list[s
   return (strings or None), (token_ids or None)
 
 
-def gpu_memory_utilization(device_bytes: int | None = None) -> float:
-  """vLLM's share of the device. An explicit VLLM_GPU_MEMORY_UTILIZATION wins;
-  otherwise the budget the launcher sized this worker for
-  (OPEN_RL_ACCELERATOR_MEMORY, in bytes) over the device actually present,
-  capped at 0.90; with neither, 0.90."""
+def gpu_memory_utilization() -> float:
+  """vLLM's share of the device: an explicit VLLM_GPU_MEMORY_UTILIZATION, else 0.90.
+
+  OPEN_RL_ACCELERATOR_MEMORY is deliberately not consulted. It is the placement
+  claim the scheduler sized this worker for, not a runtime cap: workers that
+  share an accelerator are time-sliced, so whichever one holds the device may
+  use all of it. Sizing vLLM from the claim starved the sampler of KV cache on
+  large devices and made Gemma-4's first engine init fail when the cold
+  torch.compile transient did not fit in the claim.
+  """
   explicit = os.getenv("VLLM_GPU_MEMORY_UTILIZATION")
   if explicit:
     return float(explicit)
-  budget = os.getenv("OPEN_RL_ACCELERATOR_MEMORY")
-  if not budget:
-    return 0.90
-  if device_bytes is None:
-    import torch
-
-    device_bytes = torch.cuda.mem_get_info()[1]
-  return min(int(budget) / device_bytes, 0.90)
+  return 0.90

--- a/src/server/vllm_sampler.py
+++ b/src/server/vllm_sampler.py
@@ -326,8 +326,8 @@ async def run_sampling_worker(model_id: str) -> None:
   else:
     init_engine()
 
-  async def exit_gracefully() -> None:
-    print(f"[vLLM Worker] Initiating immediate exit for model {model_id} sampler worker...")
+  async def exit_gracefully(code: int = 0) -> None:
+    print(f"[vLLM Worker] Initiating immediate exit for model {model_id} sampler worker (code {code})...")
     nonlocal snapshot_registered
     if snapshot_registered and time_slicer is not None:
       assert workload is not None
@@ -341,7 +341,27 @@ async def run_sampling_worker(model_id: str) -> None:
         await time_slicer.close()
       except Exception:
         pass
-    os._exit(0)
+    os._exit(code)
+
+  async def fail_requests(reqs: list[dict], exc: BaseException) -> None:
+    """Answers every popped-but-unserved request so clients see the failure instead of hanging."""
+    for req in reqs:
+      request_id = req.get("request_id")
+      if not request_id:
+        continue
+      try:
+        await store.set_future(request_id, {"type": "RequestFailedResponse", "error_message": f"vLLM Worker Error: {exc}"})
+      except Exception as store_exc:  # noqa: BLE001 - best effort while already failing
+        print(f"[vLLM Worker] Could not fail request {request_id}: {store_exc}")
+
+  def engine_is_dead(exc: BaseException) -> bool:
+    if engine is not None and getattr(engine, "errored", False):
+      return True
+    try:
+      from vllm.v1.engine.exceptions import EngineDeadError
+    except ImportError:
+      return False
+    return isinstance(exc, EngineDeadError)
 
   if time_slicer is not None:
     import signal
@@ -364,6 +384,9 @@ async def run_sampling_worker(model_id: str) -> None:
   print(f"[vLLM Worker] Listening for sampling requests on queue for model: {model_id}...")
   try:
     while True:
+      # Requests popped from the queue but not yet handed to process_sampling_request;
+      # an exception before dispatch would otherwise leave their futures unset forever.
+      unanswered: list[dict] = []
       try:
         batch = await store.get_sampling_requests_for_model(model_id)
         if not batch:
@@ -379,6 +402,7 @@ async def run_sampling_worker(model_id: str) -> None:
             sampling_reqs.append(req)
 
         if sampling_reqs:
+          unanswered = list(sampling_reqs)
           if time_slicer is not None:
             assert workload is not None
             async with time_slicer.acquire(workload):
@@ -388,6 +412,7 @@ async def run_sampling_worker(model_id: str) -> None:
                 IS_ENGINE_SLEEPING = False
               tasks = [asyncio.create_task(process_sampling_request(req, store)) for req in sampling_reqs]
               await asyncio.gather(*tasks)
+              unanswered = []
               if has_shutdown:
                 await exit_gracefully()
               if engine is not None:
@@ -401,6 +426,7 @@ async def run_sampling_worker(model_id: str) -> None:
               IS_ENGINE_SLEEPING = False
             tasks = [asyncio.create_task(process_sampling_request(req, store)) for req in sampling_reqs]
             await asyncio.gather(*tasks)
+            unanswered = []
 
         if has_shutdown:
           print("[vLLM Worker] Shutdown sentinel popped from queue. Initiating clean exit...")
@@ -410,6 +436,13 @@ async def run_sampling_worker(model_id: str) -> None:
       except Exception as exc:
         print(f"Error in sampling worker loop: {exc}")
         traceback.print_exc()
+        await fail_requests(unanswered, exc)
+        if engine_is_dead(exc):
+          # A dead EngineCore (e.g. a CUDA assert during a weight patch) never
+          # recovers in-process; exit non-zero so the pod restarts instead of
+          # sitting Running while every client times out.
+          print("[vLLM Worker] vLLM engine is dead; exiting so the worker can be restarted.")
+          await exit_gracefully(code=1)
         await asyncio.sleep(1)
   finally:
     if time_slicer is not None:

--- a/src/training/fft_trainer_worker.py
+++ b/src/training/fft_trainer_worker.py
@@ -245,12 +245,15 @@ class FFTTrainingWorker(BaseTrainerWorker):
       indices_list = []
       values_list = []
 
+    # int64 indices: a flat index into a tensor with more than 2**31 elements
+    # (Gemma 4's per-layer embedding table is 2.35e9) does not fit an int32, and
+    # a wrapped negative index made the sampler's index_copy_ assert mid-run.
     if indices_list:
-      indices_flat = torch.cat(indices_list).to(torch.int32).contiguous()
+      indices_flat = torch.cat(indices_list).to(torch.int64).contiguous()
       values_flat = torch.cat(values_list).contiguous()
     else:
       fallback_dtype = next(self.model.parameters()).dtype if self.model else torch.float32
-      indices_flat = torch.empty(0, dtype=torch.int32, device="cpu")
+      indices_flat = torch.empty(0, dtype=torch.int64, device="cpu")
       values_flat = torch.empty(0, dtype=fallback_dtype, device="cpu")
 
     layer_lengths_tensor = torch.tensor(layer_lengths_list, dtype=torch.int64, device="cpu")
@@ -469,7 +472,7 @@ class FFTTrainingWorker(BaseTrainerWorker):
         diff_mask = param.data.view(-1).ne(prev_gpu.view(-1))
         indices = diff_mask.nonzero(as_tuple=True)[0]
         if indices.numel() > 0:
-          idx_cpu = indices.to(torch.int32).contiguous().cpu()
+          idx_cpu = indices.to(torch.int64).contiguous().cpu()
           val_cpu = param.data.view(-1)[diff_mask].contiguous().cpu()
           layer_names_list.append(name)
           indices_list.append(idx_cpu)

--- a/tests/test_delta_weight_sync.py
+++ b/tests/test_delta_weight_sync.py
@@ -61,7 +61,8 @@ class DeltaWeightSyncTest(unittest.TestCase):
     self.assertIn("delta.indices_flat", sparse_delta)
     self.assertIn("delta.values_flat", sparse_delta)
     self.assertEqual(sparse_delta["delta.indices_flat"].numel(), 2)
-    self.assertEqual(sparse_delta["delta.indices_flat"].dtype, torch.int32)
+    # int64: Gemma 4's per-layer embedding table exceeds 2**31 elements.
+    self.assertEqual(sparse_delta["delta.indices_flat"].dtype, torch.int64)
 
     # 3. Verify Lossless Selective Overwrite reproduces exact target W1
     simulated_sampler_weight = orig_w0.clone()

--- a/tests/test_delta_weight_transfer_engine.py
+++ b/tests/test_delta_weight_transfer_engine.py
@@ -444,6 +444,75 @@ class DeltaSnapshotWeightTransferEngineTest(unittest.TestCase):
     q_numel = 14 * 64 * 896
     self.assertEqual(qkv_param.data.view(-1)[q_numel + 10].item(), 42.0)
 
+  def test_in_place_patch_rejects_out_of_range_indices(self):
+    """A flat index outside the target parameter is refused on the host, naming the parameter.
+
+    Guards the failure seen with Gemma 4: its 2.35e9-element per-layer embedding
+    overflowed int32 delta indices, and the wrapped negative index became a CUDA
+    device-side assert in index_copy_ that killed the sampler's engine mid-run."""
+    import json
+
+    from safetensors.torch import save_file
+
+    param = torch.nn.Parameter(torch.zeros(4, 4), requires_grad=False)
+
+    class SmallModel(torch.nn.Module):
+      def get_parameter(self, name):
+        if name == "model.embed_tokens.weight":
+          return param
+        raise AttributeError(name)
+
+    engine = DeltaSnapshotWeightTransferEngine(config=None, vllm_config=MagicMock(), device=torch.device("cpu"), model=SmallModel())
+
+    for bad_index in (16, -2001493954):
+      with tempfile.TemporaryDirectory() as tmpdir:
+        save_file(
+          {
+            "delta.indices_flat": torch.tensor([1, bad_index], dtype=torch.int64),
+            "delta.values_flat": torch.tensor([7.0, 42.0], dtype=torch.float32),
+            "delta.layer_lengths": torch.tensor([2], dtype=torch.int64),
+          },
+          os.path.join(tmpdir, "delta.safetensors"),
+        )
+        with open(os.path.join(tmpdir, "metadata.json"), "w") as f:
+          json.dump({"format": "sparse_delta", "layer_names": ["model.embed_tokens.weight"]}, f)
+        with patch.dict(os.environ, {"OPEN_RL_IN_PLACE_DELTA": "1"}), self.assertRaises(ValueError) as ctx:
+          engine.receive_weights(DeltaSnapshotUpdateInfo(target_weights_path=tmpdir))
+        self.assertIn("model.embed_tokens.weight", str(ctx.exception))
+        self.assertIn("16 elements", str(ctx.exception))
+    # Nothing was written: the check runs before any element is touched.
+    self.assertEqual(param.data.abs().sum().item(), 0.0)
+
+  def test_cpu_snapshot_patch_rejects_negative_indices(self):
+    """The full_replace path refuses a negative index instead of writing to the tensor's tail."""
+    import json
+
+    from safetensors.torch import save_file
+
+    class SmallModel:
+      def named_parameters(self):
+        return [("model.embed_tokens.weight", torch.nn.Parameter(torch.zeros(4, 4)))]
+
+      def named_buffers(self):
+        return []
+
+    engine = DeltaSnapshotWeightTransferEngine(config=None, parallel_config=None, model=SmallModel())  # type: ignore
+    with tempfile.TemporaryDirectory() as tmpdir:
+      save_file(
+        {
+          "delta.indices_flat": torch.tensor([-1], dtype=torch.int64),
+          "delta.values_flat": torch.tensor([9.0], dtype=torch.float32),
+          "delta.layer_lengths": torch.tensor([1], dtype=torch.int64),
+        },
+        os.path.join(tmpdir, "delta.safetensors"),
+      )
+      with open(os.path.join(tmpdir, "metadata.json"), "w") as f:
+        json.dump({"format": "sparse_delta", "layer_names": ["model.embed_tokens.weight"]}, f)
+      env = {"OPEN_RL_WEIGHT_SYNC_DELTA_APPLY_METHOD": "full_replace", "OPEN_RL_IN_PLACE_DELTA": "0"}
+      with patch.dict(os.environ, env), self.assertRaises(ValueError) as ctx:
+        engine.receive_weights(DeltaSnapshotUpdateInfo(target_weights_path=tmpdir), lambda items: None)
+    self.assertIn("model.embed_tokens.weight", str(ctx.exception))
+
   def test_sparse_delta_names_follow_hf_to_vllm_mapper_full_replace(self):
     """CPU-snapshot patching (full_replace) keys the delta by the model's names, not the checkpoint's."""
     import json

--- a/tests/test_delta_weight_transfer_engine.py
+++ b/tests/test_delta_weight_transfer_engine.py
@@ -388,6 +388,103 @@ class DeltaSnapshotWeightTransferEngineTest(unittest.TestCase):
       self.assertEqual(qkv_flat[q_numel + 10].item(), 42.0)
       self.assertEqual(qkv_flat[q_numel + 20].item(), 99.0)
 
+  def test_sparse_delta_names_follow_hf_to_vllm_mapper_in_place(self):
+    """In-place patching resolves HF names through the model's hf_to_vllm_mapper (Gemma4ForCausalLM)."""
+    import json
+
+    from safetensors.torch import save_file
+
+    class PrefixMapper:
+      def apply_list(self, names):
+        return [n.replace("model.language_model.", "model.", 1) for n in names]
+
+    embed_param = torch.nn.Parameter(torch.zeros(8, 4), requires_grad=False)
+    qkv_param = torch.nn.Parameter(torch.zeros(1152, 896), requires_grad=False)
+
+    class GemmaLikeModel(torch.nn.Module):
+      hf_to_vllm_mapper = PrefixMapper()
+
+      def get_parameter(self, name):
+        if name == "model.embed_tokens.weight":
+          return embed_param
+        if name == "model.layers.0.self_attn.qkv_proj.weight":
+          return qkv_param
+        raise AttributeError(name)
+
+    mock_config = MagicMock()
+    mock_config.hidden_size = 896
+    mock_config.num_attention_heads = 14
+    mock_config.num_key_value_heads = 2
+    mock_config.head_dim = 64
+    mock_config.intermediate_size = 4864
+    mock_hf_config = MagicMock()
+    mock_hf_config.get_text_config.return_value = mock_config
+    vllm_config = MagicMock()
+    vllm_config.model_config.hf_config = mock_hf_config
+    vllm_config.model_config.model = "google/gemma-4-e2b"
+
+    engine = DeltaSnapshotWeightTransferEngine(config=None, vllm_config=vllm_config, device=torch.device("cpu"), model=GemmaLikeModel())
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+      save_file(
+        {
+          "delta.indices_flat": torch.tensor([3, 10], dtype=torch.int32),
+          "delta.values_flat": torch.tensor([7.0, 42.0], dtype=torch.float32),
+          "delta.layer_lengths": torch.tensor([1, 1], dtype=torch.int64),
+        },
+        os.path.join(tmpdir, "delta.safetensors"),
+      )
+      names = ["model.language_model.embed_tokens.weight", "model.language_model.layers.0.self_attn.k_proj.weight"]
+      with open(os.path.join(tmpdir, "metadata.json"), "w") as f:
+        json.dump({"format": "sparse_delta", "layer_names": names}, f)
+      with patch.dict(os.environ, {"OPEN_RL_IN_PLACE_DELTA": "1"}):
+        engine.receive_weights(DeltaSnapshotUpdateInfo(target_weights_path=tmpdir))
+
+    self.assertEqual(embed_param.data.view(-1)[3].item(), 7.0)
+    q_numel = 14 * 64 * 896
+    self.assertEqual(qkv_param.data.view(-1)[q_numel + 10].item(), 42.0)
+
+  def test_sparse_delta_names_follow_hf_to_vllm_mapper_full_replace(self):
+    """CPU-snapshot patching (full_replace) keys the delta by the model's names, not the checkpoint's."""
+    import json
+
+    from safetensors.torch import save_file
+
+    class PrefixMapper:
+      def apply_list(self, names):
+        return [n.replace("model.language_model.", "model.", 1) for n in names]
+
+    class GemmaLikeModel:
+      hf_to_vllm_mapper = PrefixMapper()
+
+      def named_parameters(self):
+        return [("model.embed_tokens.weight", torch.nn.Parameter(torch.zeros(4, 4)))]
+
+      def named_buffers(self):
+        return []
+
+    model = GemmaLikeModel()
+    engine = DeltaSnapshotWeightTransferEngine(config=None, parallel_config=None, model=model)  # type: ignore
+    loaded: list[tuple[str, torch.Tensor]] = []
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+      save_file(
+        {
+          "delta.indices_flat": torch.tensor([5], dtype=torch.int32),
+          "delta.values_flat": torch.tensor([99.0], dtype=torch.float32),
+          "delta.layer_lengths": torch.tensor([1], dtype=torch.int64),
+        },
+        os.path.join(tmpdir, "delta.safetensors"),
+      )
+      with open(os.path.join(tmpdir, "metadata.json"), "w") as f:
+        json.dump({"format": "sparse_delta", "layer_names": ["model.language_model.embed_tokens.weight"]}, f)
+      with patch.dict(os.environ, {"OPEN_RL_WEIGHT_SYNC_DELTA_APPLY_METHOD": "full_replace"}, clear=False):
+        os.environ.pop("OPEN_RL_IN_PLACE_DELTA", None)
+        engine.receive_weights(DeltaSnapshotUpdateInfo(target_weights_path=tmpdir), loaded.extend)
+
+    self.assertEqual([name for name, _ in loaded], ["model.embed_tokens.weight"])
+    self.assertEqual(loaded[0][1].view(-1)[5].item(), 99.0)
+
 
 if __name__ == "__main__":
   unittest.main()

--- a/tests/test_gateway_paths.py
+++ b/tests/test_gateway_paths.py
@@ -23,6 +23,20 @@ class GetInfoTest(unittest.TestCase):
     self.assertEqual(info["model_data"]["tokenizer_id"], "env-model")
     self.assertEqual(info["model_id"], "model-a")
 
+  def test_get_info_prefers_the_models_own_base_model(self) -> None:
+    meta = json.dumps({"base_model": "google/gemma-4-e2b", "fine_tuning_type": "full"})
+    asyncio.run(gateway.store.set_value("open_rl:model_meta:model-g", meta))
+    with patch.dict(os.environ, {"BASE_MODEL": "Qwen/Qwen2.5-0.5B"}, clear=True):
+      info = asyncio.run(gateway.get_info({"model_id": "model-g"}))
+      via_sampler_ref = asyncio.run(gateway.get_info({"model_id": "tinker://model-g/sampler_weights/sampler-1"}))
+      unknown = asyncio.run(gateway.get_info({"model_id": "model-unknown"}))
+
+    # The client loads its tokenizer from this name, so it must be the job's model.
+    self.assertEqual(info["model_name"], "google/gemma-4-e2b")
+    self.assertEqual(info["model_data"]["tokenizer_id"], "google/gemma-4-e2b")
+    self.assertEqual(via_sampler_ref["model_name"], "google/gemma-4-e2b")
+    self.assertEqual(unknown["model_name"], "Qwen/Qwen2.5-0.5B")
+
   def test_get_info_404s_without_base_model_env(self) -> None:
     with patch.dict(os.environ, {}, clear=True):
       response = asyncio.run(gateway.get_info({"model_id": "model-a"}))

--- a/tests/test_vllm_options.py
+++ b/tests/test_vllm_options.py
@@ -35,15 +35,14 @@ if __name__ == "__main__":
 class GpuMemoryUtilizationTest(unittest.TestCase):
   def test_explicit_fraction_wins(self) -> None:
     with patch.dict(os.environ, {"VLLM_GPU_MEMORY_UTILIZATION": "0.5", "OPEN_RL_ACCELERATOR_MEMORY": str(70 * 1024**3)}):
-      self.assertEqual(gpu_memory_utilization(device_bytes=80 * 1024**3), 0.5)
+      self.assertEqual(gpu_memory_utilization(), 0.5)
 
-  def test_budget_over_the_actual_device_capped(self) -> None:
+  def test_placement_claim_does_not_cap_the_device(self) -> None:
+    # The claim only decides where the worker lands; once placed it owns the
+    # device while it holds it, so a 7 GiB claim still gets the 0.90 default.
     with patch.dict(os.environ, {"OPEN_RL_ACCELERATOR_MEMORY": str(7 * 1024**3)}, clear=True):
-      self.assertAlmostEqual(gpu_memory_utilization(device_bytes=24 * 1024**3), 7 / 24)
-      self.assertAlmostEqual(gpu_memory_utilization(device_bytes=80 * 1024**3), 7 / 80)
-    with patch.dict(os.environ, {"OPEN_RL_ACCELERATOR_MEMORY": str(100 * 1024**3)}, clear=True):
-      self.assertEqual(gpu_memory_utilization(device_bytes=80 * 1024**3), 0.90)
+      self.assertEqual(gpu_memory_utilization(), 0.90)
 
   def test_without_a_budget_the_default_holds(self) -> None:
     with patch.dict(os.environ, {}, clear=True):
-      self.assertEqual(gpu_memory_utilization(device_bytes=80 * 1024**3), 0.90)
+      self.assertEqual(gpu_memory_utilization(), 0.90)


### PR DESCRIPTION
Running the tiny e2e scenarios with google/gemma-4-e2b on a cluster whose gateway defaults to Qwen produced the same token soup from every sampler (IndiaIndiaIndia one one one, reward 0), FFT and LoRA alike, while a plain vLLM engine on the same GPU and checkpoint answered fine. Two bugs, one of them old:

- gateway: get_info returns the job's own base model. Since #136 made base_model per job, get_info kept answering with the gateway-wide BASE_MODEL. TrainingClient.get_tokenizer() builds its tokenizer from that name, so a Gemma job on a Qwen-defaulted gateway encoded and decoded with Qwen's tokenizer. Qwen jobs never showed it because the default matched. get_info now resolves base_model from the job's metadata (also through tinker://<id>/sampler_weights refs) and falls back to BASE_MODEL only for ids without metadata.
- sampler: map sparse delta names through hf_to_vllm_mapper. The trainer writes deltas under HF names (Gemma: model.language_model.) while vLLM's parameters and the CPU snapshot use the renamed ones (model.). patch_in_place could not resolve the GPU parameter and full_replace raised KeyError: missing from CPU snapshot. A no-op for Qwen, whose names already match.

 fft: int64 sparse delta indices, bounds-checked patches, exit on a dead engine. An 80-step Gemma-4-e2b full fine-tune died at step 21 with index_copy_(): index out of bounds in the sampler. The trainer wrote delta indices as int32, and Gemma 4's per-layer embedding table has 2.35e9 elements, past the int32 limit; the first step that touched a row for a high token id produced negative indices and the CUDA kernel asserted. Indices are now int64, the sampler bounds-checks every patch on the host and names the parameter, and a dead EngineCore fails its pending requests and exits non-zero so the pod restarts instead of hanging clients for their full timeout.

Smaller changes riding along:

- tiny_rl encodes the prompt with add_special_tokens=True (Gemma degenerates without BOS; Qwen adds nothing) and logs the tokenizer it was handed plus the first decoded sample per step, so this class of bug is visible in the log instead of only in the reward.
- The e2e runner forced patch_in_place for every FFT scenario, so --weight-sync-delta-apply-method full_replace never reached the workers. An apply method already in the environment now wins.
- New scenarios tiny-rl-x2-families / tiny-fft-rl-x2-families: two concurrent tiny_rl jobs on base_model and second_base_model, one per model family. Each job must earn a reward at least once. The single-model suite could not catch the get_info regression; this can.
- Cloud Build uses a buildx registry cache (<image>:buildcache, mode=max). Inline cache on :latest went lossy after a fully cached build, so server builds alternated between ~3 and ~20 minutes with no Dockerfile change. Measured: server 12m26s cold, 2m47s to 4m05s warm after a source change, 22s for a consecutive rebuild; gateway 40s -> 29s; client 1m57s -> 57s.

Validated on GKE (H100 samplers and trainers): tiny-fft-rl with gemma-4-e2b under both patch_in_place and full_replace (reward 0.6 -> 1.0, coherent samples, in-place patch of 405 layers in 4.9s), tiny-rl (LoRA) with gemma-4-e2b, and tiny-fft-rl-x2-families with Qwen3-0.6B + gemma-4-e2b concurrently (both jobs reward 1.0). Qwen3-0.6B tiny-fft-rl unchanged.