### PR TITLE
Sandboxed reward execution for Text-to-SQL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,8 +111,10 @@ test:
 	  uv run --extra "$(TRAINING_TEST_EXTRA)" python scripts/run_training_e2e.py "$$@" $(TRAINING_TEST_ARGS); \
 	elif [ "$$mode" = "piglatin" ]; then \
 	  PYTHONPATH="$(PIGLATIN_TEST_PYTHONPATH)" uv --project examples run python -m unittest tests.test_piglatin_qwen tests.test_piglatin_gemma; \
+	elif [ "$$mode" = "examples" ]; then \
+	  PYTHONPATH="examples:examples/text-to-sql" uv --project examples run python -m unittest tests.test_agent_sandbox; \
 	else \
-	  echo "Unknown test mode '$$mode'. Expected unit, e2e, or piglatin."; \
+	  echo "Unknown test mode '$$mode'. Expected unit, e2e, piglatin, or examples."; \
 	  exit 2; \
 	fi
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: server vllm test lint fmt help render release-bundle push-vm pull-vm cluster-eval \
-	cloud-build-gateway cloud-build-server cloud-build-client \
+	cloud-build-gateway cloud-build-server cloud-build-client cloud-build-sql-executor \
 	cloud-deploy-gateway cloud-deploy-server \
 	cloud-rollout-gateway cloud-rollout-server cloud-rollout \
 	kind-host-setup kind-create kind-gateway kind-deploy \
@@ -183,6 +183,10 @@ cloud-build-server: require-gcp-project
 
 cloud-build-client: require-gcp-project
 	$(CLOUD_BUILD) --substitutions=_IMAGE=$(CLOUD_REGISTRY)/open-rl-client,_DOCKERFILE=src/server/Dockerfile.client,_TAG=$(CLOUD_IMAGE_TAG) .
+
+# Sandbox runtime for Text-to-SQL reward execution (examples/text-to-sql/sandbox).
+cloud-build-sql-executor: require-gcp-project
+	$(CLOUD_BUILD) --substitutions=_IMAGE=$(CLOUD_REGISTRY)/open-rl-sql-executor,_DOCKERFILE=examples/text-to-sql/sandbox/Dockerfile,_TAG=$(CLOUD_IMAGE_TAG) .
 
 # Point the running workloads at the freshly built tag. Split from the build
 # steps so a tag built earlier can be re-deployed with

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Detailed guides and runnable examples are structured under `docs/` and `examples
 - **Technical Documentation**:
   - [Architecture](docs/architecture.md)
   - [Tinker Client Compatibility](docs/tinker-client-compatibility.md)
+  - [Sandboxed Reward Execution](docs/sandboxed-rewards.md)
 - **Deployment**:
   - [Kubernetes Deployment Guide (GKE)](docs/setup/gke-setup.md)
 

--- a/docs/designs/013-sandboxed-rewards-text-to-sql.md
+++ b/docs/designs/013-sandboxed-rewards-text-to-sql.md
@@ -1,0 +1,279 @@
+# Design Doc 013: Sandboxed Reward Execution for Text-to-SQL via agent-sandbox and tinker-cookbook
+
+**Status**: Plan, approved for implementation
+**Date**: 2026-09-09
+**Depends on**: Design 012 (branch `docs/rl-environments-integration`) for the P1-P4 framing.
+
+---
+
+## 1. Summary
+
+The Text-to-SQL recipe (`examples/text-to-sql`) executes model-generated SQL in-process with
+`sqlite3`. That is acceptable for SQLite but it teaches the wrong habit: the reward is *execution of
+untrusted model output*, and OpenRL users need to see how that composes with a real sandbox.
+
+This plan delivers the showcase in two increments that share one piece of code:
+
+1. **An agent-sandbox backend for tinker-cookbook's `SandboxInterface`**, living in
+   `examples/common/` for now, upstreamed to tinker-cookbook later. The cookbook ships Modal and
+   SandboxFusion backends; there is no Kubernetes backend. This closes that gap.
+2. **Two consumers of that backend.**
+   - **Phase A**: the existing Gemma 4 SFT+GRPO recipe gains an `executor=agent_sandbox` mode.
+     Model-emitted SQL runs in a small pool of long-lived gVisor sandboxes claimed from a
+     `SandboxWarmPool`. Same script, same curve, no cookbook dependency for the training loop.
+   - **Phase B**: a tinker-cookbook `rl_train` recipe for Text-to-SQL on **Qwen3-1.7B**, where each
+     prompt group claims its own sandbox in `EnvGroupBuilder.make_envs()` and releases it in
+     `cleanup()`. This demonstrates that OpenRL runs cookbook recipes unmodified and that cookbook
+     recipes gain Kubernetes sandboxing through the backend.
+
+Decisions already taken: Qwen3 for the cookbook path (the cookbook has no Gemma renderer);
+backend lands in `examples/` first; the v1alpha1 autoresearch manifest fix and the stale
+Sandbox Fusion claims in `examples/README.md` are out of scope for this effort.
+
+## 2. Facts that shape the design
+
+| Fact | Consequence |
+| --- | --- |
+| agent-sandbox v1.0.1 (2026-09-03) is v1beta1 only; Python SDK `k8s-agent-sandbox` 1.0.1 on PyPI, `[async]` extra gives `AsyncSandboxClient` + `httpx` | Use `extensions.agents.x-k8s.io/v1beta1` `SandboxTemplate` / `SandboxWarmPool` / `SandboxClaim`; async client fits the recipe's asyncio loop |
+| SDK data plane is an HTTP server in the sandbox image on `:8888` (`/execute`, `/upload`, `/download`); `SandboxInClusterConnectionConfig` talks to the pod IP with no router | We build a small runtime image; the training client must run in-cluster (or via the SDK's local-tunnel config for dev) |
+| GKE cluster `open-rl-dra` has a `gvisor` RuntimeClass but no agent-sandbox CRDs | Phase 0 installs `sandbox-with-extensions.yaml` |
+| Warm-pool claim latency measured upstream at ~2.6 s average, ~6 s max | Per-sample claims are wasteful (5,000+ per run); per-group claims (640 per run, 8 concurrent) cost ~3-6 s per step; a static pool costs nothing per step |
+| cookbook 0.5.7 requires `tinker>=0.23.0`, `torch>=2.10`, `tml-renderers`; `SandboxInterface`, `Env`, `EnvGroupBuilder.cleanup()` are unchanged from 0.4.2 | Upgrade the cookbook now (§7); nothing in this plan depends on 0.4.2 |
+| tinker SDK 0.25.0+ sends `forward_backward` as protobuf and refuses JSON `SampleResponse` / `ForwardBackwardOutput`; 0.23.0 and 0.24.1 pass the full core path against the current gateway (verified 2026-09-09) | Pin `tinker==0.24.1` with the cookbook upgrade; gateway protobuf support is a separate step (§7.2) |
+| `ProblemEnv.check_answer` is synchronous | Phase B implements `Env` directly (single turn, ~50 lines) so `step()` can `await` the sandbox |
+| `utils/rewards.py:run_sql` is used both to filter the dataset (trusted target SQL, thousands of calls) and to score predictions (untrusted) | Only prediction scoring moves into the sandbox; dataset filtering stays local. The trust boundary is model output, and the README says so explicitly |
+
+## 3. Architecture
+
+```mermaid
+graph LR
+    subgraph Client["Training client pod (examples image)"]
+        Loop["Recipe loop<br/>(texttosql_sft_grpo.py or cookbook rl_train)"]
+        Backend["AgentSandboxBackend<br/>(SandboxInterface)"]
+    end
+    GW["OpenRL gateway<br/>/api/v1/asample, forward_backward"]
+    Ctl["agent-sandbox controller"]
+    Pool["SandboxWarmPool<br/>text-to-sql-executor"]
+    SB1["Sandbox (gVisor)<br/>runtime :8888 + sqlite3"]
+    SB2["Sandbox (gVisor)"]
+    Loop -->|tokens in / out| GW
+    Loop -->|write_file + run_command| Backend
+    Backend -->|SandboxClaim| Ctl
+    Ctl --> Pool
+    Pool --> SB1
+    Pool --> SB2
+    Backend -->|HTTP, pod IP| SB1
+    Backend -->|HTTP, pod IP| SB2
+```
+
+The sandbox never holds a Tinker credential (P2 in design 012). Egress from the sandbox is denied
+by the template's network policy. Isolation is gVisor via `runtimeClassName`.
+
+## 4. Components
+
+### 4.1 Sandbox runtime image `open-rl/sql-executor`
+
+- Base `python:3.12-slim`, non-root user, the reference runtime server from
+  `agent-sandbox/examples/python-runtime-sandbox/main.py` (FastAPI `/execute`, `/upload`,
+  `/download`, `/list`, `/exists` on 8888), plus `/opt/run_sql.py`.
+- `run_sql.py` reads `schema.sql` and `query.sql` from the working directory, runs
+  `executescript(schema)` then `execute(query)` in an in-memory database with the same 250 ms
+  progress-handler deadline the recipe uses today, and prints `{"rows": [...], "error": null}` as
+  JSON. Float rounding matches `utils/rewards.py:run_sql` so results are byte-comparable.
+- Built by Cloud Build alongside the other images (`cloudbuild.yaml`), tagged per release.
+
+### 4.2 Kubernetes resources (`k8s/deploy/agent-sandbox/` or `examples/text-to-sql/k8s/`)
+
+- `SandboxTemplate text-to-sql-executor`: `runtimeClassName: gvisor`, `runAsNonRoot`, requests
+  250m / 256Mi, port 8888, `networkPolicy` with ingress only from the training-client namespace
+  and **no egress rules** (deny all), `envVarsInjectionPolicy: Disallowed`.
+- `SandboxWarmPool text-to-sql-executor`: `replicas: 4` for Phase A, `replicas: 8` for Phase B
+  (one per prompt in a step).
+- RBAC: a Role granting the client service account create/get/list/watch/delete on
+  `sandboxclaims.extensions.agents.x-k8s.io` and get/list/watch on `sandboxes.agents.x-k8s.io`,
+  bound to `open-rl-sa` (reused from the shared backend stack).
+- A `Job` manifest that runs the recipe in-cluster from the examples image so pod IPs are
+  reachable. Dev path: the SDK's `SandboxLocalTunnelConnectionConfig` with `kubectl port-forward`.
+
+### 4.3 `examples/common/agent_sandbox.py` (the reusable piece)
+
+```python
+class AgentSandboxBackend:                       # satisfies tinker_cookbook SandboxInterface
+    @classmethod
+    async def create(cls, *, warm_pool: str, namespace: str, ready_timeout: int = 180,
+                     connection=SandboxInClusterConnectionConfig()) -> "AgentSandboxBackend": ...
+    @property
+    def sandbox_id(self) -> str: ...             # claim name
+    async def run_command(self, command, workdir=None, timeout=60, max_output_bytes=None) -> SandboxResult
+    async def read_file(self, path, max_bytes=None, timeout=60) -> SandboxResult
+    async def write_file(self, path, content, executable=False, timeout=60) -> SandboxResult
+    async def send_heartbeat(self, timeout=30) -> None   # status() probe; no-op keepalive today
+    async def cleanup(self) -> None               # delete the claim
+
+class AgentSandboxPool:                          # Phase A: N long-lived sandboxes, leased round-robin
+    async def __aenter__(self) / __aexit__(self)  # claim N on enter, cleanup all on exit
+    async def lease(self) -> AsyncIterator[AgentSandboxBackend]   # bounded by a semaphore
+
+async def run_sql_in_sandbox(sb: SandboxInterface, context: str, query: str) -> tuple[rows | None, str | None]:
+    # write_file schema.sql + query.sql into a per-call temp dir, run_command python /opt/run_sql.py, parse JSON
+```
+
+Behavior details: `run_command` maps `ExecutionResult(stdout, stderr, exit_code)` to
+`SandboxResult`; `workdir` is honored by prefixing `cd`; `max_output_bytes` truncates client-side;
+a claim that goes non-Ready raises `SandboxTerminatedError`. Unit tests use a fake HTTP server;
+one integration test runs against kind with the controller installed.
+
+### 4.4 Phase A: existing recipe (`examples/text-to-sql`)
+
+- New chz group `reward: RewardConfig(executor="local" | "agent_sandbox", warm_pool, namespace,
+  pool_size=4, connection="in_cluster" | "local_tunnel")`. Default stays `local` so laptop runs are
+  unchanged.
+- `score_prediction` gains an injectable executor callable. `build_rollout` and
+  `sample_eval_metrics` become async-aware and go through `AgentSandboxPool.lease()` when the
+  sandbox executor is selected. Dataset filtering (`build_dataset_rows`) keeps calling local
+  `run_sql`.
+- New per-step metrics: `sandbox_exec_p50_ms`, `sandbox_exec_p95_ms`, `sandbox_errors`.
+- Kustomize overlay adds the template, warm pool, RBAC, and Job to the existing
+  `examples/text-to-sql/kustomization.yaml` stack.
+
+### 4.5 Phase B: cookbook recipe (`examples/text-to-sql/cookbook/`)
+
+- `data.py`: `TextToSqlDatasetBuilder(RLDatasetBuilder)` wrapping `utils.rewards.load_dataset_splits`;
+  `RLDataset.get_batch(i)` returns `groups_per_batch` `TextToSqlGroupBuilder`s.
+- `env.py`:
+  - `TextToSqlEnv(Env)`: `initial_observation` renders the existing plain prompt through the
+    `qwen3_disable_thinking` renderer as a single user message; `step` parses the response, cleans
+    SQL, awaits `run_sql_in_sandbox`, scores with `utils.rewards.score_prediction`, returns
+    `StepResult(reward, episode_done=True, ...)`. Metrics mirror the existing ones
+    (`compile`, `execution_match`, `exact_match`, `similarity`).
+  - `TextToSqlGroupBuilder(EnvGroupBuilder)`: `make_envs` claims **one sandbox per group** via a
+    `sandbox_factory`, writes `schema.sql` once, returns `group_size` envs sharing it; `cleanup`
+    deletes the claim. `logging_tags` returns `["text_to_sql"]`. Pickleable: holds only the row
+    and the factory reference.
+- `train.py`: chz `CLIConfig` in the style of `recipes/math_rl/train.py`:
+  `model_name=Qwen/Qwen3-1.7B`, `renderer_name=qwen3_disable_thinking`, `group_size=8`,
+  `groups_per_batch=8`, `max_tokens=96`, `loss_fn=importance_sampling`, `learning_rate=1e-5`,
+  `lora_rank=32`, `save_every=0` (OpenRL checkpoint limitation, issue #83), `base_url` from
+  `TINKER_BASE_URL`. `sandbox_factory` is injected exactly as `harbor_rl` does it. On cookbook
+  0.5.7 also set `rollout_error_tolerance=MinViableGroup()` so one failed sandbox claim does not
+  kill a whole prompt group, and `termination.grader_timeout_seconds` to bound a hung executor.
+- Server side: OpenRL deployed with `BASE_MODEL=Qwen/Qwen3-1.7B` (the tinker-cookbook example
+  already documents this on two L4s).
+
+## 5. Phases, deliverables, acceptance
+
+| Phase | Deliverables | Acceptance |
+| --- | --- | --- |
+| **0a. Client upgrade** (§7.1) | `examples/pyproject.toml`: `tinker-cookbook==0.5.7`, `tinker==0.24.1`; regenerate `docs/tinker-client-compatibility.md`; rerun the existing Gemma recipe and the cookbook `shorter` RL example | Compatibility report shows the same 41 supported methods; text-to-SQL `phase=full` curve unchanged within noise |
+| **0b. Cluster prereqs** | agent-sandbox v1.0.1 with extensions on `open-rl-dra`; `sql-executor` image in Cloud Build; template + warm pool + RBAC applied | `kubectl get sandboxwarmpools` shows `readyReplicas == replicas`; a manual claim can `run_command("python /opt/run_sql.py")` |
+| **1. Backend** | `examples/common/agent_sandbox.py`, unit tests, kind integration test | `isinstance(backend, SandboxInterface)` is true; write/run/read round trip passes; cleanup deletes the claim |
+| **2. Phase A** | `executor=agent_sandbox` in the Gemma recipe; Job overlay; metrics | `phase=full` on GKE reproduces the known-good curve (execution match in the 35-45% band at step 80) with all prediction scoring in sandboxes; p95 exec latency table in the README |
+| **3. Phase B** | `examples/text-to-sql/cookbook/` recipe; Qwen3 server overlay | Execution match rises monotonically over 40+ steps from the Qwen3 baseline; one claim per group visible in `kubectl get sandboxclaims -w` |
+| **4. Docs** | README section in `examples/text-to-sql`; `docs/sandboxed-rewards.md` guide with the §3 diagram and the trust-boundary explanation; note the upstream contribution plan | Docs reviewed; commands copy-paste clean from a fresh cluster |
+
+Suggested order: 0a, 0b, 1, 2, 3, 4. Phase 1 and the image in Phase 0b can proceed in parallel.
+Gateway protobuf support (§7.2) is independent of all of them and can land whenever the server
+team has capacity.
+
+## 6. Risks and open items
+
+- **In-cluster only for the default path.** Pod IPs are not routable from a laptop. Mitigation:
+  document the local-tunnel connection config for dev; the Job overlay is the supported path.
+- **Headless-service DNS fallback.** `SandboxInClusterConnectionConfig` falls back to
+  `<sandbox>.<ns>.svc.cluster.local`, which requires the template's `service` flag. Verify the
+  default in v1.0.1 during Phase 0 and set it explicitly if needed.
+- **Claim latency in Phase B.** ~3-6 s per step for 8 concurrent claims is acceptable for a demo but
+  should be logged; if it dominates, switch the group builder to lease from a pool instead of
+  claiming. Keep the choice behind one flag.
+- **SDK dependency weight.** `k8s-agent-sandbox[async]` pulls `kubernetes`, `kubernetes_asyncio<34`,
+  `httpx`, `prometheus-client`. Add as an optional extra `[sandbox]` in `examples/pyproject.toml`
+  so laptop users without a cluster are not affected.
+- **transformers override.** `examples/pyproject.toml` forces `transformers>=5.7.0` (added in
+  #81 for the Gemma guide) while cookbook 0.5.7 declares `<=5.5.4`. The override wins at resolve
+  time, so the cookbook runs on a transformers it was not tested with. The Qwen3 renderer only
+  needs the tokenizer, and the render check in §7.3 passed on 5.5.4; rerun that check against the
+  resolved version as part of Phase 0a.
+- **Upstreaming.** When contributing to tinker-cookbook, the backend should register as a
+  `SandboxBackend.AGENT_SANDBOX` value and add a `_check_with_agent_sandbox` branch in
+  `recipes/code_rl/code_grading.py` so `code_rl` gains it too. Out of scope here, but the module
+  layout should not make it harder.
+
+## 7. Client upgrade: tinker-cookbook 0.5.7 and the tinker SDK
+
+### 7.1 Do now: cookbook 0.5.7 with tinker pinned to 0.24.1
+
+Verified on 2026-09-09 by running `tests/tinker_client_compat.py` against the current gateway with
+each SDK version (Linux box; the fixture needs `/dev/shm`):
+
+| tinker | Result against current gateway |
+| --- | --- |
+| 0.22.7 (pinned) | 41 supported, baseline |
+| 0.23.0, 0.24.1 | Same 41 supported; 5 new SDK methods unsupported (`whoami`, `get_billing_usage*`, `export_session_trace*`), none on the training path |
+| 0.25.0 through 0.27.2 | `forward_backward`, `sample`, `compute_logprobs` and everything downstream fail (see §7.2) |
+
+Cookbook 0.5.7 requires `tinker>=0.23.0`, so `tinker==0.24.1` satisfies it. Costs of the cookbook
+bump: `torch>=2.10` (examples venv has 2.12 already), a new `tml-renderers` dependency used only for
+Inkling tokenizers, and the transformers override caveat in §6. There are no breaking changes for
+code that subclasses `Env`, `EnvGroupBuilder`, or `ProblemEnv`; `rl_train.Config` adds
+`termination` and widens `rollout_error_tolerance` to accept `None`. Custom `TokenCompleter`
+subclasses must accept a `max_tokens` keyword. Also note that `training_client.get_tokenizer()` is
+no longer called by `rl_train`; the tokenizer is loaded from Hugging Face by model name.
+
+### 7.2 Do later: protobuf on the gateway to unlock tinker 0.25+
+
+From 0.25.0 the SDK:
+
+- POSTs `/api/v1/forward_backward` with a protobuf body and `Content-Type: application/x-protobuf`,
+  unconditionally. With the `proto_compress_fwdbwd` client-config flag it also sets
+  `Content-Encoding: zstd`. There is no JSON fallback. The current gateway returns a validation
+  error and the SDK times out.
+- Sends `Accept: application/x-protobuf` on `/api/v1/retrieve_future` for `SampleResponse` and
+  `ForwardBackwardOutput`, and raises if the body comes back as JSON. Other response types stay JSON.
+- Optionally batch-polls `/api/v1/retrieve_futures` when the server sets
+  `sample_use_retrieve_futures` in `/api/v1/client/config`. The gateway does not set it, so this
+  is not required.
+
+The schema and converters ship in the SDK wheel (`tinker/proto/tinker_public_pb2.py`,
+`request_conv.py`, `response_conv.py`), so the gateway can import them rather than vendor a
+`.proto`. Work: decode protobuf `forward_backward` requests (with optional zstd) into the existing
+dict shape, encode the two response types as protobuf when the request carries the `Accept`
+header, keep the JSON paths for older SDKs, and extend `tests/tinker_client_compat.py` to run
+under both a JSON-era and a proto-era SDK. Track separately from this design.
+
+### 7.3 Renderer changes in 0.5.7 that affect training
+
+Rendered with the Qwen3-1.7B tokenizer, one user message and one assistant answer, checked
+against `apply_chat_template`:
+
+| Renderer | 0.4.2 | 0.5.7 | Effect |
+| --- | --- | --- | --- |
+| `qwen3_disable_thinking` | prompt 33 tokens, 7 trained, matches HF | identical | None for this plan |
+| `qwen3` (thinking on), assistant turn without reasoning | 7 trained, no think block | 11 trained, includes `<think>\n\n</think>\n\n` | 0.5.7 matches what the HF template writes on a produced turn; 0.4.2 taught the model to skip the block |
+| Quoted `<|im_end|>` inside message text | becomes a real turn boundary (4 control tokens in the example) | stays literal text (2) | Fixes a training-data injection path (#886) |
+
+Other 0.5.7 changes with training impact, from the upstream commits between the releases:
+
+- **Loss withheld from the generation-prompt prefill** (`20d06ac8`). Renderers whose prompt ends
+  in an open `<think>` (`qwen3_5`, `kimi_k25`, `nemotron3`, `deepseekv3_thinking`) trained the
+  model on a token it is always given. Tokens are unchanged, only weights move. Qwen3 was already
+  correct. **`examples/harvey_labs` trains Qwen3.5-9B and is affected**; expect a small loss shift
+  and re-baseline before comparing curves across the upgrade.
+- **Reasoning-off renderers now raise** when a supervised turn contains reasoning (`ab78b73f`)
+  instead of silently training the reasoning. SFT datasets with `<think>` content used with a
+  `*_disable_thinking` renderer will fail fast after the upgrade.
+- **Qwen3.5 boundary and content trimming fixes** (`798a63ec`, #852). Also relevant to harvey_labs.
+- **`role_colon` parse no longer strips whitespace**; it removes exactly the rendered prefix and
+  suffix so render and parse are inverses. Reward code that relied on stripped content should strip
+  itself.
+- **`build_supervised_examples` splits multi-turn conversations** into one example per assistant
+  turn instead of raising `NotImplementedError`.
+- New renderer names: `qwen3_8_*`, `glm5_3_*`, `nemotron3*_preserve_thinking`, `tml_v0`. Still no
+  Gemma renderer.
+
+## 8. Non-goals
+
+- No OpenRL server changes. The gateway, trainer, and sampler are untouched.
+- No P3 (harness inside the sandbox). That needs the OpenAI-compatible endpoint from design 012 §7.2.
+- No Substrate integration. It is gRPC-only with no Python SDK, no exec API, and is self-described
+  as not production ready. Revisit when actor forking from a checkpoint lands.
+- No Gemma renderer for the cookbook. Tracked separately as a possible upstream contribution.

--- a/docs/sandboxed-rewards.md
+++ b/docs/sandboxed-rewards.md
@@ -161,8 +161,8 @@ because the cookbook ships no Gemma renderer.
 Measured (40 batches of 8 groups × 8 samples, lr 1e-5, eval every 10 batches
 on 100 held-out examples): 21 minutes wall clock, about 31 s per batch of
 which the sandboxed rollouts take 6 s on average (16 s on the first batches); 324 claims created and 324 terminated,
-none left after the pod exited; warm-pool claims 0.2–0.3 s, the slowest 10 s
-while the pool replenished. Held-out execution match 54% → 58% → 60% → 60%
+none left after the pod exited; claim latency 0.2 s when a pre-warmed pod is
+free, median 2.6 s over the run, worst 10 s while the pool replenished. Held-out execution match 54% → 58% → 60% → 60%
 at batches 0, 10, 20, 30; Qwen3-1.7B already solves most of this task, so
 the headroom is small.
 

--- a/docs/sandboxed-rewards.md
+++ b/docs/sandboxed-rewards.md
@@ -160,7 +160,7 @@ because the cookbook ships no Gemma renderer.
 
 Measured (40 batches of 8 groups × 8 samples, lr 1e-5, eval every 10 batches
 on 100 held-out examples): 21 minutes wall clock, about 31 s per batch of
-which sandbox rollouts take 12–16 s; 324 claims created and 324 terminated,
+which the sandboxed rollouts take 6 s on average (16 s on the first batches); 324 claims created and 324 terminated,
 none left after the pod exited; warm-pool claims 0.2–0.3 s, the slowest 10 s
 while the pool replenished. Held-out execution match 54% → 58% → 60% → 60%
 at batches 0, 10, 20, 30; Qwen3-1.7B already solves most of this task, so

--- a/docs/sandboxed-rewards.md
+++ b/docs/sandboxed-rewards.md
@@ -1,0 +1,166 @@
+# Sandboxed reward execution
+
+RL rewards that *run* model output are the common case: SQL against a database,
+a program against tests, a tool call against a service. That output is
+untrusted. This guide shows how the Text-to-SQL recipe executes model-written
+SQL in gVisor sandboxes managed by
+[kubernetes-sigs/agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox),
+and how the same backend plugs into tinker-cookbook recipes unchanged.
+Design: [013-sandboxed-rewards-text-to-sql](designs/013-sandboxed-rewards-text-to-sql.md).
+
+## What runs where
+
+```mermaid
+graph LR
+    subgraph Client["Training client pod (client image, in-cluster)"]
+        Loop["Recipe loop<br/>texttosql_sft_grpo.py or cookbook rl_train"]
+        Backend["AgentSandboxBackend<br/>(tinker-cookbook SandboxInterface)"]
+    end
+    GW["OpenRL gateway<br/>sample / forward_backward"]
+    Ctl["agent-sandbox controller"]
+    Pool["SandboxWarmPool<br/>text-to-sql-executor"]
+    SB1["Sandbox (gVisor)<br/>runtime :8888 + run_sql.py"]
+    SB2["Sandbox (gVisor)"]
+    Loop -->|tokens in / out| GW
+    Loop -->|write_file + run_command| Backend
+    Backend -->|SandboxClaim| Ctl
+    Ctl --> Pool
+    Pool --> SB1
+    Pool --> SB2
+    Backend -->|HTTP, pod IP| SB1
+    Backend -->|HTTP, pod IP| SB2
+```
+
+The trust boundary is the model's output and nothing else:
+
+| Runs in the sandbox | Stays in the client |
+| --- | --- |
+| the model's SQL, against the example's schema | dataset filtering (`build_dataset_rows` executes the *target* SQL thousands of times to precompute rows) |
+| | the target query when its rows were not precomputed |
+| | scoring (`score_from_execution`), which only compares rows |
+
+The sandbox holds no credential: no service-account token is mounted, no
+environment variable can be injected by a claim, the root filesystem is
+read-only, and the template's network policy allows ingress only from the
+training namespace on :8888 and declares no egress. Isolation is gVisor via
+`runtimeClassName: gvisor`.
+
+> **NetworkPolicy needs enforcement.** The controller creates the policy from
+> the template, but it only takes effect on clusters with a policy-enforcing
+> dataplane (GKE Dataplane V2 or the NetworkPolicy add-on). On a cluster
+> without one the sandbox is still gVisor-isolated but can open outbound
+> connections. Check with `gcloud container clusters describe <cluster> --format="value(networkConfig.datapathProvider,networkPolicy.enabled)"`.
+
+## Components
+
+| Piece | Where | What |
+| --- | --- | --- |
+| runtime image `open-rl-sql-executor` | `examples/text-to-sql/sandbox/` | agent-sandbox's reference runtime server plus `/opt/run_sql.py`, which runs schema then query in an in-memory SQLite with the recipe's 250 ms deadline and float rounding, and prints `{"rows": ..., "error": ...}` |
+| Kubernetes resources | `examples/text-to-sql/k8s/agent-sandbox/` | `SandboxTemplate text-to-sql-executor`, a `SandboxWarmPool`, and a Role letting `open-rl-sa` claim sandboxes |
+| backend | `examples/common/agent_sandbox.py` | `AgentSandboxBackend` (implements `SandboxInterface`), `AgentSandboxPool` (N long-lived sandboxes, leased), `make_sandbox_factory` (one claim per call), `run_sql_in_sandbox` |
+| Phase A consumer | `examples/text-to-sql/texttosql_sft_grpo.py` | `reward.executor=agent_sandbox` scores every rollout and eval through a pool lease |
+| Phase B consumer | `examples/text-to-sql/cookbook/` | a cookbook `rl_train` recipe whose `EnvGroupBuilder` claims one sandbox per prompt group |
+| Job manifests | `examples/text-to-sql/k8s/job-*.yaml` | run either consumer in-cluster from the client image |
+
+## Setup
+
+1. Install agent-sandbox with its extensions (SandboxTemplate, SandboxWarmPool, SandboxClaim):
+
+   ```bash
+   kubectl apply --server-side -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/v1.0.1/sandbox-with-extensions.yaml
+   kubectl -n agent-sandbox-system rollout status deploy/agent-sandbox-controller
+   ```
+
+2. Make sure gVisor pods can schedule. On GKE that means a node pool with GKE Sandbox:
+
+   ```bash
+   gcloud container node-pools create sandbox-pool --cluster <cluster> --region <region> \
+     --machine-type e2-standard-4 --sandbox type=gvisor --num-nodes 1 \
+     --enable-autoscaling --min-nodes 0 --max-nodes 3
+   ```
+
+   The `gvisor` RuntimeClass carries the node selector and toleration; the template does not need them.
+
+3. Build the executor image and apply the template, warm pool and RBAC:
+
+   ```bash
+   make cloud-build-sql-executor GCP_PROJECT=<project> CLOUD_IMAGE_TAG=<tag>
+   kubectl kustomize examples/text-to-sql/k8s/agent-sandbox \
+     | sed "s#ghcr.io/gke-labs/open-rl/sql-executor:latest#<registry>/open-rl-sql-executor:<tag>#" \
+     | kubectl apply -f -
+   kubectl -n openrl-system get sandboxwarmpools   # READY should equal REPLICAS
+   ```
+
+4. The client image installs the `sandbox` extra of the examples project
+   (`k8s-agent-sandbox[async]`). For a laptop checkout:
+   `uv --project examples sync --extra sandbox`.
+
+## Phase A: the Gemma recipe with `reward.executor=agent_sandbox`
+
+```bash
+kubectl -n openrl-system apply -f examples/text-to-sql/k8s/job-recipe-sandboxed.yaml
+```
+
+or through the e2e runner:
+
+```bash
+make cluster-e2e E2E_SCENARIO=lora-textsql \
+  E2E_ARGS="base_model=google/gemma-4-e2b steps=80 extra='rl.prompts_per_step=8 rl.samples_per_prompt=8 rl.eval_every=10 dataset.rl_train_limit=5000 dataset.eval_limit=100 reward.executor=agent_sandbox reward.pool_size=4'" \
+  E2E_IMAGE=<client image>
+```
+
+The `reward` group: `executor` (`local` | `agent_sandbox`), `warm_pool`,
+`namespace`, `pool_size` (long-lived sandboxes leased round-robin),
+`ready_timeout`, `exec_timeout`. Each training step logs
+`sandbox_exec_p50_ms` / `sandbox_exec_p95_ms` (the round trip),
+`sandbox_wait_p95_ms` (time queued for a lease) and `sandbox_errors`
+(transport failures, which score like a failed query but are counted
+separately).
+
+Measured on GKE (`open-rl-dra`, e2-standard-4 gVisor node, in-cluster client):
+
+| | |
+| --- | --- |
+| warm-pool claim | 0.2–2.0 s |
+| one SQL round trip (upload + execute) | p50 ≈ 110 ms, p95 ≈ 160 ms |
+| runaway query (`WITH RECURSIVE` bomb) | interrupted at 250 ms, scored as an error |
+| 64 rollouts per step against 4 sandboxes | ≈ 2 s of scoring per step; lease wait dominates, so raise `pool_size` (and the warm pool) before anything else |
+
+## Phase B: a cookbook `rl_train` recipe
+
+```bash
+kubectl -n openrl-system apply -f examples/text-to-sql/k8s/job-cookbook-rl.yaml
+kubectl -n openrl-system get sandboxclaims -w     # one claim per prompt group per step
+```
+
+`examples/text-to-sql/cookbook/train.py` builds the cookbook's `Config`
+exactly as `recipes/math_rl/train.py` does; the only OpenRL-specific parts
+are `base_url` and `save_every=0`. `TextToSqlGroupBuilder.make_envs` claims a
+sandbox through the injected factory (the `harbor_rl` pattern), the
+`group_size` envs share it, and `cleanup` deletes the claim.
+`rollout_error_tolerance=MinViableGroup()` means a failed claim costs one
+rollout, not the group. `sandbox=local` runs the SQL in-process for smoke tests.
+
+Qwen3-1.7B with the `qwen3_disable_thinking` renderer is the cookbook path
+because the cookbook ships no Gemma renderer.
+
+## Using the backend elsewhere
+
+`AgentSandboxBackend` is a drop-in `SandboxInterface`. Anything in
+tinker-cookbook that accepts a `sandbox_factory` (for example `harbor_rl`) can
+take `make_sandbox_factory(warm_pool=..., namespace=...)` and run on a
+Kubernetes warm pool instead of Modal or SandboxFusion. Upstreaming it as a
+`SandboxBackend.AGENT_SANDBOX` value is the follow-up; the module has no
+Text-to-SQL dependency apart from `run_sql_in_sandbox`.
+
+Two runtime facts worth knowing when reusing it:
+
+* the reference runtime `shlex`-splits commands and runs them without a shell
+  from its base directory, so `run_command(..., workdir=...)` wraps the command
+  in `sh -c`, and paths are relative to `SANDBOX_BASE_DIR` (`/app/work` here);
+* the SDK's async client reaches sandboxes by pod IP, which is why the client
+  Job runs in-cluster; for a laptop, the synchronous SDK client's local-tunnel
+  mode (`kubectl port-forward`) is the alternative, not covered by this backend.
+
+Unit tests: `make test examples` (a fake sandbox runs the real `run_sql.py`
+and the results are compared with the local scorer).

--- a/docs/sandboxed-rewards.md
+++ b/docs/sandboxed-rewards.md
@@ -126,6 +126,20 @@ Measured on GKE (`open-rl-dra`, e2-standard-4 gVisor node, in-cluster client):
 | runaway query (`WITH RECURSIVE` bomb) | interrupted at 250 ms, scored as an error |
 | 64 rollouts per step against 4 sandboxes | ≈ 2 s of scoring per step; lease wait dominates, so raise `pool_size` (and the warm pool) before anything else |
 
+Acceptance run (Gemma-4-e2b LoRA, `phase=rl_only`, 80 steps, 8 prompts × 8
+samples, lr 5e-6, eval every 10 steps on 100 held-out examples; 50 minutes
+wall clock, 5,488 rollouts, 0 sandbox errors) against the same recipe with
+in-process execution, run the same day:
+
+| Eval step | 0 | 10 | 20 | 30 | 40 | 50 | 60 | 70 | 80 |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| execution match, sandboxed | 6% | 8% | 10% | 13% | 14% | 14% | 18% | 24% | 25% |
+| execution match, local | 6% | 9% | 10% | 13% | 16% | 15% | 19% | 19% | 26% |
+| similarity, sandboxed | 37% | 37% | 38% | 44% | 48% | 52% | 58% | 62% | 65% |
+
+Same curve within eval noise: moving execution into the sandbox changes where
+the SQL runs, not what the model learns.
+
 ## Phase B: a cookbook `rl_train` recipe
 
 ```bash
@@ -143,6 +157,20 @@ rollout, not the group. `sandbox=local` runs the SQL in-process for smoke tests.
 
 Qwen3-1.7B with the `qwen3_disable_thinking` renderer is the cookbook path
 because the cookbook ships no Gemma renderer.
+
+Measured (40 batches of 8 groups × 8 samples, lr 1e-5, eval every 10 batches
+on 100 held-out examples): 21 minutes wall clock, about 31 s per batch of
+which sandbox rollouts take 12–16 s; 324 claims created and 324 terminated,
+none left after the pod exited; warm-pool claims 0.2–0.3 s, the slowest 10 s
+while the pool replenished. Held-out execution match 54% → 58% → 60% → 60%
+at batches 0, 10, 20, 30; Qwen3-1.7B already solves most of this task, so
+the headroom is small.
+
+The first run claimed one sandbox per held-out *example* as well: 100 claims
+at once against a 4-replica pool, most cold-starting a gVisor pod at ~80 s,
+and the eval took longer than the training. Evals now lease from a shared
+pool (`eval_pool_size`); training groups keep one claim each, which is the
+behaviour the demo is about.
 
 ## Using the backend elsewhere
 

--- a/examples/common/agent_sandbox.py
+++ b/examples/common/agent_sandbox.py
@@ -192,14 +192,19 @@ class AgentSandboxBackend:
         await self._on_cleanup()
 
 
-def make_client(connection: Any | None = None) -> Any:
-  """An ``AsyncSandboxClient`` that talks to pod IPs unless told otherwise."""
+def make_client(connection: Any | None = None, *, cleanup_at_exit: bool = False) -> Any:
+  """An ``AsyncSandboxClient`` that talks to pod IPs unless told otherwise.
+
+  ``cleanup_at_exit`` registers the SDK's atexit sweep, which deletes every
+  claim the client made using the synchronous Kubernetes client. Use it for a
+  pool that lives as long as the process and has no natural close point (for
+  example one shared by a cookbook dataset); leave it off when the owner
+  deletes its own claims, so the sweep cannot race the event loop shutdown.
+  """
   from k8s_agent_sandbox.async_sandbox_client import AsyncSandboxClient
   from k8s_agent_sandbox.models import SandboxInClusterConnectionConfig
 
-  # cleanup=False: the pool and the group builders delete their own claims;
-  # the SDK's atexit sweep would race the event loop shutdown.
-  return AsyncSandboxClient(connection_config=connection or SandboxInClusterConnectionConfig(), cleanup=False)
+  return AsyncSandboxClient(connection_config=connection or SandboxInClusterConnectionConfig(), cleanup=cleanup_at_exit)
 
 
 class AgentSandboxPool:

--- a/examples/common/agent_sandbox.py
+++ b/examples/common/agent_sandbox.py
@@ -1,0 +1,351 @@
+"""agent-sandbox backend for tinker-cookbook's ``SandboxInterface``.
+
+Runs untrusted, model-written code (here: SQL) in gVisor sandboxes claimed
+from a Kubernetes ``SandboxWarmPool`` (kubernetes-sigs/agent-sandbox v1beta1)
+through the ``k8s-agent-sandbox[async]`` SDK. The sandbox runtime is the
+reference HTTP server on :8888 (``/execute``, ``/upload``, ``/download``); the
+client talks to the pod IP, so the training process must run in-cluster.
+
+Three things live here:
+
+* :class:`AgentSandboxBackend` satisfies ``tinker_cookbook.sandbox.SandboxInterface``
+  and wraps one claimed sandbox.
+* :class:`AgentSandboxPool` holds N long-lived sandboxes and leases them out
+  (Phase A of design 013: a fixed pool amortises the ~3 s claim latency).
+* :func:`run_sql_in_sandbox` is the Text-to-SQL reward primitive: ship the
+  schema and query, run ``/opt/run_sql.py``, get rows back.
+
+Paths handed to the runtime are relative to its working directory
+(``SANDBOX_BASE_DIR``); absolute paths under that directory are accepted and
+rewritten, anything else absolute is rejected rather than silently relocated.
+
+Install with ``uv --project examples sync --extra sandbox``. The SDK is imported
+lazily so this module can be imported, and the fakes in the tests used, without it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import collections
+import contextlib
+import json
+import logging
+import shlex
+import time
+import uuid
+from collections.abc import AsyncIterator, Awaitable, Callable
+from typing import Any, Protocol
+
+from tinker_cookbook.sandbox import SandboxResult, SandboxTerminatedError
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BASE_DIR = "/app/work"
+RUN_SQL = "/opt/run_sql.py"
+DEFAULT_MAX_OUTPUT_BYTES = 128 * 1024
+
+
+class _Commands(Protocol):
+  async def run(self, command: str, timeout: int = 60) -> Any: ...
+
+
+class _Files(Protocol):
+  async def write(self, path: str, content: bytes | str, timeout: int = 60) -> Any: ...
+  async def read(self, path: str, timeout: int = 60) -> bytes: ...
+
+
+class SandboxHandle(Protocol):
+  """The slice of ``k8s_agent_sandbox.AsyncSandbox`` this module uses."""
+
+  claim_name: str
+  namespace: str
+
+  @property
+  def commands(self) -> _Commands | None: ...
+  @property
+  def files(self) -> _Files | None: ...
+  async def status(self) -> tuple[str, str]: ...
+  async def terminate(self) -> None: ...
+
+
+def _relative_path(path: str, base_dir: str) -> str:
+  if not path.startswith("/"):
+    return path
+  prefix = base_dir.rstrip("/") + "/"
+  if path.startswith(prefix):
+    return path[len(prefix) :]
+  raise ValueError(f"sandbox paths must be relative or under {base_dir}; got {path!r}")
+
+
+def _truncate(text: str, limit: int | None) -> str:
+  if limit is None or len(text.encode("utf-8", "replace")) <= limit:
+    return text
+  return text.encode("utf-8", "replace")[:limit].decode("utf-8", "ignore") + f"\n[truncated to {limit} bytes]"
+
+
+class AgentSandboxBackend:
+  """One claimed sandbox, exposed through tinker-cookbook's SandboxInterface."""
+
+  def __init__(self, sandbox: SandboxHandle, *, base_dir: str = DEFAULT_BASE_DIR, on_cleanup: Callable[[], Awaitable[None]] | None = None):
+    self._sandbox = sandbox
+    self._base_dir = base_dir
+    self._on_cleanup = on_cleanup
+    self._closed = False
+
+  @classmethod
+  async def create(
+    cls,
+    *,
+    warm_pool: str,
+    namespace: str,
+    ready_timeout: int = 180,
+    connection: Any | None = None,
+    client: Any | None = None,
+    base_dir: str = DEFAULT_BASE_DIR,
+  ) -> AgentSandboxBackend:
+    """Claim a sandbox from ``warm_pool`` and wait until it is ready.
+
+    ``client`` is an ``AsyncSandboxClient`` to share across claims; when omitted
+    a private one is made with ``connection`` (default in-cluster pod IP).
+    """
+    own_client = client is None
+    if own_client:
+      client = make_client(connection)
+    started = time.monotonic()
+    sandbox = await client.create_sandbox(warm_pool, namespace=namespace, sandbox_ready_timeout=ready_timeout)
+    logger.info("claimed sandbox %s/%s from %s in %.1fs", namespace, sandbox.claim_name, warm_pool, time.monotonic() - started)
+
+    async def release() -> None:
+      if own_client:
+        await client.close()
+
+    return cls(sandbox, base_dir=base_dir, on_cleanup=release)
+
+  @property
+  def sandbox_id(self) -> str:
+    return self._sandbox.claim_name
+
+  @property
+  def base_dir(self) -> str:
+    return self._base_dir
+
+  def _commands(self) -> _Commands:
+    commands = self._sandbox.commands
+    if self._closed or commands is None:
+      raise SandboxTerminatedError(f"sandbox {self.sandbox_id} is closed")
+    return commands
+
+  def _files(self) -> _Files:
+    files = self._sandbox.files
+    if self._closed or files is None:
+      raise SandboxTerminatedError(f"sandbox {self.sandbox_id} is closed")
+    return files
+
+  async def run_command(self, command: str, workdir: str | None = None, timeout: int = 60, max_output_bytes: int | None = None) -> SandboxResult:
+    # The runtime shlex-splits the command and runs it without a shell from
+    # its base directory, so a working directory needs an explicit shell.
+    if workdir is not None:
+      command = "sh -c " + shlex.quote(f"cd {shlex.quote(_relative_path(workdir, self._base_dir) or '.')} && {command}")
+    started = time.monotonic()
+    result = await self._commands().run(command, timeout=timeout)
+    limit = DEFAULT_MAX_OUTPUT_BYTES if max_output_bytes is None else max_output_bytes
+    return SandboxResult(
+      stdout=_truncate(result.stdout, limit),
+      stderr=_truncate(result.stderr, limit),
+      exit_code=int(result.exit_code),
+      metrics={"duration_ms": (time.monotonic() - started) * 1000.0},
+    )
+
+  async def read_file(self, path: str, max_bytes: int | None = None, timeout: int = 60) -> SandboxResult:
+    try:
+      content = await self._files().read(_relative_path(path, self._base_dir), timeout=timeout)
+    except Exception as exc:  # the SDK raises SandboxRequestError on 404; keep the interface's result shape
+      return SandboxResult(stdout="", stderr=str(exc), exit_code=1)
+    if max_bytes is not None:
+      content = content[:max_bytes]
+    return SandboxResult(stdout=content.decode("utf-8", "replace"), stderr="", exit_code=0)
+
+  async def write_file(self, path: str, content: str | bytes, executable: bool = False, timeout: int = 60) -> SandboxResult:
+    relative = _relative_path(path, self._base_dir)
+    await self._files().write(relative, content, timeout=timeout)
+    if executable:
+      chmod = await self._commands().run(f"chmod +x {shlex.quote(relative)}", timeout=timeout)
+      if chmod.exit_code != 0:
+        return SandboxResult(stdout="", stderr=chmod.stderr, exit_code=int(chmod.exit_code))
+    return SandboxResult(stdout="", stderr="", exit_code=0)
+
+  async def send_heartbeat(self, timeout: int = 30) -> None:
+    """The runtime has no keepalive; probe the claim and fail loudly if it is gone."""
+    state, message = await asyncio.wait_for(self._sandbox.status(), timeout=timeout)
+    if state != "SandboxReady":
+      raise SandboxTerminatedError(f"sandbox {self.sandbox_id} is {state}: {message}")
+
+  async def cleanup(self) -> None:
+    if self._closed:
+      return
+    self._closed = True
+    try:
+      await self._sandbox.terminate()
+    finally:
+      if self._on_cleanup is not None:
+        await self._on_cleanup()
+
+
+def make_client(connection: Any | None = None) -> Any:
+  """An ``AsyncSandboxClient`` that talks to pod IPs unless told otherwise."""
+  from k8s_agent_sandbox.async_sandbox_client import AsyncSandboxClient
+  from k8s_agent_sandbox.models import SandboxInClusterConnectionConfig
+
+  # cleanup=False: the pool and the group builders delete their own claims;
+  # the SDK's atexit sweep would race the event loop shutdown.
+  return AsyncSandboxClient(connection_config=connection or SandboxInClusterConnectionConfig(), cleanup=False)
+
+
+class AgentSandboxPool:
+  """N long-lived sandboxes leased round-robin, at most one lease per sandbox at a time.
+
+  ``async with AgentSandboxPool(...) as pool:`` claims them; leaving the block
+  deletes every claim. A sandbox that fails a heartbeat is replaced on the next
+  lease so one dead pod does not poison the run.
+  """
+
+  def __init__(
+    self,
+    *,
+    size: int,
+    warm_pool: str,
+    namespace: str,
+    ready_timeout: int = 180,
+    connection: Any | None = None,
+    client: Any | None = None,
+    factory: Callable[[], Awaitable[AgentSandboxBackend]] | None = None,
+  ):
+    if size < 1:
+      raise ValueError("pool size must be at least 1")
+    self.size = size
+    self._warm_pool = warm_pool
+    self._namespace = namespace
+    self._ready_timeout = ready_timeout
+    self._connection = connection
+    self._client = client
+    self._factory = factory
+    self._idle: collections.deque[AgentSandboxBackend] = collections.deque()
+    self._all: list[AgentSandboxBackend] = []
+    self._available = asyncio.Semaphore(0)
+    self._replacements = 0
+
+  async def _claim(self) -> AgentSandboxBackend:
+    if self._factory is not None:
+      return await self._factory()
+    return await AgentSandboxBackend.create(
+      warm_pool=self._warm_pool, namespace=self._namespace, ready_timeout=self._ready_timeout, connection=self._connection, client=self._client
+    )
+
+  async def __aenter__(self) -> AgentSandboxPool:
+    if self._client is None and self._factory is None:
+      self._client = make_client(self._connection)
+    started = time.monotonic()
+    backends = await asyncio.gather(*(self._claim() for _ in range(self.size)))
+    for backend in backends:
+      self._all.append(backend)
+      self._idle.append(backend)
+      self._available.release()
+    logger.info("sandbox pool ready: %d sandboxes in %.1fs", self.size, time.monotonic() - started)
+    return self
+
+  async def __aexit__(self, *exc: object) -> None:
+    await self.close()
+
+  async def close(self) -> None:
+    backends, self._all = self._all, []
+    self._idle.clear()
+    results = await asyncio.gather(*(b.cleanup() for b in backends), return_exceptions=True)
+    for backend, result in zip(backends, results):
+      if isinstance(result, BaseException):
+        logger.warning("cleanup of sandbox %s failed: %s", backend.sandbox_id, result)
+    if self._client is not None and self._factory is None:
+      await self._client.close()
+      self._client = None
+
+  @property
+  def replacements(self) -> int:
+    """How many sandboxes were replaced after a failed heartbeat."""
+    return self._replacements
+
+  @contextlib.asynccontextmanager
+  async def lease(self) -> AsyncIterator[AgentSandboxBackend]:
+    await self._available.acquire()
+    backend = self._idle.popleft()
+    try:
+      yield backend
+    except SandboxTerminatedError:
+      backend = await self._replace(backend)
+      raise
+    finally:
+      self._idle.append(backend)
+      self._available.release()
+
+  async def _replace(self, dead: AgentSandboxBackend) -> AgentSandboxBackend:
+    logger.warning("replacing sandbox %s after it was reported terminated", dead.sandbox_id)
+    with contextlib.suppress(Exception):
+      await dead.cleanup()
+    fresh = await self._claim()
+    self._all = [fresh if b is dead else b for b in self._all]
+    self._replacements += 1
+    return fresh
+
+
+SandboxFactory = Callable[[], Awaitable[AgentSandboxBackend]]
+
+
+def make_sandbox_factory(*, warm_pool: str, namespace: str, ready_timeout: int = 180, connection: Any | None = None) -> SandboxFactory:
+  """A zero-argument coroutine factory that claims one sandbox per call (Phase B: one per prompt group).
+
+  One SDK client is shared by every claim the factory makes.
+  """
+  client: Any | None = None
+
+  async def factory() -> AgentSandboxBackend:
+    nonlocal client
+    if client is None:
+      client = make_client(connection)
+    return await AgentSandboxBackend.create(warm_pool=warm_pool, namespace=namespace, ready_timeout=ready_timeout, client=client)
+
+  return factory
+
+
+def _decode_value(value: Any) -> Any:
+  if isinstance(value, dict) and "__bytes__" in value:
+    return base64.b64decode(value["__bytes__"])
+  return value
+
+
+async def run_sql_in_sandbox(sandbox: Any, context: str, query: str, *, timeout: int = 30) -> tuple[list[tuple[Any, ...]] | None, str | None]:
+  """Execute ``query`` against ``context`` (the schema) inside ``sandbox``.
+
+  Mirrors ``utils.rewards.run_sql``: returns ``(rows, None)`` or ``(None, error)``.
+  Two round trips per call: one upload of the job file, one execute. The job
+  file is removed by ``run_sql.py`` itself. Transport failures surface as an
+  error string prefixed with ``sandbox:`` so they are scored like a bad query
+  but stay distinguishable in the logs.
+  """
+  job = f"jobs/{uuid.uuid4().hex[:12]}.json"
+  try:
+    written = await sandbox.write_file(job, json.dumps({"schema": context, "query": query}), timeout=timeout)
+    if written.exit_code != 0:
+      return None, f"sandbox: upload failed: {written.stderr.strip()}"
+    result = await sandbox.run_command(f"python {RUN_SQL} {job}", timeout=timeout)
+  except SandboxTerminatedError:
+    raise
+  except Exception as exc:
+    return None, f"sandbox: {type(exc).__name__}: {exc}"
+  if result.exit_code != 0:
+    return None, f"sandbox: run_sql exited {result.exit_code}: {(result.stderr or result.stdout).strip()[:300]}"
+  try:
+    payload = json.loads(result.stdout)
+  except json.JSONDecodeError:
+    return None, f"sandbox: unparsable output: {result.stdout[:300]!r}"
+  if payload.get("error") is not None:
+    return None, str(payload["error"])
+  return [tuple(_decode_value(v) for v in row) for row in payload["rows"]], None

--- a/examples/pyproject.toml
+++ b/examples/pyproject.toml
@@ -27,6 +27,11 @@ dependencies = [
     "ipykernel",
 ]
 
+[project.optional-dependencies]
+# Kubernetes sandbox backend for reward execution (examples/common/agent_sandbox.py).
+# Optional so laptop runs without a cluster do not pull the kubernetes clients.
+sandbox = ["k8s-agent-sandbox[async]>=1.0.1"]
+
 [project.scripts]
 harvey-train = "harvey_labs.train:main"
 harvey-eval = "harvey_labs.eval_checkpoint:main"

--- a/examples/text-to-sql/README.md
+++ b/examples/text-to-sql/README.md
@@ -138,6 +138,25 @@ Here are the actual plots from known-good runs for each mode. Expand the section
 ![Text-to-SQL curves SFT and RL](./results/texttosql-curves-sft-and-rl.png)
 </details>
 
+## Sandboxed reward execution
+
+By default the recipe executes model-written SQL in-process with `sqlite3`.
+With `reward.executor=agent_sandbox` every rollout and eval query runs instead
+in a gVisor sandbox leased from a Kubernetes `SandboxWarmPool`, and each step
+logs `sandbox_exec_p50_ms`, `sandbox_exec_p95_ms`, `sandbox_wait_p95_ms` and
+`sandbox_errors`. Dataset filtering and the target queries stay local: the
+trust boundary is the model's output.
+
+```bash
+# in-cluster (pod IPs must be reachable); see docs/sandboxed-rewards.md for the one-time setup
+kubectl -n openrl-system apply -f k8s/job-recipe-sandboxed.yaml
+```
+
+The cookbook variant, `cookbook/train.py`, runs the same task through
+tinker-cookbook's `rl_train` with one sandbox per prompt group
+(`k8s/job-cookbook-rl.yaml`). Details, measurements and the trust model are in
+[docs/sandboxed-rewards.md](../../docs/sandboxed-rewards.md).
+
 ## Advanced: Customizing the Run
 
 If you want to experiment further, you can override default configurations by appending them to the command line:

--- a/examples/text-to-sql/cookbook/__init__.py
+++ b/examples/text-to-sql/cookbook/__init__.py
@@ -1,0 +1,1 @@
+"""tinker-cookbook ``rl_train`` recipe for Text-to-SQL with sandboxed reward execution (design 013, Phase B)."""

--- a/examples/text-to-sql/cookbook/data.py
+++ b/examples/text-to-sql/cookbook/data.py
@@ -9,7 +9,7 @@ import chz
 from tinker_cookbook.rl.types import EnvGroupBuilder, RLDataset, RLDatasetBuilder
 from utils.rewards import DEFAULT_DATASET, load_dataset_splits
 
-from .env import SandboxFactory, TextToSqlGroupBuilder
+from .env import TextToSqlGroupBuilder
 
 
 class TextToSqlDataset(RLDataset):
@@ -37,17 +37,23 @@ class TextToSqlDatasetBuilder(RLDatasetBuilder):
   eval_limit: int = 100
   seed: int = 42
   exec_timeout: int = 30
-  # Injected by train.py; None runs the model's SQL in-process.
-  sandbox_factory: SandboxFactory | None = None
+  # "agent_sandbox": training groups claim one sandbox each (make_envs/cleanup),
+  # the eval leases from a shared pool of eval_pool_size. "local": in-process.
+  sandbox: str = "agent_sandbox"
+  warm_pool: str = "text-to-sql-executor"
+  namespace: str = "openrl-system"
+  sandbox_ready_timeout: int = 180
+  eval_pool_size: int = 4
 
-  def _builders(self, rows: list[dict[str, Any]], group_size: int) -> list[TextToSqlGroupBuilder]:
+  def _builders(self, rows: list[dict[str, Any]], group_size: int, *, factory: Any, pool: Any) -> list[TextToSqlGroupBuilder]:
     return [
       TextToSqlGroupBuilder(
         row=row,
         model_name_for_tokenizer=self.model_name_for_tokenizer,
         renderer_name=self.renderer_name,
         group_size=group_size,
-        sandbox_factory=self.sandbox_factory,
+        sandbox_factory=factory,
+        pool=pool,
         exec_timeout=self.exec_timeout,
       )
       for row in rows
@@ -61,7 +67,24 @@ class TextToSqlDatasetBuilder(RLDatasetBuilder):
       eval_limit=self.eval_limit,
       seed=self.seed,
     )
-    train = TextToSqlDataset(self._builders(train_rows, self.group_size), self.groups_per_batch)
-    # Eval: one sample per prompt, whole eval split in one batch.
-    test = TextToSqlDataset(self._builders(eval_rows, 1), max(1, len(eval_rows)))
+    factory = pool = None
+    if self.sandbox == "agent_sandbox":
+      from common.agent_sandbox import AgentSandboxPool, make_client, make_sandbox_factory
+
+      factory = make_sandbox_factory(warm_pool=self.warm_pool, namespace=self.namespace, ready_timeout=self.sandbox_ready_timeout)
+      # The eval pool lives for the whole run; the SDK's atexit sweep deletes its claims.
+      pool = AgentSandboxPool(
+        size=self.eval_pool_size,
+        warm_pool=self.warm_pool,
+        namespace=self.namespace,
+        ready_timeout=self.sandbox_ready_timeout,
+        client=make_client(cleanup_at_exit=True),
+      )
+      await pool.__aenter__()
+    elif self.sandbox != "local":
+      raise ValueError(f"sandbox must be 'agent_sandbox' or 'local', got {self.sandbox!r}")
+
+    train = TextToSqlDataset(self._builders(train_rows, self.group_size, factory=factory, pool=None), self.groups_per_batch)
+    # Eval: one sample per prompt, whole eval split in one batch, sandboxes leased from the pool.
+    test = TextToSqlDataset(self._builders(eval_rows, 1, factory=None, pool=pool), max(1, len(eval_rows)))
     return train, test

--- a/examples/text-to-sql/cookbook/data.py
+++ b/examples/text-to-sql/cookbook/data.py
@@ -1,0 +1,67 @@
+"""RL dataset for the cookbook Text-to-SQL recipe, built on ``utils.rewards.load_dataset_splits``."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+import chz
+from tinker_cookbook.rl.types import EnvGroupBuilder, RLDataset, RLDatasetBuilder
+from utils.rewards import DEFAULT_DATASET, load_dataset_splits
+
+from .env import SandboxFactory, TextToSqlGroupBuilder
+
+
+class TextToSqlDataset(RLDataset):
+  def __init__(self, builders: list[TextToSqlGroupBuilder], batch_size: int):
+    self.builders = builders
+    self.batch_size = batch_size
+
+  def get_batch(self, index: int) -> Sequence[EnvGroupBuilder]:
+    start = index * self.batch_size
+    return self.builders[start : start + self.batch_size]
+
+  def __len__(self) -> int:
+    return max(1, len(self.builders) // self.batch_size)
+
+
+@chz.chz
+class TextToSqlDatasetBuilder(RLDatasetBuilder):
+  model_name_for_tokenizer: str
+  renderer_name: str
+  group_size: int
+  groups_per_batch: int
+  dataset_name: str = DEFAULT_DATASET
+  dataset_limit: int = 12_500
+  train_limit: int = 5_000
+  eval_limit: int = 100
+  seed: int = 42
+  exec_timeout: int = 30
+  # Injected by train.py; None runs the model's SQL in-process.
+  sandbox_factory: SandboxFactory | None = None
+
+  def _builders(self, rows: list[dict[str, Any]], group_size: int) -> list[TextToSqlGroupBuilder]:
+    return [
+      TextToSqlGroupBuilder(
+        row=row,
+        model_name_for_tokenizer=self.model_name_for_tokenizer,
+        renderer_name=self.renderer_name,
+        group_size=group_size,
+        sandbox_factory=self.sandbox_factory,
+        exec_timeout=self.exec_timeout,
+      )
+      for row in rows
+    ]
+
+  async def __call__(self) -> tuple[RLDataset, RLDataset | None]:
+    train_rows, eval_rows = load_dataset_splits(
+      dataset_name=self.dataset_name,
+      dataset_limit=self.dataset_limit,
+      train_limit=self.train_limit,
+      eval_limit=self.eval_limit,
+      seed=self.seed,
+    )
+    train = TextToSqlDataset(self._builders(train_rows, self.group_size), self.groups_per_batch)
+    # Eval: one sample per prompt, whole eval split in one batch.
+    test = TextToSqlDataset(self._builders(eval_rows, 1), max(1, len(eval_rows)))
+    return train, test

--- a/examples/text-to-sql/cookbook/env.py
+++ b/examples/text-to-sql/cookbook/env.py
@@ -1,0 +1,115 @@
+"""Text-to-SQL as a tinker-cookbook ``Env``: one prompt, one SQL answer, one sandbox per group.
+
+``TextToSqlGroupBuilder.make_envs`` claims a sandbox through the injected
+``sandbox_factory`` and hands it to ``group_size`` envs; ``cleanup`` deletes the
+claim after the group's rollouts and rewards are done. The model's SQL is the
+only thing that runs in the sandbox; the target query's rows come precomputed
+from the dataset filter, which executes trusted dataset content locally.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Awaitable, Callable, Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+import tinker
+from common.agent_sandbox import run_sql_in_sandbox
+from tinker_cookbook import renderers
+from tinker_cookbook.rl.types import Action, ActionExtra, Env, EnvGroupBuilder, Observation, StepResult, StopCondition
+from tinker_cookbook.sandbox import SandboxInterface
+from tinker_cookbook.tokenizer_utils import get_tokenizer
+from utils.rewards import clean_sql_for_execution, local_executor, score_from_execution
+
+logger = logging.getLogger(__name__)
+
+SandboxFactory = Callable[[], Awaitable[SandboxInterface]]
+Executor = Callable[[str, str], Awaitable[tuple[list[tuple[Any, ...]] | None, str | None]]]
+
+METRIC_NAMES = ("compile", "execution_match", "exact_match", "similarity")
+
+
+class TextToSqlEnv(Env):
+  """Single-turn env: render the plain prompt as one user message, score the SQL that comes back."""
+
+  def __init__(self, row: dict[str, Any], renderer: renderers.Renderer, executor: Executor, exec_timeout: int):
+    self.row = row
+    self.renderer = renderer
+    self.executor = executor
+    self.exec_timeout = exec_timeout
+
+  async def initial_observation(self) -> tuple[Observation, StopCondition]:
+    convo = [{"role": "user", "content": self.row["prompt_text"]}]
+    return self.renderer.build_generation_prompt(convo), self.renderer.get_stop_sequences()
+
+  async def step(self, action: Action, *, extra: ActionExtra | None = None) -> StepResult:
+    message, _termination = self.renderer.parse_response(action)
+    predicted_sql = clean_sql_for_execution(renderers.get_text_content(message))
+    started = time.monotonic()
+    rows, error = await self.executor(self.row["context"], predicted_sql)
+    exec_ms = (time.monotonic() - started) * 1000.0
+    score = score_from_execution(
+      predicted_sql=predicted_sql,
+      target_sql=self.row["target"],
+      context=self.row["context"],
+      target_rows=self.row.get("target_rows"),
+      question=self.row["question"],
+      predicted_rows=rows,
+      predicted_error=error,
+    )
+    metrics = {name: float(score[name]) for name in METRIC_NAMES}
+    metrics["sandbox_exec_ms"] = exec_ms
+    metrics["sandbox_error"] = float(bool(error and error.startswith("sandbox:")))
+    return StepResult(
+      reward=float(score["reward"]),
+      episode_done=True,
+      next_observation=tinker.ModelInput.from_ints([]),
+      next_stop_condition=[],
+      metrics=metrics,
+      logs={"predicted_sql": predicted_sql, "target_sql": score["target"], "sqlite_error": score["sqlite_error"]},
+    )
+
+
+@dataclass(frozen=True)
+class TextToSqlGroupBuilder(EnvGroupBuilder):
+  """``group_size`` envs for one prompt sharing one sandbox claimed in ``make_envs``.
+
+  Holds only the row, names, and the factory reference so it stays cheap; the
+  renderer and the sandbox are constructed lazily. With ``sandbox_factory=None``
+  the model's SQL runs in-process (laptop / smoke-test mode).
+  """
+
+  row: dict[str, Any]
+  model_name_for_tokenizer: str
+  renderer_name: str
+  group_size: int
+  sandbox_factory: SandboxFactory | None = None
+  exec_timeout: int = 30
+  _sandbox: list[SandboxInterface] = field(default_factory=list, compare=False, repr=False)
+
+  async def make_envs(self) -> Sequence[Env]:
+    renderer = renderers.get_renderer(self.renderer_name, get_tokenizer(self.model_name_for_tokenizer))
+    executor: Executor = local_executor
+    if self.sandbox_factory is not None:
+      started = time.monotonic()
+      sandbox = await self.sandbox_factory()
+      self._sandbox.append(sandbox)
+      logger.debug("group sandbox %s claimed in %.1fs", sandbox.sandbox_id, time.monotonic() - started)
+
+      async def executor(context: str, query: str) -> tuple[list[tuple[Any, ...]] | None, str | None]:
+        return await run_sql_in_sandbox(sandbox, context, query, timeout=self.exec_timeout)
+
+    return [TextToSqlEnv(self.row, renderer, executor, self.exec_timeout) for _ in range(self.group_size)]
+
+  async def cleanup(self) -> None:
+    while self._sandbox:
+      sandbox = self._sandbox.pop()
+      try:
+        await sandbox.cleanup()
+      except Exception as exc:  # cleanup must not raise into do_group_rollout
+        logger.warning("sandbox %s cleanup failed: %s", sandbox.sandbox_id, exc)
+
+  def logging_tags(self) -> list[str]:
+    return ["text_to_sql"]

--- a/examples/text-to-sql/cookbook/env.py
+++ b/examples/text-to-sql/cookbook/env.py
@@ -2,7 +2,10 @@
 
 ``TextToSqlGroupBuilder.make_envs`` claims a sandbox through the injected
 ``sandbox_factory`` and hands it to ``group_size`` envs; ``cleanup`` deletes the
-claim after the group's rollouts and rewards are done. The model's SQL is the
+claim after the group's rollouts and rewards are done. A builder given a
+``pool`` instead leases a sandbox per call and never claims: that is what the
+held-out eval uses, where one claim per example would mean a hundred cold
+starts per eval. The model's SQL is the
 only thing that runs in the sandbox; the target query's rows come precomputed
 from the dataset filter, which executes trusted dataset content locally.
 """
@@ -86,13 +89,22 @@ class TextToSqlGroupBuilder(EnvGroupBuilder):
   renderer_name: str
   group_size: int
   sandbox_factory: SandboxFactory | None = None
+  # An entered AgentSandboxPool; when set, envs lease per call instead of claiming.
+  pool: Any = None
   exec_timeout: int = 30
   _sandbox: list[SandboxInterface] = field(default_factory=list, compare=False, repr=False)
 
   async def make_envs(self) -> Sequence[Env]:
     renderer = renderers.get_renderer(self.renderer_name, get_tokenizer(self.model_name_for_tokenizer))
     executor: Executor = local_executor
-    if self.sandbox_factory is not None:
+    if self.pool is not None:
+      pool = self.pool
+
+      async def executor(context: str, query: str) -> tuple[list[tuple[Any, ...]] | None, str | None]:
+        async with pool.lease() as sandbox:
+          return await run_sql_in_sandbox(sandbox, context, query, timeout=self.exec_timeout)
+
+    elif self.sandbox_factory is not None:
       started = time.monotonic()
       sandbox = await self.sandbox_factory()
       self._sandbox.append(sandbox)

--- a/examples/text-to-sql/cookbook/train.py
+++ b/examples/text-to-sql/cookbook/train.py
@@ -62,13 +62,15 @@ class CLIConfig:
   # OpenRL has no durable checkpoint store for cookbook saves yet (issue #83).
   save_every: int = 0
 
-  # Reward execution: "agent_sandbox" claims one sandbox per prompt group;
-  # "local" runs the model's SQL in-process.
+  # Reward execution: "agent_sandbox" claims one sandbox per training prompt
+  # group and leases eval sandboxes from a pool of eval_pool_size; "local"
+  # runs the model's SQL in-process.
   sandbox: str = "agent_sandbox"
   warm_pool: str = "text-to-sql-executor"
   namespace: str = "openrl-system"
   sandbox_ready_timeout: int = 180
   exec_timeout: int = 30
+  eval_pool_size: int = 4
 
   # Service / logging
   base_url: str | None = os.getenv("TINKER_BASE_URL")
@@ -76,16 +78,6 @@ class CLIConfig:
   behavior_if_log_dir_exists: cli_utils.LogdirBehavior = "delete"
   wandb_project: str | None = None
   wandb_name: str | None = None
-
-
-def sandbox_factory_from(cli: CLIConfig):
-  if cli.sandbox == "local":
-    return None
-  if cli.sandbox != "agent_sandbox":
-    raise ValueError(f"sandbox must be 'agent_sandbox' or 'local', got {cli.sandbox!r}")
-  from common.agent_sandbox import make_sandbox_factory
-
-  return make_sandbox_factory(warm_pool=cli.warm_pool, namespace=cli.namespace, ready_timeout=cli.sandbox_ready_timeout)
 
 
 async def cli_main(cli: CLIConfig) -> None:
@@ -104,7 +96,11 @@ async def cli_main(cli: CLIConfig) -> None:
     eval_limit=cli.eval_limit,
     seed=cli.seed,
     exec_timeout=cli.exec_timeout,
-    sandbox_factory=sandbox_factory_from(cli),
+    sandbox=cli.sandbox,
+    warm_pool=cli.warm_pool,
+    namespace=cli.namespace,
+    sandbox_ready_timeout=cli.sandbox_ready_timeout,
+    eval_pool_size=cli.eval_pool_size,
   )
   config = Config(
     learning_rate=cli.learning_rate,

--- a/examples/text-to-sql/cookbook/train.py
+++ b/examples/text-to-sql/cookbook/train.py
@@ -1,0 +1,137 @@
+"""Text-to-SQL RL with tinker-cookbook's ``rl_train`` and sandboxed reward execution.
+
+    uv --project examples run python examples/text-to-sql/cookbook/train.py \\
+        model_name=Qwen/Qwen3-1.7B base_url=http://open-rl-gateway-service:8000 \\
+        sandbox=agent_sandbox log_path=/mnt/shared/open-rl/runs/textsql-cookbook
+
+Each prompt group claims its own gVisor sandbox from the warm pool
+(``examples/text-to-sql/k8s/agent-sandbox``) in ``make_envs`` and releases it in
+``cleanup``; ``kubectl get sandboxclaims -w`` shows one claim per group per
+step. ``sandbox=local`` runs the model's SQL in-process for laptop smoke tests.
+The training loop is the cookbook's, unmodified: OpenRL is only the Tinker
+endpoint behind ``base_url``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+
+# Make `common` (examples/) and `utils` (examples/text-to-sql/) importable when
+# run as a script from any working directory.
+_HERE = Path(__file__).resolve().parent
+sys.path[:0] = [str(_HERE.parent), str(_HERE.parents[1])]
+
+import chz  # noqa: E402
+from tinker_cookbook import cli_utils  # noqa: E402
+from tinker_cookbook.rl.rollout_strategy import MinViableGroup  # noqa: E402
+from tinker_cookbook.rl.train import Config, main  # noqa: E402
+
+from cookbook.data import TextToSqlDatasetBuilder  # noqa: E402
+
+os.environ.setdefault("TINKER_API_KEY", "tml-dummy-key")
+
+
+@chz.chz
+class CLIConfig:
+  model_name: str = "Qwen/Qwen3-1.7B"
+  renderer_name: str = "qwen3_disable_thinking"
+  lora_rank: int = 32
+  load_checkpoint_path: str | None = None
+
+  # Data
+  dataset_limit: int = 12_500
+  train_limit: int = 5_000
+  eval_limit: int = 100
+  seed: int = 42
+
+  # Rollouts / optimisation
+  group_size: int = 8
+  groups_per_batch: int = 8
+  max_tokens: int = 96
+  temperature: float = 1.0
+  learning_rate: float = 1e-5
+  loss_fn: str = "importance_sampling"
+  kl_penalty_coef: float = 0.0
+  max_steps: int | None = 40
+  eval_every: int = 10
+  # OpenRL has no durable checkpoint store for cookbook saves yet (issue #83).
+  save_every: int = 0
+
+  # Reward execution: "agent_sandbox" claims one sandbox per prompt group;
+  # "local" runs the model's SQL in-process.
+  sandbox: str = "agent_sandbox"
+  warm_pool: str = "text-to-sql-executor"
+  namespace: str = "openrl-system"
+  sandbox_ready_timeout: int = 180
+  exec_timeout: int = 30
+
+  # Service / logging
+  base_url: str | None = os.getenv("TINKER_BASE_URL")
+  log_path: str | None = None
+  behavior_if_log_dir_exists: cli_utils.LogdirBehavior = "delete"
+  wandb_project: str | None = None
+  wandb_name: str | None = None
+
+
+def sandbox_factory_from(cli: CLIConfig):
+  if cli.sandbox == "local":
+    return None
+  if cli.sandbox != "agent_sandbox":
+    raise ValueError(f"sandbox must be 'agent_sandbox' or 'local', got {cli.sandbox!r}")
+  from common.agent_sandbox import make_sandbox_factory
+
+  return make_sandbox_factory(warm_pool=cli.warm_pool, namespace=cli.namespace, ready_timeout=cli.sandbox_ready_timeout)
+
+
+async def cli_main(cli: CLIConfig) -> None:
+  model_slug = cli.model_name.replace("/", "-")
+  stamp = f"{datetime.now():%Y-%m-%d-%H-%M}"
+  run_name = f"textsql-{model_slug}-{cli.lora_rank}rank-{cli.learning_rate}lr-{cli.group_size}x{cli.groups_per_batch}-{cli.sandbox}-{stamp}"
+  log_path = cli.log_path or f"/tmp/tinker-examples/text_to_sql/{run_name}"
+
+  dataset_builder = TextToSqlDatasetBuilder(
+    model_name_for_tokenizer=cli.model_name,
+    renderer_name=cli.renderer_name,
+    group_size=cli.group_size,
+    groups_per_batch=cli.groups_per_batch,
+    dataset_limit=cli.dataset_limit,
+    train_limit=cli.train_limit,
+    eval_limit=cli.eval_limit,
+    seed=cli.seed,
+    exec_timeout=cli.exec_timeout,
+    sandbox_factory=sandbox_factory_from(cli),
+  )
+  config = Config(
+    learning_rate=cli.learning_rate,
+    dataset_builder=dataset_builder,
+    model_name=cli.model_name,
+    recipe_name="recipe_text_to_sql_sandboxed",
+    renderer_name=cli.renderer_name,
+    lora_rank=cli.lora_rank,
+    max_tokens=cli.max_tokens,
+    temperature=cli.temperature,
+    loss_fn=cli.loss_fn,  # type: ignore[arg-type]
+    kl_penalty_coef=cli.kl_penalty_coef,
+    eval_every=cli.eval_every,
+    save_every=cli.save_every,
+    log_path=log_path,
+    base_url=cli.base_url,
+    load_checkpoint_path=cli.load_checkpoint_path,
+    wandb_project=cli.wandb_project,
+    wandb_name=cli.wandb_name or run_name,
+    max_steps=cli.max_steps,
+    # One failed sandbox claim should cost a rollout, not the whole prompt group.
+    rollout_error_tolerance=MinViableGroup(),
+  )
+  cli_utils.check_log_dir(log_path, behavior_if_exists=cli.behavior_if_log_dir_exists)
+  logging.getLogger("tinker").setLevel(logging.WARNING)
+  await main(config)
+
+
+if __name__ == "__main__":
+  asyncio.run(cli_main(chz.entrypoint(CLIConfig)))

--- a/examples/text-to-sql/k8s/agent-sandbox/kustomization.yaml
+++ b/examples/text-to-sql/k8s/agent-sandbox/kustomization.yaml
@@ -1,0 +1,15 @@
+# Sandboxed reward execution for the Text-to-SQL recipe (design 013).
+# Requires agent-sandbox v1.0.1 with extensions and a node pool with GKE Sandbox:
+#   kubectl apply --server-side -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/v1.0.1/sandbox-with-extensions.yaml
+# Then:  kubectl apply -k examples/text-to-sql/k8s/agent-sandbox
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openrl-system
+resources:
+  - sandbox-template.yaml
+  - warm-pool.yaml
+  - rbac.yaml
+images:
+  - name: SQL_EXECUTOR_IMAGE
+    newName: ghcr.io/gke-labs/open-rl/sql-executor
+    newTag: latest

--- a/examples/text-to-sql/k8s/agent-sandbox/rbac.yaml
+++ b/examples/text-to-sql/k8s/agent-sandbox/rbac.yaml
@@ -1,0 +1,25 @@
+# The training client claims sandboxes from the warm pool and reads the bound
+# Sandbox to find its pod IP. Bound to the shared open-rl-sa the client Job runs as.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: text-to-sql-sandbox-claimer
+rules:
+  - apiGroups: ["extensions.agents.x-k8s.io"]
+    resources: ["sandboxclaims"]
+    verbs: ["create", "get", "list", "watch", "delete"]
+  - apiGroups: ["agents.x-k8s.io"]
+    resources: ["sandboxes"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: text-to-sql-sandbox-claimer
+subjects:
+  - kind: ServiceAccount
+    name: open-rl-sa
+roleRef:
+  kind: Role
+  name: text-to-sql-sandbox-claimer
+  apiGroup: rbac.authorization.k8s.io

--- a/examples/text-to-sql/k8s/agent-sandbox/sandbox-template.yaml
+++ b/examples/text-to-sql/k8s/agent-sandbox/sandbox-template.yaml
@@ -1,0 +1,70 @@
+# gVisor sandbox that executes one model-written SQLite query per call.
+# Claimed from the warm pool below by examples/common/agent_sandbox.py.
+apiVersion: extensions.agents.x-k8s.io/v1beta1
+kind: SandboxTemplate
+metadata:
+  name: text-to-sql-executor
+spec:
+  # Headless Service per sandbox: the SDK falls back to
+  # <sandbox>.<namespace>.svc.cluster.local when the pod IP is not yet in status.
+  service: true
+  # Claims may not inject environment variables; every sandbox is identical.
+  envVarsInjectionPolicy: Disallowed
+  networkPolicy:
+    # Only the training client, which runs in this namespace, may reach :8888.
+    ingress:
+      - from:
+          - namespaceSelector:
+              matchLabels:
+                kubernetes.io/metadata.name: openrl-system
+        ports:
+          - protocol: TCP
+            port: 8888
+    # No egress rules at all: the sandbox cannot open a connection anywhere.
+    egress: []
+  podTemplate:
+    metadata:
+      labels:
+        app.kubernetes.io/name: text-to-sql-executor
+        app.kubernetes.io/part-of: text-to-sql
+    spec:
+      # GKE Sandbox: the RuntimeClass carries the gvisor nodeSelector and toleration.
+      runtimeClassName: gvisor
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: executor
+          image: SQL_EXECUTOR_IMAGE
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8888
+              name: http
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 250m
+              memory: 256Mi
+            limits:
+              memory: 512Mi
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8888
+            periodSeconds: 2
+          volumeMounts:
+            - name: work
+              mountPath: /app/work
+      volumes:
+        - name: work
+          emptyDir:
+            medium: Memory
+            sizeLimit: 64Mi

--- a/examples/text-to-sql/k8s/agent-sandbox/warm-pool.yaml
+++ b/examples/text-to-sql/k8s/agent-sandbox/warm-pool.yaml
@@ -1,0 +1,10 @@
+# Pre-warmed executors. Phase A leases from a fixed pool of this size; Phase B
+# claims one per prompt group, so bump replicas to groups_per_batch there.
+apiVersion: extensions.agents.x-k8s.io/v1beta1
+kind: SandboxWarmPool
+metadata:
+  name: text-to-sql-executor
+spec:
+  replicas: 4
+  sandboxTemplateRef:
+    name: text-to-sql-executor

--- a/examples/text-to-sql/k8s/job-cookbook-rl.yaml
+++ b/examples/text-to-sql/k8s/job-cookbook-rl.yaml
@@ -1,0 +1,45 @@
+# Phase B of design 013: tinker-cookbook rl_train on Text-to-SQL (Qwen3-1.7B),
+# one sandbox claimed per prompt group. Watch the claims come and go with
+#   kubectl -n openrl-system get sandboxclaims -w
+#
+#   kubectl -n openrl-system delete job textsql-cookbook-rl --ignore-not-found
+#   kubectl -n openrl-system apply -f examples/text-to-sql/k8s/job-cookbook-rl.yaml
+#   kubectl -n openrl-system logs -f job/textsql-cookbook-rl
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: textsql-cookbook-rl
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      restartPolicy: Never
+      serviceAccountName: open-rl-sa
+      containers:
+        - name: recipe
+          image: ghcr.io/gke-labs/open-rl/client:latest
+          imagePullPolicy: Always
+          workingDir: /app
+          command: ["uv", "--project", "examples", "run", "python", "examples/text-to-sql/cookbook/train.py"]
+          args:
+            - model_name=Qwen/Qwen3-1.7B
+            - base_url=http://open-rl-gateway-service:8000
+            - log_path=/mnt/shared/open-rl/runs/textsql-cookbook-rl
+            - sandbox=agent_sandbox
+            - max_steps=40
+          env:
+            - name: PYTHONUNBUFFERED
+              value: "1"
+            - name: HF_HOME
+              value: /mnt/shared/open-rl/huggingface
+          resources:
+            requests: {cpu: "2", memory: 8Gi}
+            limits: {memory: 16Gi}
+          volumeMounts:
+            - name: shared-storage
+              mountPath: /mnt/shared
+      volumes:
+        - name: shared-storage
+          persistentVolumeClaim:
+            claimName: open-rl-shared-pvc

--- a/examples/text-to-sql/k8s/job-recipe-sandboxed.yaml
+++ b/examples/text-to-sql/k8s/job-recipe-sandboxed.yaml
@@ -1,0 +1,45 @@
+# Phase A of design 013: the Gemma SFT+GRPO recipe with reward.executor=agent_sandbox,
+# run in-cluster from the client image so sandbox pod IPs are reachable.
+#
+#   kubectl -n openrl-system delete job textsql-recipe-sandboxed --ignore-not-found
+#   kubectl -n openrl-system apply -f examples/text-to-sql/k8s/job-recipe-sandboxed.yaml
+#   kubectl -n openrl-system logs -f job/textsql-recipe-sandboxed
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: textsql-recipe-sandboxed
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      restartPolicy: Never
+      serviceAccountName: open-rl-sa
+      containers:
+        - name: recipe
+          image: ghcr.io/gke-labs/open-rl/client:latest
+          imagePullPolicy: Always
+          workingDir: /app
+          command: ["uv", "--project", "examples", "run", "python", "examples/text-to-sql/texttosql_sft_grpo.py"]
+          args:
+            - gemma4_e2b_rl_recipe
+            - phase=rl_only
+            - base_url=http://open-rl-gateway-service:8000
+            - log_dir=/mnt/shared/open-rl/runs/textsql-recipe-sandboxed
+            - reward.executor=agent_sandbox
+            - reward.pool_size=4
+          env:
+            - name: PYTHONUNBUFFERED
+              value: "1"
+            - name: HF_HOME
+              value: /mnt/shared/open-rl/huggingface
+          resources:
+            requests: {cpu: "2", memory: 8Gi}
+            limits: {memory: 16Gi}
+          volumeMounts:
+            - name: shared-storage
+              mountPath: /mnt/shared
+      volumes:
+        - name: shared-storage
+          persistentVolumeClaim:
+            claimName: open-rl-shared-pvc

--- a/examples/text-to-sql/sandbox/Dockerfile
+++ b/examples/text-to-sql/sandbox/Dockerfile
@@ -1,0 +1,28 @@
+# Sandbox runtime for Text-to-SQL reward execution.
+#
+# The agent-sandbox reference runtime server (main.py, from
+# kubernetes-sigs/agent-sandbox examples/python-runtime-sandbox) on :8888 plus
+# /opt/run_sql.py, which executes one model-written query against a schema in
+# an in-memory SQLite database. Nothing else is installed: sqlite3 is in the
+# standard library and the sandbox has no network egress.
+#
+# Build (Cloud Build, from the repo root):
+#   make cloud-build-sql-executor GCP_PROJECT=<project> CLOUD_IMAGE_TAG=<tag>
+FROM python:3.12-slim
+
+WORKDIR /app
+# Pinned inline: the repo's .gitignore drops *.txt from the build context.
+RUN pip install --no-cache-dir fastapi==0.138.0 uvicorn==0.49.0 python-multipart==0.0.32
+
+COPY examples/text-to-sql/sandbox/main.py /opt/main.py
+COPY examples/text-to-sql/sandbox/run_sql.py /opt/run_sql.py
+
+# Commands and uploads are confined to SANDBOX_BASE_DIR; the template mounts
+# an emptyDir there so the root filesystem can stay read-only.
+ENV SANDBOX_BASE_DIR=/app/work \
+    SANDBOX_EXEC_TIMEOUT_SECONDS=30 \
+    PYTHONUNBUFFERED=1
+RUN mkdir -p /app/work && chown -R 1000:1000 /app
+USER 1000
+EXPOSE 8888
+CMD ["uvicorn", "--app-dir", "/opt", "main:app", "--host", "0.0.0.0", "--port", "8888", "--log-level", "warning"]

--- a/examples/text-to-sql/sandbox/main.py
+++ b/examples/text-to-sql/sandbox/main.py
@@ -13,228 +13,218 @@
 # limitations under the License.
 
 import asyncio
+import logging
 import math
-import signal
-import subprocess
 import os
 import shlex
-import logging
+import signal
+import subprocess
 import urllib.parse
 
-from fastapi import FastAPI, UploadFile, File
+from fastapi import FastAPI, File, UploadFile
 from fastapi.responses import FileResponse, JSONResponse
 from pydantic import BaseModel
 
+
 class ExecuteRequest(BaseModel):
-    """Request model for the /execute endpoint."""
-    command: str
+  """Request model for the /execute endpoint."""
+
+  command: str
+
 
 class ExecuteResponse(BaseModel):
-    """Response model for the /execute endpoint."""
-    stdout: str
-    stderr: str
-    exit_code: int
+  """Response model for the /execute endpoint."""
+
+  stdout: str
+  stderr: str
+  exit_code: int
+
 
 def get_base_dir() -> str:
-    """Reads SANDBOX_BASE_DIR, falling back to /app when it's unset or blank.
+  """Reads SANDBOX_BASE_DIR, falling back to /app when it's unset or blank.
 
-    Making the base directory configurable lets the sandbox run with a
-    read-only root filesystem: the runtime code stays wherever the image put
-    it, while commands and file operations are confined to a writable volume
-    (e.g. an emptyDir) mounted at SANDBOX_BASE_DIR.
-    """
-    return os.environ.get("SANDBOX_BASE_DIR", "").strip() or "/app"
+  Making the base directory configurable lets the sandbox run with a
+  read-only root filesystem: the runtime code stays wherever the image put
+  it, while commands and file operations are confined to a writable volume
+  (e.g. an emptyDir) mounted at SANDBOX_BASE_DIR.
+  """
+  return os.environ.get("SANDBOX_BASE_DIR", "").strip() or "/app"
+
 
 def get_safe_path(file_path: str) -> str:
-    """Sanitizes the file path to ensure it stays within the base directory."""
-    base_dir = os.path.realpath(get_base_dir())
-    # Remove leading slashes to ensure path is relative
-    clean_path = file_path.lstrip("/")
-    full_path = os.path.realpath(os.path.join(base_dir, clean_path))
+  """Sanitizes the file path to ensure it stays within the base directory."""
+  base_dir = os.path.realpath(get_base_dir())
+  # Remove leading slashes to ensure path is relative
+  clean_path = file_path.lstrip("/")
+  full_path = os.path.realpath(os.path.join(base_dir, clean_path))
 
-    if os.path.commonpath([base_dir, full_path]) != base_dir:
-        raise ValueError("Access denied: Path must be within the sandbox base directory")
+  if os.path.commonpath([base_dir, full_path]) != base_dir:
+    raise ValueError("Access denied: Path must be within the sandbox base directory")
 
-    return full_path
+  return full_path
+
 
 app = FastAPI(
-    title="Agentic Sandbox Runtime",
-    description="An API server for executing commands and managing files in a secure sandbox.",
-    version="1.0.0",
+  title="Agentic Sandbox Runtime",
+  description="An API server for executing commands and managing files in a secure sandbox.",
+  version="1.0.0",
 )
 
-def _get_exec_timeout_seconds() -> float:
-    """Reads SANDBOX_EXEC_TIMEOUT_SECONDS, falling back to the 300s default
-    (with a warning) if it's unset or not a finite number greater than 0, so
-    a misconfigured value doesn't fail every /execute request.
-    """
-    raw = os.environ.get("SANDBOX_EXEC_TIMEOUT_SECONDS", "300")
-    try:
-        value = float(raw)
-    except ValueError:
-        value = float("nan")
 
-    if not (math.isfinite(value) and value > 0):
-        logging.warning(
-            "Ignoring invalid SANDBOX_EXEC_TIMEOUT_SECONDS=%r; using default of 300 seconds",
-            raw,
-        )
-        return 300.0
-    return value
+def _get_exec_timeout_seconds() -> float:
+  """Reads SANDBOX_EXEC_TIMEOUT_SECONDS, falling back to the 300s default
+  (with a warning) if it's unset or not a finite number greater than 0, so
+  a misconfigured value doesn't fail every /execute request.
+  """
+  raw = os.environ.get("SANDBOX_EXEC_TIMEOUT_SECONDS", "300")
+  try:
+    value = float(raw)
+  except ValueError:
+    value = float("nan")
+
+  if not (math.isfinite(value) and value > 0):
+    logging.warning(
+      "Ignoring invalid SANDBOX_EXEC_TIMEOUT_SECONDS=%r; using default of 300 seconds",
+      raw,
+    )
+    return 300.0
+  return value
+
 
 def _run_command(args: list, timeout: float) -> subprocess.CompletedProcess:
-    """Runs args as the leader of a new process group so that on timeout the
-    entire process tree can be killed, not just the direct child (matching
-    the pattern used in examples/firecracker-sandbox/main.py).
-    """
-    with subprocess.Popen(
-        args,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-        cwd=get_base_dir(),
-        start_new_session=True,
-    ) as process:
-        try:
-            stdout, stderr = process.communicate(timeout=timeout)
-        except subprocess.TimeoutExpired:
-            try:
-                os.killpg(os.getpgid(process.pid), signal.SIGKILL)
-            except (ProcessLookupError, OSError):
-                pass
-            process.communicate()
-            raise
-        return subprocess.CompletedProcess(args, process.returncode, stdout, stderr)
+  """Runs args as the leader of a new process group so that on timeout the
+  entire process tree can be killed, not just the direct child (matching
+  the pattern used in examples/firecracker-sandbox/main.py).
+  """
+  with subprocess.Popen(
+    args,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+    text=True,
+    cwd=get_base_dir(),
+    start_new_session=True,
+  ) as process:
+    try:
+      stdout, stderr = process.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+      try:
+        os.killpg(os.getpgid(process.pid), signal.SIGKILL)
+      except (ProcessLookupError, OSError):
+        pass
+      process.communicate()
+      raise
+    return subprocess.CompletedProcess(args, process.returncode, stdout, stderr)
+
 
 @app.get("/", summary="Health Check")
 async def health_check():
-    """A simple health check endpoint to confirm the server is running."""
-    return {"status": "ok", "message": "Sandbox Runtime is active."}
+  """A simple health check endpoint to confirm the server is running."""
+  return {"status": "ok", "message": "Sandbox Runtime is active."}
+
 
 @app.post("/execute", summary="Execute a shell command", response_model=ExecuteResponse)
 async def execute_command(request: ExecuteRequest):
-    """
-    Executes a shell command inside the sandbox and returns its output.
-    Uses shlex.split for security to prevent shell injection.
-    """
-    try:
-        # Split the command string into a list to safely pass to subprocess
-        args = shlex.split(request.command)
-        
-        # Execute the command, always from the base directory. Run it in a
-        # worker thread so a long-running or hung command doesn't block the
-        # event loop (and with it, the health check and file endpoints), and
-        # enforce a timeout so a runaway command can't wedge the sandbox
-        # forever.
-        process = await asyncio.to_thread(
-            _run_command,
-            args,
-            _get_exec_timeout_seconds(),
-        )
-        return ExecuteResponse(
-            stdout=process.stdout,
-            stderr=process.stderr,
-            exit_code=process.returncode
-        )
-    except Exception as e:
-        return ExecuteResponse(
-            stdout="",
-            stderr=f"Failed to execute command: {str(e)}",
-            exit_code=1
-        )
+  """
+  Executes a shell command inside the sandbox and returns its output.
+  Uses shlex.split for security to prevent shell injection.
+  """
+  try:
+    # Split the command string into a list to safely pass to subprocess
+    args = shlex.split(request.command)
+
+    # Execute the command, always from the base directory. Run it in a
+    # worker thread so a long-running or hung command doesn't block the
+    # event loop (and with it, the health check and file endpoints), and
+    # enforce a timeout so a runaway command can't wedge the sandbox
+    # forever.
+    process = await asyncio.to_thread(
+      _run_command,
+      args,
+      _get_exec_timeout_seconds(),
+    )
+    return ExecuteResponse(stdout=process.stdout, stderr=process.stderr, exit_code=process.returncode)
+  except Exception as e:
+    return ExecuteResponse(stdout="", stderr=f"Failed to execute command: {str(e)}", exit_code=1)
+
 
 @app.post("/upload", summary="Upload a file to the sandbox")
-async def upload_file(file: UploadFile = File(...)):
-    """
-    Receives a file and saves it to the base directory in the sandbox.
-    """
+async def upload_file(file: UploadFile = File(...)):  # noqa: B008 (FastAPI dependency idiom)
+  """
+  Receives a file and saves it to the base directory in the sandbox.
+  """
+  try:
+    logging.info(f"--- UPLOAD_FILE CALLED: Attempting to save '{file.filename}' ---")
+
     try:
-        logging.info(f"--- UPLOAD_FILE CALLED: Attempting to save '{file.filename}' ---")
+      file_path = get_safe_path(file.filename)
+    except ValueError:
+      return JSONResponse(status_code=403, content={"message": "Access denied"})
 
-        try:
-            file_path = get_safe_path(file.filename)
-        except ValueError:
-            return JSONResponse(
-                status_code=403,
-                content={"message": "Access denied"}
-            )
+    # The filename may carry a relative destination path (e.g.
+    # "data/input.csv"); create the intermediate directories so such
+    # uploads don't fail. file_path is already confined to the base
+    # directory by get_safe_path, so its parents are too.
+    os.makedirs(os.path.dirname(file_path), exist_ok=True)
 
-        # The filename may carry a relative destination path (e.g.
-        # "data/input.csv"); create the intermediate directories so such
-        # uploads don't fail. file_path is already confined to the base
-        # directory by get_safe_path, so its parents are too.
-        os.makedirs(os.path.dirname(file_path), exist_ok=True)
+    with open(file_path, "wb") as f:
+      f.write(await file.read())
 
-        with open(file_path, "wb") as f:
-            f.write(await file.read())
-            
-        return JSONResponse(
-            status_code=200,
-            content={"message": f"File '{file.filename}' uploaded successfully."}
-        )
-    except Exception as e:
-        logging.exception("An error occurred during file upload.") 
-        return JSONResponse(
-            status_code=500,
-            content={"message": f"File upload failed: {str(e)}"}
-        )
+    return JSONResponse(status_code=200, content={"message": f"File '{file.filename}' uploaded successfully."})
+  except Exception as e:
+    logging.exception("An error occurred during file upload.")
+    return JSONResponse(status_code=500, content={"message": f"File upload failed: {str(e)}"})
+
 
 @app.get("/download/{encoded_file_path:path}", summary="Download a file from the sandbox")
 async def download_file(encoded_file_path: str):
-    """
-    Downloads a specified file from the base directory in the sandbox.
-    """
-    decoded_path = urllib.parse.unquote(encoded_file_path)
-    try:
-        full_path = get_safe_path(decoded_path)
-    except ValueError:
-        return JSONResponse(status_code=403, content={"message": "Access denied"})
+  """
+  Downloads a specified file from the base directory in the sandbox.
+  """
+  decoded_path = urllib.parse.unquote(encoded_file_path)
+  try:
+    full_path = get_safe_path(decoded_path)
+  except ValueError:
+    return JSONResponse(status_code=403, content={"message": "Access denied"})
 
-    if os.path.isfile(full_path):
-        return FileResponse(path=full_path, media_type='application/octet-stream', filename=decoded_path)
-    return JSONResponse(status_code=404, content={"message": "File not found"})
+  if os.path.isfile(full_path):
+    return FileResponse(path=full_path, media_type="application/octet-stream", filename=decoded_path)
+  return JSONResponse(status_code=404, content={"message": "File not found"})
+
 
 @app.get("/list/{encoded_file_path:path}", summary="List files in a directory")
 async def list_files(encoded_file_path: str):
-    """
-    Lists the contents of a directory under the base directory in the sandbox.
-    """
-    decoded_path = urllib.parse.unquote(encoded_file_path)
-    try:
-        full_path = get_safe_path(decoded_path)
-    except ValueError:
-        return JSONResponse(status_code=403, content={"message": "Access denied"})
+  """
+  Lists the contents of a directory under the base directory in the sandbox.
+  """
+  decoded_path = urllib.parse.unquote(encoded_file_path)
+  try:
+    full_path = get_safe_path(decoded_path)
+  except ValueError:
+    return JSONResponse(status_code=403, content={"message": "Access denied"})
 
-    if not os.path.isdir(full_path):
-        return JSONResponse(status_code=404, content={"message": "Path is not a directory"})
-    
-    try:
-        entries = []
-        with os.scandir(full_path) as it:
-            for entry in it:
-                stats = entry.stat()
-                entries.append({
-                    "name": entry.name,
-                    "size": stats.st_size,
-                    "type": "directory" if entry.is_dir() else "file",
-                    "mod_time": stats.st_mtime
-                })
-        return JSONResponse(status_code=200, content=entries)
-    except Exception as e:
-        return JSONResponse(status_code=500, content={"message": f"List files failed: {str(e)}"})
+  if not os.path.isdir(full_path):
+    return JSONResponse(status_code=404, content={"message": "Path is not a directory"})
+
+  try:
+    entries = []
+    with os.scandir(full_path) as it:
+      for entry in it:
+        stats = entry.stat()
+        entries.append({"name": entry.name, "size": stats.st_size, "type": "directory" if entry.is_dir() else "file", "mod_time": stats.st_mtime})
+    return JSONResponse(status_code=200, content=entries)
+  except Exception as e:
+    return JSONResponse(status_code=500, content={"message": f"List files failed: {str(e)}"})
+
 
 @app.get("/exists/{encoded_file_path:path}", summary="Check if the relative path exists")
 async def exists(encoded_file_path: str):
-    """
-    Checks if a specified file or directory exists under the base directory in the sandbox.
-    """
-    decoded_path = urllib.parse.unquote(encoded_file_path)
-    try:
-        full_path = get_safe_path(decoded_path)
-    except ValueError:
-        return JSONResponse(status_code=403, content={"message": "Access denied"})
+  """
+  Checks if a specified file or directory exists under the base directory in the sandbox.
+  """
+  decoded_path = urllib.parse.unquote(encoded_file_path)
+  try:
+    full_path = get_safe_path(decoded_path)
+  except ValueError:
+    return JSONResponse(status_code=403, content={"message": "Access denied"})
 
-    return JSONResponse(status_code=200, content={
-        "path": decoded_path,
-        "exists": os.path.exists(full_path)
-    })
+  return JSONResponse(status_code=200, content={"path": decoded_path, "exists": os.path.exists(full_path)})

--- a/examples/text-to-sql/sandbox/main.py
+++ b/examples/text-to-sql/sandbox/main.py
@@ -1,0 +1,240 @@
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import math
+import signal
+import subprocess
+import os
+import shlex
+import logging
+import urllib.parse
+
+from fastapi import FastAPI, UploadFile, File
+from fastapi.responses import FileResponse, JSONResponse
+from pydantic import BaseModel
+
+class ExecuteRequest(BaseModel):
+    """Request model for the /execute endpoint."""
+    command: str
+
+class ExecuteResponse(BaseModel):
+    """Response model for the /execute endpoint."""
+    stdout: str
+    stderr: str
+    exit_code: int
+
+def get_base_dir() -> str:
+    """Reads SANDBOX_BASE_DIR, falling back to /app when it's unset or blank.
+
+    Making the base directory configurable lets the sandbox run with a
+    read-only root filesystem: the runtime code stays wherever the image put
+    it, while commands and file operations are confined to a writable volume
+    (e.g. an emptyDir) mounted at SANDBOX_BASE_DIR.
+    """
+    return os.environ.get("SANDBOX_BASE_DIR", "").strip() or "/app"
+
+def get_safe_path(file_path: str) -> str:
+    """Sanitizes the file path to ensure it stays within the base directory."""
+    base_dir = os.path.realpath(get_base_dir())
+    # Remove leading slashes to ensure path is relative
+    clean_path = file_path.lstrip("/")
+    full_path = os.path.realpath(os.path.join(base_dir, clean_path))
+
+    if os.path.commonpath([base_dir, full_path]) != base_dir:
+        raise ValueError("Access denied: Path must be within the sandbox base directory")
+
+    return full_path
+
+app = FastAPI(
+    title="Agentic Sandbox Runtime",
+    description="An API server for executing commands and managing files in a secure sandbox.",
+    version="1.0.0",
+)
+
+def _get_exec_timeout_seconds() -> float:
+    """Reads SANDBOX_EXEC_TIMEOUT_SECONDS, falling back to the 300s default
+    (with a warning) if it's unset or not a finite number greater than 0, so
+    a misconfigured value doesn't fail every /execute request.
+    """
+    raw = os.environ.get("SANDBOX_EXEC_TIMEOUT_SECONDS", "300")
+    try:
+        value = float(raw)
+    except ValueError:
+        value = float("nan")
+
+    if not (math.isfinite(value) and value > 0):
+        logging.warning(
+            "Ignoring invalid SANDBOX_EXEC_TIMEOUT_SECONDS=%r; using default of 300 seconds",
+            raw,
+        )
+        return 300.0
+    return value
+
+def _run_command(args: list, timeout: float) -> subprocess.CompletedProcess:
+    """Runs args as the leader of a new process group so that on timeout the
+    entire process tree can be killed, not just the direct child (matching
+    the pattern used in examples/firecracker-sandbox/main.py).
+    """
+    with subprocess.Popen(
+        args,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        cwd=get_base_dir(),
+        start_new_session=True,
+    ) as process:
+        try:
+            stdout, stderr = process.communicate(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            try:
+                os.killpg(os.getpgid(process.pid), signal.SIGKILL)
+            except (ProcessLookupError, OSError):
+                pass
+            process.communicate()
+            raise
+        return subprocess.CompletedProcess(args, process.returncode, stdout, stderr)
+
+@app.get("/", summary="Health Check")
+async def health_check():
+    """A simple health check endpoint to confirm the server is running."""
+    return {"status": "ok", "message": "Sandbox Runtime is active."}
+
+@app.post("/execute", summary="Execute a shell command", response_model=ExecuteResponse)
+async def execute_command(request: ExecuteRequest):
+    """
+    Executes a shell command inside the sandbox and returns its output.
+    Uses shlex.split for security to prevent shell injection.
+    """
+    try:
+        # Split the command string into a list to safely pass to subprocess
+        args = shlex.split(request.command)
+        
+        # Execute the command, always from the base directory. Run it in a
+        # worker thread so a long-running or hung command doesn't block the
+        # event loop (and with it, the health check and file endpoints), and
+        # enforce a timeout so a runaway command can't wedge the sandbox
+        # forever.
+        process = await asyncio.to_thread(
+            _run_command,
+            args,
+            _get_exec_timeout_seconds(),
+        )
+        return ExecuteResponse(
+            stdout=process.stdout,
+            stderr=process.stderr,
+            exit_code=process.returncode
+        )
+    except Exception as e:
+        return ExecuteResponse(
+            stdout="",
+            stderr=f"Failed to execute command: {str(e)}",
+            exit_code=1
+        )
+
+@app.post("/upload", summary="Upload a file to the sandbox")
+async def upload_file(file: UploadFile = File(...)):
+    """
+    Receives a file and saves it to the base directory in the sandbox.
+    """
+    try:
+        logging.info(f"--- UPLOAD_FILE CALLED: Attempting to save '{file.filename}' ---")
+
+        try:
+            file_path = get_safe_path(file.filename)
+        except ValueError:
+            return JSONResponse(
+                status_code=403,
+                content={"message": "Access denied"}
+            )
+
+        # The filename may carry a relative destination path (e.g.
+        # "data/input.csv"); create the intermediate directories so such
+        # uploads don't fail. file_path is already confined to the base
+        # directory by get_safe_path, so its parents are too.
+        os.makedirs(os.path.dirname(file_path), exist_ok=True)
+
+        with open(file_path, "wb") as f:
+            f.write(await file.read())
+            
+        return JSONResponse(
+            status_code=200,
+            content={"message": f"File '{file.filename}' uploaded successfully."}
+        )
+    except Exception as e:
+        logging.exception("An error occurred during file upload.") 
+        return JSONResponse(
+            status_code=500,
+            content={"message": f"File upload failed: {str(e)}"}
+        )
+
+@app.get("/download/{encoded_file_path:path}", summary="Download a file from the sandbox")
+async def download_file(encoded_file_path: str):
+    """
+    Downloads a specified file from the base directory in the sandbox.
+    """
+    decoded_path = urllib.parse.unquote(encoded_file_path)
+    try:
+        full_path = get_safe_path(decoded_path)
+    except ValueError:
+        return JSONResponse(status_code=403, content={"message": "Access denied"})
+
+    if os.path.isfile(full_path):
+        return FileResponse(path=full_path, media_type='application/octet-stream', filename=decoded_path)
+    return JSONResponse(status_code=404, content={"message": "File not found"})
+
+@app.get("/list/{encoded_file_path:path}", summary="List files in a directory")
+async def list_files(encoded_file_path: str):
+    """
+    Lists the contents of a directory under the base directory in the sandbox.
+    """
+    decoded_path = urllib.parse.unquote(encoded_file_path)
+    try:
+        full_path = get_safe_path(decoded_path)
+    except ValueError:
+        return JSONResponse(status_code=403, content={"message": "Access denied"})
+
+    if not os.path.isdir(full_path):
+        return JSONResponse(status_code=404, content={"message": "Path is not a directory"})
+    
+    try:
+        entries = []
+        with os.scandir(full_path) as it:
+            for entry in it:
+                stats = entry.stat()
+                entries.append({
+                    "name": entry.name,
+                    "size": stats.st_size,
+                    "type": "directory" if entry.is_dir() else "file",
+                    "mod_time": stats.st_mtime
+                })
+        return JSONResponse(status_code=200, content=entries)
+    except Exception as e:
+        return JSONResponse(status_code=500, content={"message": f"List files failed: {str(e)}"})
+
+@app.get("/exists/{encoded_file_path:path}", summary="Check if the relative path exists")
+async def exists(encoded_file_path: str):
+    """
+    Checks if a specified file or directory exists under the base directory in the sandbox.
+    """
+    decoded_path = urllib.parse.unquote(encoded_file_path)
+    try:
+        full_path = get_safe_path(decoded_path)
+    except ValueError:
+        return JSONResponse(status_code=403, content={"message": "Access denied"})
+
+    return JSONResponse(status_code=200, content={
+        "path": decoded_path,
+        "exists": os.path.exists(full_path)
+    })

--- a/examples/text-to-sql/sandbox/run_sql.py
+++ b/examples/text-to-sql/sandbox/run_sql.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Run one SQLite query inside the sandbox and print the rows as JSON.
+
+Usage: python /opt/run_sql.py <job>
+
+`<job>` is either a directory holding `schema.sql` and `query.sql`, or a JSON
+file `{"schema": ..., "query": ...}` (one upload instead of two; the file is
+deleted after it is read so the sandbox does not accumulate jobs). The schema
+is executed, then the query, in an in-memory database, and one JSON object is
+printed:
+
+    {"rows": [[...], ...], "error": null}   on success
+    {"rows": null, "error": "<sqlite message>"} on any sqlite error
+
+The 250 ms progress-handler deadline and the 8-digit float rounding match
+`examples/text-to-sql/utils/rewards.py:run_sql`, so a result computed here is
+byte-comparable with one computed locally. Only untrusted, model-written SQL
+should ever reach this script; the schema is trusted dataset content.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+DEADLINE_SECONDS = 0.25
+
+
+def encode_value(value: object) -> object:
+  if isinstance(value, float):
+    return round(value, 8)
+  if isinstance(value, bytes):
+    return {"__bytes__": base64.b64encode(value).decode("ascii")}
+  return value
+
+
+def load_job(job: Path) -> tuple[str, str]:
+  if job.is_dir():
+    return (job / "schema.sql").read_text(), (job / "query.sql").read_text()
+  payload = json.loads(job.read_text())
+  job.unlink(missing_ok=True)
+  return str(payload["schema"]), str(payload["query"])
+
+
+def run(job: Path) -> dict[str, object]:
+  try:
+    schema, query = load_job(job)
+  except (OSError, ValueError, KeyError) as exc:
+    return {"rows": None, "error": f"bad job: {exc}"}
+  connection = sqlite3.connect(":memory:")
+  try:
+    deadline = time.monotonic() + DEADLINE_SECONDS
+    connection.set_progress_handler(lambda: 1 if time.monotonic() > deadline else 0, 10_000)
+    connection.executescript(schema)
+    rows = connection.execute(query).fetchall()
+    return {"rows": [[encode_value(v) for v in row] for row in rows], "error": None}
+  except sqlite3.Error as exc:
+    return {"rows": None, "error": str(exc)}
+  finally:
+    connection.close()
+
+
+def main() -> int:
+  if len(sys.argv) != 2:
+    print(json.dumps({"rows": None, "error": "usage: run_sql.py <job-dir-or-json>"}))
+    return 2
+  print(json.dumps(run(Path(sys.argv[1]))))
+  return 0
+
+
+if __name__ == "__main__":
+  sys.exit(main())

--- a/examples/text-to-sql/texttosql_sft_grpo.py
+++ b/examples/text-to-sql/texttosql_sft_grpo.py
@@ -73,30 +73,40 @@ LossValue = float | int
 
 
 class SandboxStats:
-  """Per-step latency and error counts for the reward executor."""
+  """Per-step latency and error counts for the reward executor.
+
+  ``exec`` is the sandbox round trip itself; ``wait`` is time spent queueing
+  for a lease when more rollouts are being scored than the pool has sandboxes.
+  """
 
   def __init__(self) -> None:
-    self.durations_ms: list[float] = []
+    self.exec_ms: list[float] = []
+    self.wait_ms: list[float] = []
     self.errors = 0
 
-  def record(self, duration_ms: float, error: str | None) -> None:
-    self.durations_ms.append(duration_ms)
+  def record(self, *, exec_ms: float, wait_ms: float, error: str | None) -> None:
+    self.exec_ms.append(exec_ms)
+    self.wait_ms.append(wait_ms)
     if error is not None and error.startswith("sandbox:"):
       self.errors += 1
 
   def snapshot(self) -> dict[str, float]:
     """Metrics for the calls since the last snapshot; empty when nothing ran."""
-    if not self.durations_ms:
+    if not self.exec_ms:
       return {}
-    ordered = sorted(self.durations_ms)
-    pick = lambda q: ordered[min(len(ordered) - 1, int(q * len(ordered)))]  # noqa: E731
+
+    def pct(values: list[float], q: float) -> float:
+      ordered = sorted(values)
+      return ordered[min(len(ordered) - 1, int(q * len(ordered)))]
+
     out = {
-      "sandbox_exec_calls": float(len(ordered)),
-      "sandbox_exec_p50_ms": pick(0.50),
-      "sandbox_exec_p95_ms": pick(0.95),
+      "sandbox_exec_calls": float(len(self.exec_ms)),
+      "sandbox_exec_p50_ms": pct(self.exec_ms, 0.50),
+      "sandbox_exec_p95_ms": pct(self.exec_ms, 0.95),
+      "sandbox_wait_p95_ms": pct(self.wait_ms, 0.95),
       "sandbox_errors": float(self.errors),
     }
-    self.durations_ms, self.errors = [], 0
+    self.exec_ms, self.wait_ms, self.errors = [], [], 0
     return out
 
 
@@ -119,10 +129,12 @@ async def reward_executor(reward: RewardConfig) -> AsyncIterator[Executor]:
   async with pool:
 
     async def sandboxed(context: str, query: str) -> tuple[list[tuple[Any, ...]] | None, str | None]:
-      started = time.monotonic()
+      queued = time.monotonic()
       async with pool.lease() as sandbox:
+        started = time.monotonic()
         rows, error = await run_sql_in_sandbox(sandbox, context, query, timeout=reward.exec_timeout)
-      sandbox_stats.record((time.monotonic() - started) * 1000.0, error)
+      done = time.monotonic()
+      sandbox_stats.record(exec_ms=(done - started) * 1000.0, wait_ms=(started - queued) * 1000.0, error=error)
       return rows, error
 
     yield sandboxed
@@ -288,7 +300,10 @@ async def run_rl_phase(
       num_rollouts=len(rollouts),
       **exec_metrics,
     )
-    exec_str = f" sandbox_p95={exec_metrics['sandbox_exec_p95_ms']:.0f}ms errors={int(exec_metrics['sandbox_errors'])}" if exec_metrics else ""
+    exec_str = ""
+    if exec_metrics:
+      exec_str = f" sandbox_exec_p95={exec_metrics['sandbox_exec_p95_ms']:.0f}ms wait_p95={exec_metrics['sandbox_wait_p95_ms']:.0f}ms"
+      exec_str += f" errors={int(exec_metrics['sandbox_errors'])}"
     progress = f"reward={reward:.3f} compile={compile_rate * 100:.1f}% exec={exec_rate * 100:.1f}% rollouts={len(rollouts)}{exec_str}"
     log_progress("rl step", local_step, progress)
 

--- a/examples/text-to-sql/texttosql_sft_grpo.py
+++ b/examples/text-to-sql/texttosql_sft_grpo.py
@@ -7,16 +7,26 @@ Common phase modes:
 - `phase=sft_only`: stop after SFT; saves `{preset}-sft` adapter for later
 - `phase=rl_only`: run RL only. If a `{preset}-sft` adapter was saved by a prior
   sft_only run it's picked up automatically; otherwise RL starts from a fresh LoRA.
+
+Reward execution (`reward.executor`):
+- `local` (default): model-written SQL runs in-process with sqlite3.
+- `agent_sandbox`: model-written SQL runs in gVisor sandboxes leased from a
+  Kubernetes SandboxWarmPool (see examples/common/agent_sandbox.py and
+  k8s/agent-sandbox/). Requires running in-cluster with the `sandbox` extra.
+  Dataset filtering and target queries stay local: the trust boundary is the
+  model's output, not the dataset.
 """
 
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import os
 import statistics
 import sys
-from collections.abc import Sequence
+import time
+from collections.abc import AsyncIterator, Sequence
 from pathlib import Path
 from typing import Any, cast
 
@@ -31,12 +41,18 @@ from utils.helpers import (
   shuffled_batches,
 )
 from utils.rewards import (
+  Executor,
   aggregate_eval_scores,
   empty_eval_metrics,
   load_dataset_splits,
+  local_executor,
   normalize_sql,
-  score_eval_prediction,
+  score_eval_prediction_with,
 )
+
+# examples/common is importable as `common` when the examples project is
+# installed or PYTHONPATH includes examples/; make the script self-sufficient.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 BASE_URL = "http://127.0.0.1:9003"
 DATASET = "philschmid/gretel-synthetic-text-to-sql"
@@ -51,8 +67,65 @@ config: Config
 ml_logger: ml_log.Logger
 service_client: tinker.ServiceClient
 tokenizer: PreTrainedTokenizerBase
+executor: Executor = local_executor
 EvalMetrics = dict[str, float]
 LossValue = float | int
+
+
+class SandboxStats:
+  """Per-step latency and error counts for the reward executor."""
+
+  def __init__(self) -> None:
+    self.durations_ms: list[float] = []
+    self.errors = 0
+
+  def record(self, duration_ms: float, error: str | None) -> None:
+    self.durations_ms.append(duration_ms)
+    if error is not None and error.startswith("sandbox:"):
+      self.errors += 1
+
+  def snapshot(self) -> dict[str, float]:
+    """Metrics for the calls since the last snapshot; empty when nothing ran."""
+    if not self.durations_ms:
+      return {}
+    ordered = sorted(self.durations_ms)
+    pick = lambda q: ordered[min(len(ordered) - 1, int(q * len(ordered)))]  # noqa: E731
+    out = {
+      "sandbox_exec_calls": float(len(ordered)),
+      "sandbox_exec_p50_ms": pick(0.50),
+      "sandbox_exec_p95_ms": pick(0.95),
+      "sandbox_errors": float(self.errors),
+    }
+    self.durations_ms, self.errors = [], 0
+    return out
+
+
+sandbox_stats = SandboxStats()
+
+
+@contextlib.asynccontextmanager
+async def reward_executor(reward: RewardConfig) -> AsyncIterator[Executor]:
+  """Yield the callable that executes model-written SQL for scoring."""
+  if reward.executor == "local":
+    yield local_executor
+    return
+  if reward.executor != "agent_sandbox":
+    raise ValueError(f"reward.executor must be 'local' or 'agent_sandbox', got {reward.executor!r}")
+
+  from common.agent_sandbox import AgentSandboxPool, run_sql_in_sandbox
+
+  logging.info("Reward executor: agent_sandbox pool=%d warm_pool=%s/%s", reward.pool_size, reward.namespace, reward.warm_pool)
+  pool = AgentSandboxPool(size=reward.pool_size, warm_pool=reward.warm_pool, namespace=reward.namespace, ready_timeout=reward.ready_timeout)
+  async with pool:
+
+    async def sandboxed(context: str, query: str) -> tuple[list[tuple[Any, ...]] | None, str | None]:
+      started = time.monotonic()
+      async with pool.lease() as sandbox:
+        rows, error = await run_sql_in_sandbox(sandbox, context, query, timeout=reward.exec_timeout)
+      sandbox_stats.record((time.monotonic() - started) * 1000.0, error)
+      return rows, error
+
+    yield sandboxed
 
 
 # *** Training phases (SFT + PPO+KL RL) ***
@@ -142,10 +215,15 @@ async def run_rl_phase(
       futures.append(sampler.sample_async(prompt=prompt, num_samples=config.rl.samples_per_prompt, sampling_params=sampling_params))
     responses = await bounded(asyncio.gather(*futures), f"sampling step {local_step}")
 
+    scored = await bounded(
+      asyncio.gather(*(build_rollout(example, seq, tokenizer) for example, response in zip(examples, responses) for seq in response.sequences)),
+      f"scoring step {local_step}",
+    )
+    groups = iter(scored)
     datums: list[types.Datum] = []
     rollouts: list[dict[str, Any]] = []
-    for example, response in zip(examples, responses):
-      group = [build_rollout(example, seq, tokenizer) for seq in response.sequences]
+    for response in responses:
+      group = [next(groups) for _ in response.sequences]
       rewards = [rr["reward"] for rr in group]
       # Standardize rewards within each sampled group before the PPO update.
       mean, std = statistics.fmean(rewards), statistics.pstdev(rewards)
@@ -170,8 +248,9 @@ async def run_rl_phase(
         )
 
     global_step = step_offset + local_step
+    exec_metrics = sandbox_stats.snapshot()
     if not datums:
-      log_step("rl_train", global_step, loss=0.0, reward=0.0, compile_rate=0.0, execution_match=0.0, similarity=0.0, num_rollouts=0)
+      log_step("rl_train", global_step, loss=0.0, reward=0.0, compile_rate=0.0, execution_match=0.0, similarity=0.0, num_rollouts=0, **exec_metrics)
       continue
 
     # --- Train: one PPO+KL step on the scored rollouts ---
@@ -207,8 +286,11 @@ async def run_rl_phase(
       execution_match=exec_rate,
       similarity=sim_rate,
       num_rollouts=len(rollouts),
+      **exec_metrics,
     )
-    log_progress("rl step", local_step, f"reward={reward:.3f} compile={compile_rate * 100:.1f}% exec={exec_rate * 100:.1f}% rollouts={len(rollouts)}")
+    exec_str = f" sandbox_p95={exec_metrics['sandbox_exec_p95_ms']:.0f}ms errors={int(exec_metrics['sandbox_errors'])}" if exec_metrics else ""
+    progress = f"reward={reward:.3f} compile={compile_rate * 100:.1f}% exec={exec_rate * 100:.1f}% rollouts={len(rollouts)}{exec_str}"
+    log_progress("rl step", local_step, progress)
 
     if local_step % config.rl.eval_every == 0 or local_step == config.rl.steps:
       metrics = await snapshot_eval(trainer, f"texttosql_rl_s{local_step}", eval_examples)
@@ -220,6 +302,12 @@ async def run_rl_phase(
 
 async def run_training(preset: str, metrics_path: Path) -> dict[str, float | str]:
   """Orchestrate the configured phases. Reads config/service_client/tokenizer from module scope."""
+  global executor
+  async with reward_executor(config.reward) as executor:
+    return await _run_training(preset, metrics_path)
+
+
+async def _run_training(preset: str, metrics_path: Path) -> dict[str, float | str]:
   server_model = await require_server(service_client, config.base_url)
   logging.info("Server ready at %s | model=%s", config.base_url, server_model or "unset")
 
@@ -390,14 +478,14 @@ async def snapshot_eval(trainer: tinker.TrainingClient, alias: str, eval_example
   return await sample_eval_metrics(sampler, tokenizer, alias, eval_examples, max_tokens=config.dataset.eval_max_tokens, seed=config.seed)
 
 
-def build_rollout(
+async def build_rollout(
   example: dict[str, Any],
   sequence: Any,
   tokenizer: PreTrainedTokenizerBase,
 ) -> dict[str, Any]:
-  """Decode one sampled sequence and attach token/logprob fields for PPO."""
+  """Decode one sampled sequence, score it through the executor, attach token/logprob fields for PPO."""
   predicted_sql = tokenizer.decode(sequence.tokens, skip_special_tokens=True)
-  score = score_eval_prediction(predicted_sql, example)
+  score = await score_eval_prediction_with(executor, predicted_sql, example)
   return {
     **score,
     "prompt_tokens": example["prompt_tokens"],
@@ -425,10 +513,11 @@ async def sample_eval_metrics(
     for idx, example in enumerate(examples)
   ]
   responses = await asyncio.gather(*futures)
+  predictions = [tokenizer.decode(response.sequences[0].tokens if response.sequences else [], skip_special_tokens=True) for response in responses]
+  infos = await asyncio.gather(*(score_eval_prediction_with(executor, sql, example) for sql, example in zip(predictions, examples)))
+  sandbox_stats.snapshot()  # eval latency is not a training-step metric
 
-  for idx, (example, response) in enumerate(zip(examples, responses)):
-    predicted_sql = tokenizer.decode(response.sequences[0].tokens if response.sequences else [], skip_special_tokens=True)
-    info = score_eval_prediction(predicted_sql, example)
+  for idx, (example, info) in enumerate(zip(examples, infos)):
     predicted = normalize_sql(info["predicted_sql"])
     target = normalize_sql(example["target"])
     matches_execution = bool(info["execution_match"])
@@ -495,6 +584,18 @@ class RlConfig:
 
 
 @chz.chz
+class RewardConfig:
+  # "local": in-process sqlite3. "agent_sandbox": gVisor sandboxes leased from a
+  # Kubernetes SandboxWarmPool through examples/common/agent_sandbox.py.
+  executor: str = "local"
+  warm_pool: str = "text-to-sql-executor"
+  namespace: str = "openrl-system"
+  pool_size: int = 4
+  ready_timeout: int = 180
+  exec_timeout: int = 30
+
+
+@chz.chz
 class Config:
   model: ModelConfig
   phase: str = "full"  # "full" | "sft_only" | "rl_only"
@@ -510,6 +611,7 @@ class Config:
   dataset: DatasetConfig = chz.field(default_factory=DatasetConfig)
   sft: SftConfig = chz.field(default_factory=SftConfig)
   rl: RlConfig = chz.field(default_factory=RlConfig)
+  reward: RewardConfig = chz.field(default_factory=RewardConfig)
 
 
 GEMMA4_E2B = {"model.base_model": "google/gemma-4-e2b", "model.tokenizer_name": "google/gemma-4-e2b"}

--- a/examples/text-to-sql/utils/rewards.py
+++ b/examples/text-to-sql/utils/rewards.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 import sqlite3
 import time
-from collections.abc import Iterable
+from collections.abc import Awaitable, Callable, Iterable
 from difflib import SequenceMatcher
 from typing import Any
 
@@ -249,6 +249,15 @@ def partial_execution_score(predicted_rows: list[tuple[Any, ...]] | None, target
   return score
 
 
+Executor = Callable[[str, str], Awaitable[tuple[list[tuple[Any, ...]] | None, str | None]]]
+"""``await executor(context, query)`` -> ``(rows, None)`` or ``(None, error)``, like ``run_sql``."""
+
+
+async def local_executor(context: str, query: str) -> tuple[list[tuple[Any, ...]] | None, str | None]:
+  """In-process sqlite3, the default. Only for trusted callers or laptop runs."""
+  return run_sql(context, query)
+
+
 def score_prediction(
   *,
   predicted_sql: str,
@@ -257,8 +266,70 @@ def score_prediction(
   target_rows: list[tuple[Any, ...]] | None = None,
   question: str = "",
 ) -> dict[str, Any]:
-  """Score generated SQL against explicit target SQL and schema context."""
+  """Score generated SQL against explicit target SQL and schema context, executing locally."""
   predicted_sql = clean_sql_for_execution(predicted_sql)
+  predicted_rows, predicted_error = run_sql(context, predicted_sql)
+  return score_from_execution(
+    predicted_sql=predicted_sql,
+    target_sql=target_sql,
+    context=context,
+    target_rows=target_rows,
+    question=question,
+    predicted_rows=predicted_rows,
+    predicted_error=predicted_error,
+  )
+
+
+async def score_prediction_with(
+  executor: Executor,
+  *,
+  predicted_sql: str,
+  target_sql: str,
+  context: str,
+  target_rows: list[tuple[Any, ...]] | None = None,
+  question: str = "",
+) -> dict[str, Any]:
+  """Like ``score_prediction`` but runs the *model's* query through ``executor``.
+
+  The trust boundary is the prediction: it is untrusted model output and goes
+  wherever the executor sends it (a sandbox). The target query is dataset
+  content and is still executed locally when its rows were not precomputed.
+  """
+  predicted_sql = clean_sql_for_execution(predicted_sql)
+  predicted_rows, predicted_error = await executor(context, predicted_sql)
+  return score_from_execution(
+    predicted_sql=predicted_sql,
+    target_sql=target_sql,
+    context=context,
+    target_rows=target_rows,
+    question=question,
+    predicted_rows=predicted_rows,
+    predicted_error=predicted_error,
+  )
+
+
+async def score_eval_prediction_with(executor: Executor, predicted_sql: str, example: dict[str, Any]) -> dict[str, Any]:
+  return await score_prediction_with(
+    executor,
+    predicted_sql=predicted_sql,
+    target_sql=example["target"],
+    context=example["context"],
+    target_rows=example.get("target_rows"),
+    question=example["question"],
+  )
+
+
+def score_from_execution(
+  *,
+  predicted_sql: str,
+  target_sql: str,
+  context: str,
+  target_rows: list[tuple[Any, ...]] | None,
+  question: str,
+  predicted_rows: list[tuple[Any, ...]] | None,
+  predicted_error: str | None,
+) -> dict[str, Any]:
+  """Pure scoring given the prediction's execution result. ``predicted_sql`` must already be cleaned."""
   target_sql = clean_sql_for_execution(target_sql)
   normalized_predicted_sql = normalize_sql(predicted_sql)
   normalized_target_sql = normalize_sql(target_sql)
@@ -268,7 +339,6 @@ def score_prediction(
     if target_error is not None:
       target_rows = None
 
-  predicted_rows, predicted_error = run_sql(context, predicted_sql)
   execution_error = None
   if predicted_error is not None:
     execution_error = f"predicted query error: {predicted_error}"

--- a/examples/uv.lock
+++ b/examples/uv.lock
@@ -611,6 +611,15 @@ wheels = [
 ]
 
 [[package]]
+name = "durationpy"
+version = "0.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/5d/5f8571bd5dedc80863191621ac4be001f3f3dd8315d2ec078705dab7dec1/durationpy-0.11.tar.gz", hash = "sha256:181898e1ae282e288f0a2291829656bf1b6b3aadf30a97993b85db4943642905", size = 3582, upload-time = "2026-08-26T13:56:00.991Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/c4/ebdf7837bc4ef6fd98cfb013c28855bb358467bf86c1af011bbc21e21df0/durationpy-0.11-py3-none-any.whl", hash = "sha256:a739fe2b8972c250ff72f8e2c488d18cf25f7b852f49ee76048775d5171df30c", size = 4133, upload-time = "2026-08-26T13:55:59.456Z" },
+]
+
+[[package]]
 name = "executing"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1180,6 +1189,27 @@ wheels = [
 ]
 
 [[package]]
+name = "k8s-agent-sandbox"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "kubernetes" },
+    { name = "prometheus-client" },
+    { name = "pydantic" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/81/d4caf149187bc0da70d5dc665d028bb989a15d840d444bd1c3acd4522f55/k8s_agent_sandbox-1.0.1.tar.gz", hash = "sha256:9b75fa852069863293afdbb685661a1022d6c9dd7eb2341a3efb8698ca73ef1d", size = 166691, upload-time = "2026-09-03T18:50:49.733Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/3c/42b6621b6e3622ae4e79692c68e24f44a0af39b08d9b00bcb1582ff80ae5/k8s_agent_sandbox-1.0.1-py3-none-any.whl", hash = "sha256:19796373e952d818266ec4133bfeee1118a7e75aec149272ffd93b2c94cd8c41", size = 96553, upload-time = "2026-09-03T18:50:48.126Z" },
+]
+
+[package.optional-dependencies]
+async = [
+    { name = "httpx" },
+    { name = "kubernetes-asyncio" },
+]
+
+[[package]]
 name = "kiwisolver"
 version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1263,6 +1293,44 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0f/41/c5f71f9f00aabcc71fee8b7475e3f64747282580c2fe748961ba29b18385/kiwisolver-1.5.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:f6764a4ccab3078db14a632420930f6186058750df066b8ea2a7106df91d3203", size = 138036, upload-time = "2026-03-09T13:15:36.894Z" },
     { url = "https://files.pythonhosted.org/packages/fa/06/7399a607f434119c6e1fdc8ec89a8d51ccccadf3341dee4ead6bd14caaf5/kiwisolver-1.5.0-graalpy312-graalpy250_312_native-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c31c13da98624f957b0fb1b5bae5383b2333c2c3f6793d9825dd5ce79b525cb7", size = 194295, upload-time = "2026-03-09T13:15:38.22Z" },
     { url = "https://files.pythonhosted.org/packages/b5/91/53255615acd2a1eaca307ede3c90eb550bae9c94581f8c00081b6b1c8f44/kiwisolver-1.5.0-graalpy312-graalpy250_312_native-win_amd64.whl", hash = "sha256:1f1489f769582498610e015a8ef2d36f28f505ab3096d0e16b4858a9ec214f57", size = 75987, upload-time = "2026-03-09T13:15:39.65Z" },
+]
+
+[[package]]
+name = "kubernetes"
+version = "36.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "certifi" },
+    { name = "durationpy" },
+    { name = "python-dateutil" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "requests-oauthlib" },
+    { name = "six" },
+    { name = "urllib3" },
+    { name = "websocket-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/57/b07b96353f902aa1bdbe00e878e3a12a137977d03a962479785576aa8ec9/kubernetes-36.0.3.tar.gz", hash = "sha256:36993ed25ce59b789c9341473a228fcf268504a2fec7c2b2b1531d73072e5ce7", size = 2337528, upload-time = "2026-07-13T20:38:12.128Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/30/a96d47df739689ac0001ade0afefc16e3b477fc2fb426b568515fdc8afce/kubernetes-36.0.3-py2.py3-none-any.whl", hash = "sha256:8fde9241c4b298e6374a069dcf728359b4e72c2fb29489a975ba4e1c047cf10f", size = 4618066, upload-time = "2026-07-13T20:38:10.172Z" },
+]
+
+[[package]]
+name = "kubernetes-asyncio"
+version = "33.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "certifi" },
+    { name = "python-dateutil" },
+    { name = "pyyaml" },
+    { name = "six" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/41/5f/c175f86b92ff5f19444e3be1423819491ae9859d1f6f7d83d404eab8b10d/kubernetes_asyncio-33.3.0.tar.gz", hash = "sha256:4c59cd4c99b197995ef38ef0c8ff45aab24b84830ebf0ddcb67355caea9674c9", size = 1124931, upload-time = "2025-08-11T21:39:37.825Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/20/90985f53c141e6f3464b7295a617ffd36574168861882f9291847d09f9b1/kubernetes_asyncio-33.3.0-py3-none-any.whl", hash = "sha256:25e6e265932ebb1aeecbdb30a107dbef3ee0bcd388ed12d092be70915733982b", size = 2174591, upload-time = "2025-08-11T21:39:35.697Z" },
 ]
 
 [[package]]
@@ -1755,6 +1823,15 @@ wheels = [
 ]
 
 [[package]]
+name = "oauthlib"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
+]
+
+[[package]]
 name = "open-rl-client"
 version = "0.0.1"
 source = { editable = "." }
@@ -1777,6 +1854,11 @@ dependencies = [
     { name = "transformers" },
 ]
 
+[package.optional-dependencies]
+sandbox = [
+    { name = "k8s-agent-sandbox", extra = ["async"] },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "chz", specifier = ">=0.4.0" },
@@ -1784,6 +1866,7 @@ requires-dist = [
     { name = "huggingface-hub", specifier = ">=0.28.1" },
     { name = "ipykernel" },
     { name = "jinja2" },
+    { name = "k8s-agent-sandbox", extras = ["async"], marker = "extra == 'sandbox'", specifier = ">=1.0.1" },
     { name = "matplotlib", specifier = ">=3.10.8" },
     { name = "nbclient", specifier = ">=0.10.2" },
     { name = "nbformat", specifier = ">=5.10.4" },
@@ -1796,6 +1879,7 @@ requires-dist = [
     { name = "tinker-cookbook", extras = ["math-rl"], specifier = "==0.5.7" },
     { name = "transformers", specifier = ">=5.16.1" },
 ]
+provides-extras = ["sandbox"]
 
 [[package]]
 name = "opentelemetry-api"
@@ -2118,6 +2202,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/73/f1334c29c2af4cd9dba6c7817e61b611bd0215e2eb5565c6064a4de18802/prometheus_client-0.26.0.tar.gz", hash = "sha256:04a91bcf94e2cf74a44a1a874d651a2e853ed354b6e822f3b7487751465d5c2b", size = 92910, upload-time = "2026-07-24T19:36:41.893Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/a3/b69efbf4143b5b9859b977770bbbabcc2796b702fa69dc40271e45cd5a56/prometheus_client-0.26.0-py3-none-any.whl", hash = "sha256:fa93d06737aa02bacd05794768508bb97d2fbee28cb3bca04eaae92f0ca953d6", size = 64494, upload-time = "2026-07-24T19:36:40.854Z" },
 ]
 
 [[package]]
@@ -2766,6 +2859,19 @@ wheels = [
 ]
 
 [[package]]
+name = "requests-oauthlib"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "oauthlib" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
+]
+
+[[package]]
 name = "rich"
 version = "15.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3291,6 +3397,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2c/ee/afaf0f85a9a18fe47a67f1e4422ed6cf1fe642f0ae0a2f81166231303c52/wcwidth-0.7.0.tar.gz", hash = "sha256:90e3a7ea092341c44b99562e75d09e4d5160fe7a3974c6fb842a101a95e7eed0", size = 182132, upload-time = "2026-05-02T16:04:12.653Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/52/e465037f5375f43533d1a80b6923955201596a99142ed524d77b571a1418/wcwidth-0.7.0-py3-none-any.whl", hash = "sha256:5d69154c429a82910e241c738cd0e2976fac8a2dd47a1a805f4afed1c0f136f2", size = 110825, upload-time = "2026-05-02T16:04:11.033Z" },
+]
+
+[[package]]
+name = "websocket-client"
+version = "1.9.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/cb/a5abcc2891249f393827c650c6296660ce40374ac22d99ab9aea41f9d2a2/websocket_client-1.9.2.tar.gz", hash = "sha256:0fcb57545848be86992e128218fd96dd87a6769ffdb1a968dff79632b85604d0", size = 84110, upload-time = "2026-08-31T14:08:40.964Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/d2/cc4dc1271e464942db7ee278baae2daa99ee77cb2af744025c04da585a3e/websocket_client-1.9.2-py3-none-any.whl", hash = "sha256:e1a673830a9c7bfa47b1cd3d5e4178f4c9651d80a4eab02c9c23a1c3ec6250ce", size = 95786, upload-time = "2026-08-31T14:08:39.899Z" },
 ]
 
 [[package]]

--- a/src/server/Dockerfile.client
+++ b/src/server/Dockerfile.client
@@ -28,7 +28,7 @@ ENV UV_LINK_MODE=copy \
 # Sync CPU-only dependencies for root (with cluster extra for kubernetes launcher) and examples
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-install-project --extra cluster && \
-    uv --project examples sync --frozen --no-install-project
+    uv --project examples sync --frozen --no-install-project --extra sandbox
 
 # Copy source code
 COPY . .

--- a/tests/test_agent_sandbox.py
+++ b/tests/test_agent_sandbox.py
@@ -1,0 +1,262 @@
+"""Unit tests for examples/common/agent_sandbox.py.
+
+Run with the examples environment (tinker-cookbook is needed for the
+interface types):
+
+    PYTHONPATH=examples:examples/text-to-sql uv --project examples run python -m unittest tests.test_agent_sandbox
+
+The fake sandbox below executes commands locally with the same contract as the
+runtime image (shlex-split, no shell, cwd = base dir, uploads confined to the
+base dir), and maps /opt/run_sql.py to the real script in the repo, so the
+SQL round trip is exercised end to end against utils.rewards.run_sql.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import shlex
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+from common.agent_sandbox import AgentSandboxBackend, AgentSandboxPool, run_sql_in_sandbox
+from tinker_cookbook.sandbox import SandboxInterface, SandboxTerminatedError
+from utils.rewards import run_sql
+
+REPO = Path(__file__).resolve().parents[1]
+RUN_SQL_SCRIPT = REPO / "examples" / "text-to-sql" / "sandbox" / "run_sql.py"
+
+
+class FakeCommands:
+  def __init__(self, base: Path):
+    self.base = base
+    self.calls: list[str] = []
+
+  async def run(self, command: str, timeout: int = 60) -> SimpleNamespace:
+    self.calls.append(command)
+    args = [sys.executable if a == "python" else str(RUN_SQL_SCRIPT) if a == "/opt/run_sql.py" else a for a in shlex.split(command)]
+    proc = await asyncio.to_thread(subprocess.run, args, cwd=self.base, capture_output=True, text=True, timeout=timeout)
+    return SimpleNamespace(stdout=proc.stdout, stderr=proc.stderr, exit_code=proc.returncode)
+
+
+class FakeFiles:
+  def __init__(self, base: Path):
+    self.base = base
+
+  def _safe(self, path: str) -> Path:
+    full = (self.base / path.lstrip("/")).resolve()
+    if os.path.commonpath([self.base.resolve(), full]) != str(self.base.resolve()):
+      raise RuntimeError("Access denied")
+    return full
+
+  async def write(self, path: str, content: bytes | str, timeout: int = 60) -> None:
+    full = self._safe(path)
+    full.parent.mkdir(parents=True, exist_ok=True)
+    full.write_bytes(content.encode() if isinstance(content, str) else content)
+
+  async def read(self, path: str, timeout: int = 60) -> bytes:
+    full = self._safe(path)
+    if not full.is_file():
+      raise RuntimeError("404 File not found")
+    return full.read_bytes()
+
+
+class FakeSandbox:
+  created = 0
+
+  def __init__(self, base: Path, ready: bool = True):
+    FakeSandbox.created += 1
+    self.claim_name = f"sandbox-claim-{FakeSandbox.created:04d}"
+    self.namespace = "openrl-system"
+    self._commands = FakeCommands(base)
+    self._files = FakeFiles(base)
+    self.ready = ready
+    self.terminated = False
+
+  @property
+  def commands(self):
+    return None if self.terminated else self._commands
+
+  @property
+  def files(self):
+    return None if self.terminated else self._files
+
+  async def status(self) -> tuple[str, str]:
+    return ("SandboxReady", "ok") if self.ready else ("SandboxNotReady", "pod evicted")
+
+  async def terminate(self) -> None:
+    self.terminated = True
+
+
+def run(coro):
+  return asyncio.run(coro)
+
+
+SCHEMA = "CREATE TABLE t(a INT, b REAL, c TEXT); INSERT INTO t VALUES (1, 0.1234567891234, 'x'), (2, 2.5, NULL), (3, 1.0, 'y');"
+
+
+class BackendTest(unittest.TestCase):
+  def setUp(self) -> None:
+    self.tmp = tempfile.TemporaryDirectory()
+    self.base = Path(self.tmp.name)
+    self.sandbox = FakeSandbox(self.base)
+    self.backend = AgentSandboxBackend(self.sandbox, base_dir="/app/work")
+
+  def tearDown(self) -> None:
+    self.tmp.cleanup()
+
+  def test_satisfies_cookbook_interface(self) -> None:
+    self.assertIsInstance(self.backend, SandboxInterface)
+    self.assertEqual(self.backend.sandbox_id, self.sandbox.claim_name)
+
+  def test_write_run_read_round_trip(self) -> None:
+    async def go():
+      await self.backend.write_file("dir/hello.txt", "hi there")
+      listed = await self.backend.run_command("cat dir/hello.txt")
+      absolute = await self.backend.read_file("/app/work/dir/hello.txt")
+      missing = await self.backend.read_file("nope.txt")
+      return listed, absolute, missing
+
+    listed, absolute, missing = run(go())
+    self.assertEqual((listed.exit_code, listed.stdout), (0, "hi there"))
+    self.assertGreater(listed.metrics["duration_ms"], 0)
+    self.assertEqual(absolute.stdout, "hi there")
+    self.assertEqual(missing.exit_code, 1)
+
+  def test_workdir_and_executable(self) -> None:
+    async def go():
+      await self.backend.write_file("bin/say.sh", "#!/bin/sh\necho from $(pwd)\n", executable=True)
+      return await self.backend.run_command("./say.sh", workdir="bin")
+
+    result = run(go())
+    self.assertEqual(result.exit_code, 0, result.stderr)
+    self.assertTrue(result.stdout.strip().endswith("/bin"))
+
+  def test_paths_outside_base_dir_are_rejected(self) -> None:
+    with self.assertRaises(ValueError):
+      run(self.backend.write_file("/etc/passwd", "x"))
+
+  def test_output_is_truncated(self) -> None:
+    result = run(self.backend.run_command("python -c \"print('x' * 5000)\"", max_output_bytes=100))
+    self.assertLess(len(result.stdout), 200)
+    self.assertIn("truncated", result.stdout)
+
+  def test_heartbeat_reports_dead_sandbox(self) -> None:
+    run(self.backend.send_heartbeat())
+    self.sandbox.ready = False
+    with self.assertRaises(SandboxTerminatedError):
+      run(self.backend.send_heartbeat())
+
+  def test_cleanup_terminates_once_and_closes(self) -> None:
+    closes = []
+
+    async def on_cleanup():
+      closes.append(1)
+
+    backend = AgentSandboxBackend(self.sandbox, on_cleanup=on_cleanup)
+    run(backend.cleanup())
+    run(backend.cleanup())
+    self.assertTrue(self.sandbox.terminated)
+    self.assertEqual(closes, [1])
+    with self.assertRaises(SandboxTerminatedError):
+      run(backend.run_command("true"))
+
+
+class RunSqlTest(unittest.TestCase):
+  def setUp(self) -> None:
+    self.tmp = tempfile.TemporaryDirectory()
+    self.backend = AgentSandboxBackend(FakeSandbox(Path(self.tmp.name)))
+
+  def tearDown(self) -> None:
+    self.tmp.cleanup()
+
+  def test_matches_local_run_sql(self) -> None:
+    for query in (
+      "select a, b, c from t order by a",
+      "select count(*), avg(b) from t",
+      "select * from nope",
+      "select a from t where",
+      "select group_concat(c) from t",
+    ):
+      with self.subTest(query=query):
+        local = run_sql(SCHEMA, query)
+        remote = run(run_sql_in_sandbox(self.backend, SCHEMA, query))
+        self.assertEqual(remote, local)
+
+  def test_job_file_is_removed(self) -> None:
+    run(run_sql_in_sandbox(self.backend, SCHEMA, "select 1"))
+    self.assertEqual(list((Path(self.tmp.name) / "jobs").iterdir()), [])
+
+  def test_runaway_query_times_out_like_local(self) -> None:
+    query = "WITH RECURSIVE r(x) AS (SELECT 1 UNION ALL SELECT x+1 FROM r) SELECT count(*) FROM r"
+    self.assertEqual(run(run_sql_in_sandbox(self.backend, SCHEMA, query)), (None, "interrupted"))
+
+  def test_transport_failure_is_an_error_not_an_exception(self) -> None:
+    class Broken(AgentSandboxBackend):
+      async def run_command(self, *a, **k):
+        raise ConnectionError("pod gone")
+
+    rows, error = run(run_sql_in_sandbox(Broken(FakeSandbox(Path(self.tmp.name))), SCHEMA, "select 1"))
+    self.assertIsNone(rows)
+    self.assertTrue(error.startswith("sandbox: ConnectionError"))
+
+
+class PoolTest(unittest.TestCase):
+  def setUp(self) -> None:
+    self.tmp = tempfile.TemporaryDirectory()
+    self.sandboxes: list[FakeSandbox] = []
+
+  def tearDown(self) -> None:
+    self.tmp.cleanup()
+
+  async def factory(self) -> AgentSandboxBackend:
+    sandbox = FakeSandbox(Path(self.tmp.name))
+    self.sandboxes.append(sandbox)
+    return AgentSandboxBackend(sandbox)
+
+  def test_leases_are_bounded_and_claims_are_released(self) -> None:
+    async def go():
+      async with AgentSandboxPool(size=2, warm_pool="wp", namespace="ns", factory=self.factory) as pool:
+        in_flight = 0
+        peak = 0
+
+        async def use():
+          nonlocal in_flight, peak
+          async with pool.lease() as sandbox:
+            in_flight += 1
+            peak = max(peak, in_flight)
+            await asyncio.sleep(0.01)
+            self.assertIsInstance(sandbox, AgentSandboxBackend)
+            in_flight -= 1
+
+        await asyncio.gather(*(use() for _ in range(6)))
+        return peak
+
+    peak = run(go())
+    self.assertEqual(peak, 2)
+    self.assertEqual(len(self.sandboxes), 2)
+    self.assertTrue(all(s.terminated for s in self.sandboxes))
+
+  def test_dead_sandbox_is_replaced(self) -> None:
+    async def go():
+      async with AgentSandboxPool(size=1, warm_pool="wp", namespace="ns", factory=self.factory) as pool:
+        self.sandboxes[0].ready = False
+        with self.assertRaises(SandboxTerminatedError):
+          async with pool.lease() as sandbox:
+            await sandbox.send_heartbeat()
+        async with pool.lease() as sandbox:
+          await sandbox.send_heartbeat()
+          return pool.replacements, sandbox.sandbox_id
+
+    replacements, sandbox_id = run(go())
+    self.assertEqual(replacements, 1)
+    self.assertEqual(sandbox_id, self.sandboxes[1].claim_name)
+    self.assertTrue(self.sandboxes[0].terminated)
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
The Text-to-SQL recipe used to run model-generated SQL in the training process. This PR moves that execution into gVisor sandboxes managed by agent-sandbox, and adds a Kubernetes sandbox backend for tinker-cookbook so cookbook recipes get the same isolation without changes to their training loop.

### What's in it

- A sandbox backend that implements tinker-cookbook's `SandboxInterface` on top of agent-sandbox warm pools. It can hold a fixed pool of sandboxes for a run, or claim one per prompt group and release it afterwards.
- A small executor image: the agent-sandbox reference runtime plus a script that runs a schema and a query in an in-memory SQLite with the same deadline and rounding the recipe uses, so results match the in-process path exactly.
- The Gemma recipe gains `reward.executor=agent_sandbox`. Every rollout and eval query runs in a sandbox; dataset filtering and target queries stay local, since the trust boundary is the model's output, not the dataset. Each step logs sandbox round-trip and queue-wait latency and error counts.
- A cookbook `rl_train` recipe for the same task on Qwen3-1.7B, claiming one sandbox per prompt group. OpenRL is only the Tinker endpoint; the loop is the cookbook's.
- Manifests for the sandbox template, warm pool and RBAC, Job manifests to run either recipe in-cluster, unit tests, and a guide covering the trust model, setup and measurements.

### Results on GKE

- Gemma LoRA, 80 steps with sandboxed rewards: execution match 6% → 25%, against 6% → 26% with in-process execution the same day. Same curve, zero sandbox errors over ~5,500 executions, no measurable cost per step.
- Cookbook Qwen3-1.7B, 40 batches: 324 sandbox claims created and released, none leaked, held-out execution match 54% → 60%.
- One sandbox round trip is ~110 ms at p50; a warm claim takes 0.2 s when a pre-warmed pod is free, ~2.6 s median over a run.

### Things to know

- Sandboxes only schedule on nodes with GKE Sandbox enabled; the guide covers adding a small gVisor node pool.
- The template declares no egress, but that only holds on clusters that enforce NetworkPolicy. Ours does not, so isolation there is gVisor only. Documented as a prerequisite.
- Evals lease from a small shared pool rather than claiming per example. The first run claimed one sandbox per held-out example and spent most of its time cold-starting pods.

### Follow-ups

- Upstream the backend to tinker-cookbook as an `AGENT_SANDBOX` option.
- Write the schema once per group instead of shipping it with every call.